### PR TITLE
lint(pre-commit): add trivy check on terraform directory (issues ignored)

### DIFF
--- a/.lint/trivy/trivy-scan.sh
+++ b/.lint/trivy/trivy-scan.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -euxo pipefail
+
+# list of the folders that we want to parse, only if a README.md exists and no .trivy_ignore
+echo "Scanning terraform files in aws dir with trivy:"
+trivy config --config .lint/trivy/trivy.yaml --ignorefile .trivyignore --skip-dirs aws/ec2/test/fixtures aws

--- a/.lint/trivy/trivy.yaml
+++ b/.lint/trivy/trivy.yaml
@@ -1,0 +1,9 @@
+---
+quiet: false
+debug: false
+format: table
+exit-code: 1
+
+misconfiguration:
+    scanners:
+        - terraform

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -76,3 +76,12 @@ repos:
       rev: 0.2.3
       hooks:
           - id: yamlfmt
+
+    - repo: local
+      hooks:
+          - id: trivy-scan
+            name: Trivy Scan
+            entry: .lint/trivy/trivy-scan.sh
+            language: script
+            types: [terraform]
+            pass_filenames: false

--- a/.tool-versions
+++ b/.tool-versions
@@ -35,3 +35,5 @@ terraform-docs 0.19.0
 tflint 0.55.0
 
 zbctl 8.5.8
+
+trivy 0.58.1

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,18 @@
+AVD-AWS-0040 #(CRITICAL): Public cluster access is enabled.
+AVD-AWS-0041 #(CRITICAL): Cluster allows access from a public CIDR: 0.0.0.0/0
+AVD-AWS-0104 #(CRITICAL): Security group rule allows egress to multiple public internet addresses.
+AVD-AWS-0054 #(CRITICAL): Listener for application load balancer does not use HTTPS.
+
+AVD-AWS-0028 #(HIGH): Instance does not require IMDS access to require a token.
+AVD-AWS-0131 #(HIGH): Root block device is not encrypted.
+AVD-AWS-0052 #(HIGH): Application load balancer is not set to drop invalid headers.
+AVD-AWS-0053 #(HIGH): Load balancer is exposed publicly.
+AVD-AWS-0107 #(HIGH): Security group rule allows ingress from public internet.
+
+AVD-AWS-0343 #(MEDIUM): Cluster does not have Deletion Protection enabled
+AVD-AWS-0178 #(MEDIUM): VPC does not have VPC Flow Logs enabled.
+AVD-AWS-0038 #(MEDIUM): Control plane scheduler logging is not enabled.
+AVD-AWS-0077 #(MEDIUM): Cluster instance has very low backup retention period.
+
+AVD-AWS-0133 #(LOW): Instance does not have performance insights enabled.
+AVD-AWS-0124 #(LOW): Security group rule does not have a description.

--- a/.trivyignore
+++ b/.trivyignore
@@ -15,4 +15,3 @@ AVD-AWS-0038 #(MEDIUM): Control plane scheduler logging is not enabled.
 AVD-AWS-0077 #(MEDIUM): Cluster instance has very low backup retention period.
 
 AVD-AWS-0133 #(LOW): Instance does not have performance insights enabled.
-AVD-AWS-0124 #(LOW): Security group rule does not have a description.

--- a/aws/ec2/terraform/security.tf
+++ b/aws/ec2/terraform/security.tf
@@ -27,18 +27,18 @@ resource "aws_security_group" "allow_necessary_camunda_ports_within_vpc" {
       to_port     = ingress.value
       protocol    = "TCP"
       cidr_blocks = [module.vpc.vpc_cidr_block]
+      description = "Allow inbound traffic on port ${ingress.value}"
     }
-
   }
 
   dynamic "egress" {
     for_each = var.ports
-
     content {
       from_port   = egress.value
       to_port     = egress.value
       protocol    = "TCP"
       cidr_blocks = [module.vpc.vpc_cidr_block]
+      description = "Allow outbound traffic on port ${egress.value}"
     }
   }
 
@@ -57,6 +57,7 @@ resource "aws_security_group" "allow_package_80_443" {
     to_port     = 80
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
+    description = "Allow outbound HTTP traffic"
   }
 
   egress {
@@ -64,6 +65,7 @@ resource "aws_security_group" "allow_package_80_443" {
     to_port     = 443
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
+    description = "Allow outbound HTTPS traffic"
   }
 
   tags = {
@@ -81,6 +83,7 @@ resource "aws_security_group" "allow_remote_80_443" {
     to_port     = 80
     protocol    = "tcp"
     cidr_blocks = var.limit_access_to_cidrs
+    description = "Allow inbound HTTP traffic"
   }
 
   egress {
@@ -88,6 +91,7 @@ resource "aws_security_group" "allow_remote_80_443" {
     to_port     = 80
     protocol    = "tcp"
     cidr_blocks = var.limit_access_to_cidrs
+    description = "Allow outbound HTTP traffic"
   }
 
   ingress {
@@ -95,6 +99,7 @@ resource "aws_security_group" "allow_remote_80_443" {
     to_port     = 443
     protocol    = "tcp"
     cidr_blocks = var.limit_access_to_cidrs
+    description = "Allow inbound HTTPS traffic"
   }
 
   egress {
@@ -102,6 +107,7 @@ resource "aws_security_group" "allow_remote_80_443" {
     to_port     = 443
     protocol    = "tcp"
     cidr_blocks = var.limit_access_to_cidrs
+    description = "Allow outbound HTTPS traffic"
   }
 
   tags = {
@@ -119,6 +125,7 @@ resource "aws_security_group" "allow_remote_9090" {
     to_port     = 9090
     protocol    = "tcp"
     cidr_blocks = var.limit_access_to_cidrs
+    description = "Allow inbound traffic on port 9090"
   }
 
   egress {
@@ -126,6 +133,7 @@ resource "aws_security_group" "allow_remote_9090" {
     to_port     = 9090
     protocol    = "tcp"
     cidr_blocks = var.limit_access_to_cidrs
+    description = "Allow outbound traffic on port 9090"
   }
 
   tags = {
@@ -143,6 +151,7 @@ resource "aws_security_group" "allow_ssh" {
     to_port     = 22
     protocol    = "tcp"
     cidr_blocks = var.limit_access_to_cidrs
+    description = "Allow inbound SSH traffic"
   }
 
   tags = {
@@ -160,6 +169,7 @@ resource "aws_security_group" "allow_remote_grpc" {
     to_port     = 26500
     protocol    = "tcp"
     cidr_blocks = var.limit_access_to_cidrs
+    description = "Allow inbound gRPC traffic on port 26500"
   }
 
   tags = {

--- a/aws/ec2/test/golden/tfplan.json
+++ b/aws/ec2/test/golden/tfplan.json
@@ -2085,7 +2085,7 @@
             "cidr_blocks": [
               "10.200.0.0/16"
             ],
-            "description": "",
+            "description": "Allow outbound traffic on port 22",
             "from_port": 22,
             "ipv6_cidr_blocks": [],
             "prefix_list_ids": [],
@@ -2098,7 +2098,7 @@
             "cidr_blocks": [
               "10.200.0.0/16"
             ],
-            "description": "",
+            "description": "Allow outbound traffic on port 26500",
             "from_port": 26500,
             "ipv6_cidr_blocks": [],
             "prefix_list_ids": [],
@@ -2111,7 +2111,7 @@
             "cidr_blocks": [
               "10.200.0.0/16"
             ],
-            "description": "",
+            "description": "Allow outbound traffic on port 26501",
             "from_port": 26501,
             "ipv6_cidr_blocks": [],
             "prefix_list_ids": [],
@@ -2124,7 +2124,7 @@
             "cidr_blocks": [
               "10.200.0.0/16"
             ],
-            "description": "",
+            "description": "Allow outbound traffic on port 26502",
             "from_port": 26502,
             "ipv6_cidr_blocks": [],
             "prefix_list_ids": [],
@@ -2137,7 +2137,7 @@
             "cidr_blocks": [
               "10.200.0.0/16"
             ],
-            "description": "",
+            "description": "Allow outbound traffic on port 443",
             "from_port": 443,
             "ipv6_cidr_blocks": [],
             "prefix_list_ids": [],
@@ -2150,7 +2150,7 @@
             "cidr_blocks": [
               "10.200.0.0/16"
             ],
-            "description": "",
+            "description": "Allow outbound traffic on port 8080",
             "from_port": 8080,
             "ipv6_cidr_blocks": [],
             "prefix_list_ids": [],
@@ -2163,7 +2163,7 @@
             "cidr_blocks": [
               "10.200.0.0/16"
             ],
-            "description": "",
+            "description": "Allow outbound traffic on port 9090",
             "from_port": 9090,
             "ipv6_cidr_blocks": [],
             "prefix_list_ids": [],
@@ -2176,7 +2176,7 @@
             "cidr_blocks": [
               "10.200.0.0/16"
             ],
-            "description": "",
+            "description": "Allow outbound traffic on port 9600",
             "from_port": 9600,
             "ipv6_cidr_blocks": [],
             "prefix_list_ids": [],
@@ -2191,7 +2191,7 @@
             "cidr_blocks": [
               "10.200.0.0/16"
             ],
-            "description": "",
+            "description": "Allow inbound traffic on port 22",
             "from_port": 22,
             "ipv6_cidr_blocks": [],
             "prefix_list_ids": [],
@@ -2204,7 +2204,7 @@
             "cidr_blocks": [
               "10.200.0.0/16"
             ],
-            "description": "",
+            "description": "Allow inbound traffic on port 26500",
             "from_port": 26500,
             "ipv6_cidr_blocks": [],
             "prefix_list_ids": [],
@@ -2217,7 +2217,7 @@
             "cidr_blocks": [
               "10.200.0.0/16"
             ],
-            "description": "",
+            "description": "Allow inbound traffic on port 26501",
             "from_port": 26501,
             "ipv6_cidr_blocks": [],
             "prefix_list_ids": [],
@@ -2230,7 +2230,7 @@
             "cidr_blocks": [
               "10.200.0.0/16"
             ],
-            "description": "",
+            "description": "Allow inbound traffic on port 26502",
             "from_port": 26502,
             "ipv6_cidr_blocks": [],
             "prefix_list_ids": [],
@@ -2243,7 +2243,7 @@
             "cidr_blocks": [
               "10.200.0.0/16"
             ],
-            "description": "",
+            "description": "Allow inbound traffic on port 443",
             "from_port": 443,
             "ipv6_cidr_blocks": [],
             "prefix_list_ids": [],
@@ -2256,7 +2256,7 @@
             "cidr_blocks": [
               "10.200.0.0/16"
             ],
-            "description": "",
+            "description": "Allow inbound traffic on port 8080",
             "from_port": 8080,
             "ipv6_cidr_blocks": [],
             "prefix_list_ids": [],
@@ -2269,7 +2269,7 @@
             "cidr_blocks": [
               "10.200.0.0/16"
             ],
-            "description": "",
+            "description": "Allow inbound traffic on port 9090",
             "from_port": 9090,
             "ipv6_cidr_blocks": [],
             "prefix_list_ids": [],
@@ -2282,7 +2282,7 @@
             "cidr_blocks": [
               "10.200.0.0/16"
             ],
-            "description": "",
+            "description": "Allow inbound traffic on port 9600",
             "from_port": 9600,
             "ipv6_cidr_blocks": [],
             "prefix_list_ids": [],
@@ -2341,20 +2341,7 @@
             "cidr_blocks": [
               "0.0.0.0/0"
             ],
-            "description": "",
-            "from_port": 443,
-            "ipv6_cidr_blocks": [],
-            "prefix_list_ids": [],
-            "protocol": "tcp",
-            "security_groups": [],
-            "self": false,
-            "to_port": 443
-          },
-          {
-            "cidr_blocks": [
-              "0.0.0.0/0"
-            ],
-            "description": "",
+            "description": "Allow outbound HTTP traffic",
             "from_port": 80,
             "ipv6_cidr_blocks": [],
             "prefix_list_ids": [],
@@ -2362,6 +2349,19 @@
             "security_groups": [],
             "self": false,
             "to_port": 80
+          },
+          {
+            "cidr_blocks": [
+              "0.0.0.0/0"
+            ],
+            "description": "Allow outbound HTTPS traffic",
+            "from_port": 443,
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "protocol": "tcp",
+            "security_groups": [],
+            "self": false,
+            "to_port": 443
           }
         ],
         "name": "allow_package_80_443",
@@ -2430,20 +2430,7 @@
             "cidr_blocks": [
               "0.0.0.0/0"
             ],
-            "description": "",
-            "from_port": 443,
-            "ipv6_cidr_blocks": [],
-            "prefix_list_ids": [],
-            "protocol": "tcp",
-            "security_groups": [],
-            "self": false,
-            "to_port": 443
-          },
-          {
-            "cidr_blocks": [
-              "0.0.0.0/0"
-            ],
-            "description": "",
+            "description": "Allow outbound HTTP traffic",
             "from_port": 80,
             "ipv6_cidr_blocks": [],
             "prefix_list_ids": [],
@@ -2451,6 +2438,19 @@
             "security_groups": [],
             "self": false,
             "to_port": 80
+          },
+          {
+            "cidr_blocks": [
+              "0.0.0.0/0"
+            ],
+            "description": "Allow outbound HTTPS traffic",
+            "from_port": 443,
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "protocol": "tcp",
+            "security_groups": [],
+            "self": false,
+            "to_port": 443
           }
         ],
         "ingress": [
@@ -2458,20 +2458,7 @@
             "cidr_blocks": [
               "0.0.0.0/0"
             ],
-            "description": "",
-            "from_port": 443,
-            "ipv6_cidr_blocks": [],
-            "prefix_list_ids": [],
-            "protocol": "tcp",
-            "security_groups": [],
-            "self": false,
-            "to_port": 443
-          },
-          {
-            "cidr_blocks": [
-              "0.0.0.0/0"
-            ],
-            "description": "",
+            "description": "Allow inbound HTTP traffic",
             "from_port": 80,
             "ipv6_cidr_blocks": [],
             "prefix_list_ids": [],
@@ -2479,6 +2466,19 @@
             "security_groups": [],
             "self": false,
             "to_port": 80
+          },
+          {
+            "cidr_blocks": [
+              "0.0.0.0/0"
+            ],
+            "description": "Allow inbound HTTPS traffic",
+            "from_port": 443,
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "protocol": "tcp",
+            "security_groups": [],
+            "self": false,
+            "to_port": 443
           }
         ],
         "name": "allow_remote_80_443",
@@ -2531,7 +2531,7 @@
             "cidr_blocks": [
               "0.0.0.0/0"
             ],
-            "description": "",
+            "description": "Allow outbound traffic on port 9090",
             "from_port": 9090,
             "ipv6_cidr_blocks": [],
             "prefix_list_ids": [],
@@ -2546,7 +2546,7 @@
             "cidr_blocks": [
               "0.0.0.0/0"
             ],
-            "description": "",
+            "description": "Allow inbound traffic on port 9090",
             "from_port": 9090,
             "ipv6_cidr_blocks": [],
             "prefix_list_ids": [],
@@ -2597,7 +2597,7 @@
             "cidr_blocks": [
               "0.0.0.0/0"
             ],
-            "description": "",
+            "description": "Allow inbound gRPC traffic on port 26500",
             "from_port": 26500,
             "ipv6_cidr_blocks": [],
             "prefix_list_ids": [],
@@ -2648,7 +2648,7 @@
             "cidr_blocks": [
               "0.0.0.0/0"
             ],
-            "description": "",
+            "description": "Allow inbound SSH traffic",
             "from_port": 22,
             "ipv6_cidr_blocks": [],
             "prefix_list_ids": [],


### PR DESCRIPTION
Source issue: https://github.com/camunda/team-infrastructure-experience/issues/37

Extending the scope of the above issue to this repository as well, implementing a trivy scan of terraform files within was directory, excluding fixtures (formerly tfsec).

Issues are ignored for now and listed in .trivyignore