### PR TITLE
fix: use /tmp as working directory to download archives

### DIFF
--- a/.github/actions/aws-openshift-rosa-hcp-single-region-cleanup/action.yml
+++ b/.github/actions/aws-openshift-rosa-hcp-single-region-cleanup/action.yml
@@ -43,6 +43,7 @@ runs:
 
         - name: Install ROSA CLI
           shell: bash
+          working-directory: /tmp
           run: |
               curl -LO "https://mirror.openshift.com/pub/openshift-v4/clients/rosa/${{ inputs.rosa-cli-version }}/rosa-linux.tar.gz"
               tar -xvf rosa-linux.tar.gz
@@ -59,6 +60,7 @@ runs:
         - name: Install Cloud Nuke for retry
           shell: bash
           if: ${{ env.RETRY_DESTROY == 'true' }}
+          working-directory: /tmp
           env:
               # renovate: datasource=github-tags depName=gruntwork-io/cloud-nuke
               CLOUD_NUKE_VERSION: v0.38.2

--- a/.github/actions/aws-openshift-rosa-hcp-single-region-create/action.yml
+++ b/.github/actions/aws-openshift-rosa-hcp-single-region-create/action.yml
@@ -90,6 +90,7 @@ runs:
         # TODO: when available on asdf, migrate this to it
         - name: Install ROSA CLI
           shell: bash
+          working-directory: /tmp
           run: |
               curl -LO "https://mirror.openshift.com/pub/openshift-v4/clients/rosa/${{ inputs.rosa-cli-version }}/rosa-linux.tar.gz"
               tar -xvf rosa-linux.tar.gz

--- a/.github/actions/aws-utility-action/action.yml
+++ b/.github/actions/aws-utility-action/action.yml
@@ -78,6 +78,7 @@ runs:
 
         - name: Install AWS CLI
           shell: bash
+          working-directory: /tmp
           run: |
               set -euxo pipefail
 

--- a/.github/workflows/internal_openshift_artifact_rosa_versions.yml
+++ b/.github/workflows/internal_openshift_artifact_rosa_versions.yml
@@ -34,6 +34,7 @@ jobs:
 
             - name: Install ROSA CLI and output rosa versions
               shell: bash
+              working-directory: /tmp
               run: |
                   curl -LO "https://mirror.openshift.com/pub/openshift-v4/clients/rosa/latest/rosa-linux.tar.gz"
                   tar -xvf rosa-linux.tar.gz

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -4,7 +4,7 @@ TODO: write the complete maintenance guide (https://github.com/camunda/camunda-d
 
 ## Branching Strategy for camunda-deployment-references
 
-The repository [https://github.com/camunda/camunda-deployment-references](https://github.com/camunda/camunda-deployment-references) follows the logic of maintaining only the [next unreleased version of Camunda](https://docs.camunda.io/docs/8.7/reference/release-notes/) on the `main` branch.
+The repository [https://github.com/camunda/camunda-deployment-references](https://github.com/camunda/camunda-deployment-references) follows the logic of maintaining only the [next unreleased version of Camunda](https://docs.camunda.io/docs/next/reference/announcements-release-notes/overview/#announcements--release-notes) on the `main` branch.
 
 => Most of the time, we work on the next unreleased version, we should then merge into `main`.
 


### PR DESCRIPTION
This PR enforce usage of the /tmp directory to prevent any leftover in the current project when we download cli & artifacts

Related to https://github.com/camunda/infraex-common-config/pull/212