### PR TITLE
fix: remove empty-dir addition since its fixed upstream

### DIFF
--- a/aws/openshift/rosa-hcp-dual-region/procedure/helm-values/values-base.yml
+++ b/aws/openshift/rosa-hcp-dual-region/procedure/helm-values/values-base.yml
@@ -149,8 +149,3 @@ elasticsearch:
             echo "${DOLLAR}S3_SECRET_KEY" | elasticsearch-keystore add -x s3.client.camunda.secret_key
             echo "${DOLLAR}S3_ACCESS_KEY" | elasticsearch-keystore add -x s3.client.camunda.access_key
     extraEnvVarsSecret: elasticsearch-env-secret
-    # Bitnami chart fix to allow adding keystore secrets
-    extraVolumeMounts:
-        - name: empty-dir
-          mountPath: /bitnami/elasticsearch
-          subPath: app-volume-dir


### PR DESCRIPTION
the emptyDir situation was fixed upstream in the Bitnami Chart, which the 11.2.2 Camunda Helm chart is using.