### PR TITLE
fix: schedules 8.6

### DIFF
--- a/.github/workflows/aws_ec2_golden.yml
+++ b/.github/workflows/aws_ec2_golden.yml
@@ -21,7 +21,7 @@ concurrency:
     cancel-in-progress: true
 
 env:
-    IS_SCHEDULE: ${{ contains(github.ref, 'refs/heads/schedule/') || github.event_name == 'schedule' && 'true' || 'false' }}
+    IS_SCHEDULE: ${{ contains(github.ref, 'refs/heads/schedules/') || github.event_name == 'schedule' && 'true' || 'false' }}
 
     AWS_PROFILE: infex
     AWS_REGION: eu-west-2

--- a/.github/workflows/aws_ec2_tests.yml
+++ b/.github/workflows/aws_ec2_tests.yml
@@ -21,7 +21,7 @@ concurrency:
     cancel-in-progress: ${{ !contains('renovate[bot]', github.actor) }}
 
 env:
-    IS_SCHEDULE: ${{ contains(github.ref, 'refs/heads/schedule/') || github.event_name == 'schedule' && 'true' || 'false' }}
+    IS_SCHEDULE: ${{ contains(github.ref, 'refs/heads/schedules/') || github.event_name == 'schedule' && 'true' || 'false' }}
 
     AWS_PROFILE: infex
     AWS_REGION: eu-west-2

--- a/.github/workflows/aws_openshift_rosa_hcp_single_region_daily_cleanup.yml
+++ b/.github/workflows/aws_openshift_rosa_hcp_single_region_daily_cleanup.yml
@@ -27,7 +27,7 @@ concurrency:
     cancel-in-progress: ${{ !contains('renovate[bot]', github.actor) }}
 
 env:
-    IS_SCHEDULE: ${{ contains(github.ref, 'refs/heads/schedule/') || github.event_name == 'schedule' && 'true' || 'false' }}
+    IS_SCHEDULE: ${{ contains(github.ref, 'refs/heads/schedules/') || github.event_name == 'schedule' && 'true' || 'false' }}
 
     MAX_AGE_HOURS_CLUSTER: ${{ github.event.inputs.max_age_hours_cluster || '20' }}
 

--- a/.github/workflows/aws_openshift_rosa_hcp_single_region_golden.yml
+++ b/.github/workflows/aws_openshift_rosa_hcp_single_region_golden.yml
@@ -16,7 +16,7 @@ concurrency:
     cancel-in-progress: true
 
 env:
-    IS_SCHEDULE: ${{ contains(github.ref, 'refs/heads/schedule/') || github.event_name == 'schedule' && 'true' || 'false' }}
+    IS_SCHEDULE: ${{ contains(github.ref, 'refs/heads/schedules/') || github.event_name == 'schedule' && 'true' || 'false' }}
 
     # keep this synced with other workflows
     AWS_PROFILE: infex

--- a/.github/workflows/aws_openshift_rosa_hcp_single_region_tests.yml
+++ b/.github/workflows/aws_openshift_rosa_hcp_single_region_tests.yml
@@ -41,7 +41,7 @@ concurrency:
     cancel-in-progress: ${{ !contains('renovate[bot]', github.actor) }}
 
 env:
-    IS_SCHEDULE: ${{ contains(github.ref, 'refs/heads/schedule/') || github.event_name == 'schedule' && 'true' || 'false' }}
+    IS_SCHEDULE: ${{ contains(github.ref, 'refs/heads/schedules/') || github.event_name == 'schedule' && 'true' || 'false' }}
 
     AWS_PROFILE: infex
     AWS_REGION: eu-west-2


### PR DESCRIPTION
the branch of the schedules is /schedules/, not /schedule/ (see https://github.com/camunda/camunda-deployment-references/actions/runs/13890802184?pr=152)