### PR TITLE
fix: triage should always return false on non PR

### DIFF
--- a/.github/actions/internal-triage-skip/action.yml
+++ b/.github/actions/internal-triage-skip/action.yml
@@ -16,6 +16,11 @@ runs:
           id: check_labels
           shell: bash
           run: |
+              if [[ "${{ github.event_name }}" != "pull_request" ]]; then
+                echo "workflow_should_skip=false" | tee -a "$GITHUB_OUTPUT"
+                exit 0
+              fi
+
               workflow_file_name=$(echo "${{ github.workflow_ref }}" | sed 's/@.*//')
               workflow_file_name=$(basename "$workflow_file_name" | sed 's/\(.*\)\(\.yaml\|\.yml\)$/\1/')
               echo "workflow_file_name=$workflow_file_name" | tee -a "$GITHUB_ENV"


### PR DESCRIPTION
maybe it was working implicitly already, I just want to have it explicit that it should do those checks on PRs otherwise simply always return false.

Not sure it was tried prior or not with any other event but PR, want to avoid failing schedules.

Tried it out without the fix since I was using `push` trigger on my EKS workings. (fails)

```
Prepare all required actions
Run ./.github/actions/internal-triage-skip
Run workflow_file_name=$(echo "camunda/camunda-deployment-references/.github/workflows/aws_kubernetes_eks-single_region_tests.yml@refs/heads/infraex-64[2](https://github.com/camunda/camunda-deployment-references/actions/runs/14084609563/job/39445279393#step:3:2)" | sed 's/@.*//')
workflow_file_name=aws_kubernetes_eks-single_region_tests
jq: error (at /home/runner/work/_temp/_github_workflow/event.json:219): Cannot iterate over null (null)
```

With the fix was working 🟢 