### PR TITLE
chore: rename merge-branch occurences to main

### DIFF
--- a/.github/actions/aws-aurora-manage-cluster/README.md
+++ b/.github/actions/aws-aurora-manage-cluster/README.md
@@ -22,7 +22,7 @@ This action will also install Terraform and awscli. It will output the Aurora cl
 | `s3-backend-bucket` | <p>Name of the S3 bucket to store Terraform state</p> | `true` | `""` |
 | `s3-bucket-region` | <p>Region of the bucket containing the resources states</p> | `false` | `""` |
 | `s3-bucket-key-prefix` | <p>Key prefix of the bucket containing the resources states. It must contain a / at the end e.g 'my-prefix/'.</p> | `false` | `""` |
-| `tf-modules-revision` | <p>Git revision of the tf modules to use</p> | `false` | `merge-branch` |
+| `tf-modules-revision` | <p>Git revision of the tf modules to use</p> | `false` | `main` |
 | `tf-modules-path` | <p>Path where the tf Aurora modules will be cloned</p> | `false` | `./.action-tf-modules/aurora/` |
 | `tf-cli-config-credentials-hostname` | <p>The hostname of a HCP Terraform/Terraform Enterprise instance to place within the credentials block of the Terraform CLI configuration file. Defaults to <code>app.terraform.io</code>.</p> | `false` | `app.terraform.io` |
 | `tf-cli-config-credentials-token` | <p>The API token for a HCP Terraform/Terraform Enterprise instance to place within the credentials block of the Terraform CLI configuration file.</p> | `false` | `""` |
@@ -125,7 +125,7 @@ This action is a `composite` action.
     # Git revision of the tf modules to use
     #
     # Required: false
-    # Default: merge-branch
+    # Default: main
 
     tf-modules-path:
     # Path where the tf Aurora modules will be cloned

--- a/.github/actions/aws-aurora-manage-cluster/action.yml
+++ b/.github/actions/aws-aurora-manage-cluster/action.yml
@@ -57,7 +57,7 @@ inputs:
 
     tf-modules-revision:
         description: Git revision of the tf modules to use
-        default: merge-branch
+        default: main
 
     tf-modules-path:
         description: Path where the tf Aurora modules will be cloned
@@ -113,7 +113,7 @@ runs:
           id: utility
           # see https://github.com/orgs/community/discussions/41927 it's not possible to optimize this yet
           # steps.uses  cannot access the github context.
-          uses: camunda/camunda-deployment-references/.github/actions/aws-utility-action@merge-branch
+          uses: camunda/camunda-deployment-references/.github/actions/aws-utility-action@main
           with:
               awscli-version: ${{ inputs.awscli-version }}
               terraform-version: ${{ inputs.terraform-version }}

--- a/.github/actions/aws-eks-manage-cluster/README.md
+++ b/.github/actions/aws-eks-manage-cluster/README.md
@@ -16,7 +16,7 @@ This action will also install Terraform, awscli, and kubectl. The kube context w
 | `s3-backend-bucket` | <p>Name of the S3 bucket to store Terraform state</p> | `true` | `""` |
 | `s3-bucket-region` | <p>Region of the bucket containing the resources states, if not set, will fallback on aws-region</p> | `false` | `""` |
 | `s3-bucket-key-prefix` | <p>Key prefix of the bucket containing the resources states. It must contain a / at the end e.g 'my-prefix/'.</p> | `false` | `""` |
-| `tf-modules-revision` | <p>Git revision of the tf modules to use</p> | `false` | `merge-branch` |
+| `tf-modules-revision` | <p>Git revision of the tf modules to use</p> | `false` | `main` |
 | `tf-modules-path` | <p>Path where the tf EKS modules will be cloned</p> | `false` | `./.action-tf-modules/eks/` |
 | `login` | <p>Authenticate the current kube context on the created cluster</p> | `false` | `true` |
 | `tf-cli-config-credentials-hostname` | <p>The hostname of a HCP Terraform/Terraform Enterprise instance to place within the credentials block of the Terraform CLI configuration file. Defaults to <code>app.terraform.io</code>.</p> | `false` | `app.terraform.io` |
@@ -84,7 +84,7 @@ This action is a `composite` action.
     # Git revision of the tf modules to use
     #
     # Required: false
-    # Default: merge-branch
+    # Default: main
 
     tf-modules-path:
     # Path where the tf EKS modules will be cloned

--- a/.github/actions/aws-eks-manage-cluster/action.yml
+++ b/.github/actions/aws-eks-manage-cluster/action.yml
@@ -33,7 +33,7 @@ inputs:
 
     tf-modules-revision:
         description: Git revision of the tf modules to use
-        default: merge-branch
+        default: main
 
     tf-modules-path:
         description: Path where the tf EKS modules will be cloned
@@ -92,7 +92,7 @@ runs:
           # see https://github.com/orgs/community/discussions/41927 it's not possible to optimize this yet
           # steps.uses  cannot access the github context.
           # uses: ${{ github.action_repository }}/aws-utility-action@${{ github.action_ref }}
-          uses: camunda/camunda-deployment-references/.github/actions/aws-utility-action@merge-branch
+          uses: camunda/camunda-deployment-references/.github/actions/aws-utility-action@main
           with:
               awscli-version: ${{ inputs.awscli-version }}
               terraform-version: ${{ inputs.terraform-version }}

--- a/.github/actions/aws-opensearch-manage-cluster/README.md
+++ b/.github/actions/aws-opensearch-manage-cluster/README.md
@@ -22,7 +22,7 @@ It will also install Terraform and awscli. It will output the OpenSearch domain 
 | `s3-backend-bucket` | <p>Name of the S3 bucket to store Terraform state</p> | `true` | `""` |
 | `s3-bucket-region` | <p>Region of the bucket containing the resources states</p> | `false` | `""` |
 | `s3-bucket-key-prefix` | <p>Key prefix of the bucket containing the resources states. It must contain a / at the end e.g 'my-prefix/'.</p> | `false` | `""` |
-| `tf-modules-revision` | <p>Git revision of the tf modules to use</p> | `false` | `merge-branch` |
+| `tf-modules-revision` | <p>Git revision of the tf modules to use</p> | `false` | `main` |
 | `tf-modules-path` | <p>Path where the tf OpenSearch modules will be cloned</p> | `false` | `./.action-tf-modules/opensearch/` |
 | `tf-cli-config-credentials-hostname` | <p>The hostname of a HCP Terraform/Terraform Enterprise instance to place within the credentials block of the Terraform CLI configuration file. Defaults to <code>app.terraform.io</code>.</p> | `false` | `app.terraform.io` |
 | `tf-cli-config-credentials-token` | <p>The API token for a HCP Terraform/Terraform Enterprise instance to place within the credentials block of the Terraform CLI configuration file.</p> | `false` | `""` |
@@ -125,7 +125,7 @@ This action is a `composite` action.
     # Git revision of the tf modules to use
     #
     # Required: false
-    # Default: merge-branch
+    # Default: main
 
     tf-modules-path:
     # Path where the tf OpenSearch modules will be cloned

--- a/.github/actions/aws-opensearch-manage-cluster/action.yml
+++ b/.github/actions/aws-opensearch-manage-cluster/action.yml
@@ -57,7 +57,7 @@ inputs:
 
     tf-modules-revision:
         description: Git revision of the tf modules to use
-        default: merge-branch
+        default: main
 
     tf-modules-path:
         description: Path where the tf OpenSearch modules will be cloned
@@ -109,7 +109,7 @@ runs:
     steps:
         - name: Use Utility Actions
           id: utility
-          uses: camunda/camunda-deployment-references/.github/actions/aws-utility-action@merge-branch
+          uses: camunda/camunda-deployment-references/.github/actions/aws-utility-action@main
           with:
               awscli-version: ${{ inputs.awscli-version }}
               terraform-version: ${{ inputs.tf-terraform-version }}

--- a/aws/kubernetes/eks-single-region-irsa/procedure/get-your-copy.sh
+++ b/aws/kubernetes/eks-single-region-irsa/procedure/get-your-copy.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Download a copy of the reference architecture
-BRANCH="merge-branch"  # TODO: Change the branch to main then [release-duty] to 8.7
+BRANCH="main"  # TODO: [release-duty] before the release, update this!
 
 git clone --depth 1 --branch "$BRANCH" https://github.com/camunda/camunda-deployment-references.git
 

--- a/aws/kubernetes/eks-single-region/procedure/get-your-copy.sh
+++ b/aws/kubernetes/eks-single-region/procedure/get-your-copy.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Download a copy of the reference architecture
-BRANCH="merge-branch"  # TODO: Change the branch to main then [release-duty] to 8.7
+BRANCH="main"  # TODO: [release-duty] before the release, update this!
 
 git clone --depth 1 --branch "$BRANCH" https://github.com/camunda/camunda-deployment-references.git
 

--- a/aws/openshift/rosa-hcp-single-region/procedure/get-your-copy.sh
+++ b/aws/openshift/rosa-hcp-single-region/procedure/get-your-copy.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Download a copy of the reference architecture
-BRANCH="main"  # TODO: Change the branch to main then [release-duty] to 8.7
+BRANCH="main"  # TODO: [release-duty] before the release, update this!
 
 git clone --depth 1 --branch "$BRANCH" https://github.com/camunda/camunda-deployment-references.git
 


### PR DESCRIPTION
Removal of some leftover `merge-branch` names to `main`.