### PR TITLE
chore: add missing pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,12 +2,43 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
+    - repo: https://github.com/camunda/infraex-common-config
+      rev: 1.2.4 # use tags until renovate supports sha: https://github.com/renovatebot/renovate/issues/22567
+      hooks:
+          - id: update-action-readmes-docker
+
     - repo: https://github.com/pre-commit/pre-commit-hooks
       rev: v5.0.0
       hooks:
-          - id: trailing-whitespace
-          - id: end-of-file-fixer
           - id: check-added-large-files
+          - id: end-of-file-fixer
+          - id: trailing-whitespace
+          - id: check-yaml
+            args: [--allow-multiple-documents]
+          - id: check-json
+          - id: check-symlinks
+          - id: check-shebang-scripts-are-executable
+          - id: detect-private-key
+
+    - repo: https://github.com/rhysd/actionlint
+      rev: v1.7.3
+      hooks:
+          - id: actionlint-docker
+
+    - repo: https://github.com/renovatebot/pre-commit-hooks
+      rev: 38.132.1
+      hooks:
+          - id: renovate-config-validator
+            args: [--strict]
+            # TODO : revert this when https://github.com/renovatebot/pre-commit-hooks/issues/2460 is fixed
+            language_version: 20.18.0
+
+    - repo: https://github.com/compilerla/conventional-pre-commit
+      rev: v3.6.0 # use tags until renovate supports sha: https://github.com/renovatebot/renovate/issues/22567
+      hooks:
+          - id: conventional-pre-commit
+            stages: [commit-msg]
+            args: [--strict, --force-scope]
 
     - repo: https://github.com/antonbabenko/pre-commit-terraform
       rev: v1.96.1
@@ -21,24 +52,18 @@ repos:
                 - --hook-config=--add-to-existing-file=true
                 - --args=--config=.lint/terraform_docs/.terraform-docs.yml
 
-    - repo: https://github.com/rhysd/actionlint
-      rev: v1.7.3
+    - repo: https://github.com/dnephin/pre-commit-golang
+      rev: v0.5.1
       hooks:
-          - id: actionlint-docker
+          - id: go-fmt
+          - id: no-go-testing
+          - id: go-mod-tidy
 
     - repo: https://github.com/shellcheck-py/shellcheck-py
       rev: v0.9.0.6
       hooks:
           - id: shellcheck
             args: [--external-sources, --source-path, .github/workflows/scripts, '--exclude=SC2154,SC2034,SC1091']
-
-    - repo: https://github.com/renovatebot/pre-commit-hooks
-      rev: 38.132.1
-      hooks:
-          - id: renovate-config-validator
-            args: [--strict]
-            # TODO : revert this when https://github.com/renovatebot/pre-commit-hooks/issues/2460 is fixed
-            language_version: 20.18.0
 
     - repo: https://github.com/adrienverge/yamllint
       rev: v1.35.1


### PR DESCRIPTION
adding missing pre-commit hooks that are present in the https://github.com/camunda/camunda-tf-eks-module repo.

Will merge without review after linting run succeeded.