### PR TITLE
fix: always post diff if golden triggered

### DIFF
--- a/.github/workflows/aws_ec2_golden.yml
+++ b/.github/workflows/aws_ec2_golden.yml
@@ -106,3 +106,21 @@ jobs:
                       If the changes are expected, you can use the uploaded artifact on the workflow to update the golden file on your branch.
                       Alternatively run `just regenerate-aws-ec2-golden-file` locally to update the golden file.
                   comment-body-no-diff: ✅ No diff, you can ignore this comment and below footer.
+
+            - name: Delete specific comment containing the text and post diff
+              if: always() && github.event_name == 'pull_request'
+              env:
+                  GH_TOKEN: ${{ github.token }}
+              run: |
+                  diff_comment_url=$(gh pr view ${{ github.event.pull_request.number }} --json comments \
+                      --jq ".comments[] | select(.body | contains(\"✅ No diff, you can ignore this comment and below footer.\")) | .url")
+
+                  if [ -n "$diff_comment_url" ]; then
+                      # shellcheck disable=SC2001
+                      comment_id=$(echo "$diff_comment_url" | sed 's/.*#issuecomment-\([^ ]*\)/\1/')
+                      echo "Deleting no diff comment $diff_comment_url (#$comment_id)"
+                      gh api \
+                        --method DELETE \
+                        -H "Accept: application/vnd.github+json" \
+                        "/repos/${{ github.repository }}/issues/comments/$comment_id"
+                  fi

--- a/.github/workflows/aws_ec2_golden.yml
+++ b/.github/workflows/aws_ec2_golden.yml
@@ -105,3 +105,4 @@ jobs:
                       Check the delta diff in the [workflow run](${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}) for a detailed comparison.
                       If the changes are expected, you can use the uploaded artifact on the workflow to update the golden file on your branch.
                       Alternatively run `just regenerate-aws-ec2-golden-file` locally to update the golden file.
+                  comment-body-no-diff: ✅ No diff, you can ignore this comment and below footer.

--- a/.github/workflows/aws_openshift_rosa_hcp_single_region_golden.yml
+++ b/.github/workflows/aws_openshift_rosa_hcp_single_region_golden.yml
@@ -108,5 +108,8 @@ jobs:
 
                   if [ -n "$DIFF_COMMENT" ]; then
                       echo "Deleting no diff comment with ID $DIFF_COMMENT"
-                      gh pr comment ${{ github.event.pull_request.number }} --delete --comment-id "$DIFF_COMMENT"
+                      gh api \
+                        --method DELETE \
+                        -H "Accept: application/vnd.github+json" \
+                        "/repos/${{ github.repository }}/pulls/comments/$DIFF_COMMENT"
                   fi

--- a/.github/workflows/aws_openshift_rosa_hcp_single_region_golden.yml
+++ b/.github/workflows/aws_openshift_rosa_hcp_single_region_golden.yml
@@ -97,3 +97,14 @@ jobs:
                       just regenerate-golden-file "${{ env.MODULE_DIR }}" "${{ env.S3_BUCKET_REGION }}" "${{ env.S3_BACKEND_BUCKET }}" "${{ env.S3_BUCKET_KEY }}"
                       ```
                   comment-body-no-diff: ✅ No diff, you can ignore this comment and below footer.
+
+            - name: Delete specific comment containing the text and post diff
+              if: always() && github.event_name == 'pull_request'
+              run: |
+                  DIFF_COMMENT=$(gh pr view ${{ github.event.pull_request.number }} --json comments \
+                      --jq ".comments[] | select(.body | contains(\"✅ No diff, you can ignore this comment and below footer.\")) | .id")
+
+                  if [ -n "$DIFF_COMMENT" ]; then
+                      echo "Deleting no diff comment with ID $DIFF_COMMENT"
+                      gh pr comment ${{ github.event.pull_request.number }} --delete --comment-id "$DIFF_COMMENT"
+                  fi

--- a/.github/workflows/aws_openshift_rosa_hcp_single_region_golden.yml
+++ b/.github/workflows/aws_openshift_rosa_hcp_single_region_golden.yml
@@ -78,7 +78,7 @@ jobs:
                   exit $?
 
             - name: Post diff on PR
-              if: failure() && github.event_name == 'pull_request'
+              if: always() && github.event_name == 'pull_request'
               uses: int128/diff-action@db6cce01542cb26e181798736eea1e71f5d36706 # v1
               with:
                   base: ${{ env.MODULE_DIR }}test/golden/tfplan-golden.json
@@ -96,3 +96,4 @@ jobs:
                       ```sh
                       just regenerate-golden-file "${{ env.MODULE_DIR }}" "${{ env.S3_BUCKET_REGION }}" "${{ env.S3_BACKEND_BUCKET }}" "${{ env.S3_BUCKET_KEY }}"
                       ```
+                  comment-body-no-diff: ✅ No diff, you can ignore this comment and below footer.

--- a/.github/workflows/aws_openshift_rosa_hcp_single_region_golden.yml
+++ b/.github/workflows/aws_openshift_rosa_hcp_single_region_golden.yml
@@ -111,5 +111,5 @@ jobs:
                       gh api \
                         --method DELETE \
                         -H "Accept: application/vnd.github+json" \
-                        "/repos/${{ github.repository }}/pulls/comments/$DIFF_COMMENT"
+                        "/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments/$DIFF_COMMENT"
                   fi

--- a/.github/workflows/aws_openshift_rosa_hcp_single_region_golden.yml
+++ b/.github/workflows/aws_openshift_rosa_hcp_single_region_golden.yml
@@ -106,7 +106,7 @@ jobs:
                   diff_comment_url=$(gh pr view ${{ github.event.pull_request.number }} --json comments \
                       --jq ".comments[] | select(.body | contains(\"✅ No diff, you can ignore this comment and below footer.\")) | .url")
 
-                  if [ -n "$DIFF_COMMENT" ]; then
+                  if [ -n "$diff_comment_url" ]; then
                       # shellcheck disable=SC2001
                       comment_id=$(echo "$diff_comment_url" | sed 's/.*#issuecomment-\([^ ]*\)/\1/')
                       echo "Deleting no diff comment $diff_comment_url (#$comment_id)"

--- a/.github/workflows/aws_openshift_rosa_hcp_single_region_golden.yml
+++ b/.github/workflows/aws_openshift_rosa_hcp_single_region_golden.yml
@@ -103,13 +103,15 @@ jobs:
               env:
                   GH_TOKEN: ${{ github.token }}
               run: |
-                  DIFF_COMMENT=$(gh pr view ${{ github.event.pull_request.number }} --json comments \
-                      --jq ".comments[] | select(.body | contains(\"✅ No diff, you can ignore this comment and below footer.\")) | .id")
+                  diff_comment_url=$(gh pr view ${{ github.event.pull_request.number }} --json comments \
+                      --jq ".comments[] | select(.body | contains(\"✅ No diff, you can ignore this comment and below footer.\")) | .url")
 
                   if [ -n "$DIFF_COMMENT" ]; then
-                      echo "Deleting no diff comment with ID $DIFF_COMMENT"
+                      # shellcheck disable=SC2001
+                      comment_id=$(echo "$diff_comment_url" | sed 's/.*#issuecomment-\([^ ]*\)/\1/')
+                      echo "Deleting no diff comment $diff_comment_url (#$comment_id)"
                       gh api \
                         --method DELETE \
                         -H "Accept: application/vnd.github+json" \
-                        "/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments/$DIFF_COMMENT"
+                        "/repos/${{ github.repository }}/issues/comments/$comment_id"
                   fi

--- a/.github/workflows/aws_openshift_rosa_hcp_single_region_golden.yml
+++ b/.github/workflows/aws_openshift_rosa_hcp_single_region_golden.yml
@@ -100,6 +100,8 @@ jobs:
 
             - name: Delete specific comment containing the text and post diff
               if: always() && github.event_name == 'pull_request'
+              env:
+                  GH_TOKEN: ${{ github.token }}
               run: |
                   DIFF_COMMENT=$(gh pr view ${{ github.event.pull_request.number }} --json comments \
                       --jq ".comments[] | select(.body | contains(\"✅ No diff, you can ignore this comment and below footer.\")) | .id")

--- a/aws/openshift/rosa-hcp-single-region/test/golden/tfplan-golden.json
+++ b/aws/openshift/rosa-hcp-single-region/test/golden/tfplan-golden.json
@@ -1,6 +1,6 @@
 {
   "child_modules": {
-    "module.rosa_cluster": {
+    "module.rosa_cluster_diff": {
       "child_modules": {
         "module.rosa_cluster.module.htpasswd_idp": {
           "resources": {

--- a/aws/openshift/rosa-hcp-single-region/test/golden/tfplan-golden.json
+++ b/aws/openshift/rosa-hcp-single-region/test/golden/tfplan-golden.json
@@ -1,6 +1,6 @@
 {
   "child_modules": {
-    "module.rosa_cluster_diff": {
+    "module.rosa_cluster": {
       "child_modules": {
         "module.rosa_cluster.module.htpasswd_idp": {
           "resources": {


### PR DESCRIPTION
We should always execute the PR diff message otherwise you will miss out on it actually succeeding.

Related to - https://github.com/camunda/camunda-deployment-references/pull/144#issuecomment-2729069928

Had a meeting inbetween 😓 