### PR TITLE
chore: change cron for ec2 test

### DIFF
--- a/.github/workflows/aws_ec2_tests.yml
+++ b/.github/workflows/aws_ec2_tests.yml
@@ -3,7 +3,7 @@ name: AWS EC2 Tests
 
 on:
     schedule:
-        - cron: 0 4 * * 1-5
+        - cron: 0 3 * * 1-5
     workflow_dispatch:
     pull_request:
         paths:


### PR DESCRIPTION
due to the runtime can and will overlap with nightly cleanup