### PR TITLE
chore: bump elasticsearch instances

### DIFF
--- a/aws/rosa-hcp-dual-region/procedure/camunda/8.7/helm-values/values-base.yml
+++ b/aws/rosa-hcp-dual-region/procedure/camunda/8.7/helm-values/values-base.yml
@@ -128,7 +128,7 @@ zeebeGateway:
 elasticsearch:
     enabled: true
     master:
-        replicaCount: 2
+        replicaCount: 3
         resources:
             requests:
                 cpu: 100m


### PR DESCRIPTION
based on feedback, we should align the elasticsearch master count with the helm chart.