### PR TITLE
fix: schedules don't break yaml formatting

### DIFF
--- a/.github/workflows/internal_global_branches_workflow_scheduler.yml
+++ b/.github/workflows/internal_global_branches_workflow_scheduler.yml
@@ -104,10 +104,6 @@ jobs:
                     ')
                   fi
 
-                  schedule_name="Everyday schedules 8.6"
-                  filtered_schedules=$(echo "$formatted_schedules" | jq -c --arg schedule_name "$schedule_name" \
-                     '[.[] | select(.name == $schedule_name)]')
-
                   echo "schedules=${filtered_schedules}" | tee -a "$GITHUB_OUTPUT"
 
     schedule-workflows:


### PR DESCRIPTION
Currently, the use of `yq` in the scheduler breaks the file formatting, causing the lint step to fail and generating large diffs in scheduled PRs.  

This PR fixes the issue by adding a `pre-commit` format step.  

🔹 **Example run**:  https://github.com/camunda/camunda-deployment-references/actions/runs/13903972702/job/38902390579

Additionally, this improvement will make it easier to identify failed scheduled workflows, as they will now appear as failed PRs:  

- **Before**: https://github.com/camunda/camunda-deployment-references/pull/152
- **After**: https://github.com/camunda/camunda-deployment-references/pull/162

Note: due to yamlfmt changing indentation of everything except the comments, we have to remove all the comments from the file