### PR TITLE
chore: dont cancle renovate concurrent prs to allow finishing runs

### DIFF
--- a/.github/workflows/aws_ec2_tests.yml
+++ b/.github/workflows/aws_ec2_tests.yml
@@ -16,7 +16,9 @@ on:
 # limit to a single execution per actor of this workflow
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
-    cancel-in-progress: true
+    # in case of renovate we don't cancel the previous run, so it can finish it
+    # otherwise weekly renovate PRs with tf docs updates result in broken clusters
+    cancel-in-progress: ${{ github.actor == 'renovate[bot]' && false || true }}
 
 env:
     AWS_PROFILE: infex


### PR DESCRIPTION
related to https://github.com/camunda/camunda-tf-eks-module/pull/233