### PR TITLE
fix: generation of golden files

### DIFF
--- a/justfile
+++ b/justfile
@@ -81,7 +81,7 @@ regenerate-golden-file module_dir backend_bucket_region backend_bucket_name back
           if (.resources | length == 0) then
             { "resources": {} }
           else
-            { "resources": (.resources | map(transform) | add) }
+            { "resources": map(transform) | add }
           end
         elif has("child_modules") then
           { "child_modules": map(transform) | add }


### PR DESCRIPTION
related to https://github.com/camunda/camunda-deployment-references/actions/runs/14440234251/job/40488572608

The else didn't need a change and affected ec2, rest was fine.

Related runs:
- EC2 - https://github.com/camunda/camunda-deployment-references/actions/runs/14443636761 ✅ 
- EKS - https://github.com/camunda/camunda-deployment-references/actions/runs/14443647386 ✅ 
- ROSA - dual - https://github.com/camunda/camunda-deployment-references/actions/runs/14443649136 ✅ 
- ROSA - single - https://github.com/camunda/camunda-deployment-references/actions/runs/14443651016 ✅ 