### PR TITLE
chore: add single nat option for EKS

### DIFF
--- a/.github/actions/aws-eks-manage-cluster/README.md
+++ b/.github/actions/aws-eks-manage-cluster/README.md
@@ -24,6 +24,7 @@ This action will also install Terraform, awscli, and kubectl. The kube context w
 | `tf-terraform-version` | <p>The version of Terraform CLI to install. Instead of full version string you can also specify constraint string starting with "&lt;" (for example <code>&lt;1.13.0</code>) to install the latest version satisfying the constraint. A value of <code>latest</code> will install the latest version of Terraform CLI. Defaults to <code>latest</code>.</p> | `false` | `latest` |
 | `tf-terraform-wrapper` | <p>Whether or not to install a wrapper to wrap subsequent calls of the <code>terraform</code> binary and expose its STDOUT, STDERR, and exit code as outputs named <code>stdout</code>, <code>stderr</code>, and <code>exitcode</code> respectively. Defaults to <code>true</code>.</p> | `false` | `true` |
 | `awscli-version` | <p>Version of the aws cli to use</p> | `false` | `2.15.52` |
+| `single-nat-gateway` | <p>Whether to use a single NAT gateway or not. Default is true for our tests to save on IPs.</p> | `false` | `true` |
 
 
 ## Outputs
@@ -127,4 +128,10 @@ This action is a `composite` action.
     #
     # Required: false
     # Default: 2.15.52
+
+    single-nat-gateway:
+    # Whether to use a single NAT gateway or not. Default is true for our tests to save on IPs.
+    #
+    # Required: false
+    # Default: true
 ```

--- a/.github/actions/aws-eks-manage-cluster/action.yml
+++ b/.github/actions/aws-eks-manage-cluster/action.yml
@@ -70,6 +70,10 @@ inputs:
         # renovate: datasource=github-releases depName=aws/aws-cli
         default: 2.15.52
 
+    single-nat-gateway:
+        description: Whether to use a single NAT gateway or not. Default is true for our tests to save on IPs.
+        default: 'true'
+
 outputs:
     eks-cluster-endpoint:
         description: The API endpoint of the deployed EKS cluster
@@ -140,7 +144,8 @@ runs:
                 -var-file=/tmp/var.tfvars.json \
                 -var "name=${{ inputs.cluster-name }}" \
                 -var "region=${{ inputs.aws-region }}" \
-                -var "name=${{ inputs.cluster-name }}"
+                -var "name=${{ inputs.cluster-name }}" \
+                -var "single_nat_gateway=${{ inputs.single-nat-gateway }}"
 
         - name: Terraform Apply
           shell: bash

--- a/.github/actions/aws-kubernetes-eks-single-region-create/README.md
+++ b/.github/actions/aws-kubernetes-eks-single-region-create/README.md
@@ -13,6 +13,7 @@ The kube context will be set on the created cluster.
 | `cluster-name` | <p>Name of the EKS cluster to deploy</p> | `true` | `""` |
 | `aws-region` | <p>AWS region where the EKS cluster will be deployed</p> | `true` | `""` |
 | `kubernetes-version` | <p>Version of Kubernetes to install</p> | `false` | `1.32` |
+| `single-nat-gateway` | <p>Whether to use a single NAT gateway or not. Default is true for our tests to save on IPs.</p> | `false` | `true` |
 | `s3-backend-bucket` | <p>Name of the S3 bucket to store Terraform state</p> | `true` | `""` |
 | `s3-bucket-region` | <p>Region of the bucket containing the resources states, if not set, will fallback on aws-region</p> | `false` | `""` |
 | `s3-bucket-key-prefix` | <p>Key prefix of the bucket containing the resources states. It must contain a / at the end e.g 'my-prefix/'.</p> | `false` | `""` |
@@ -55,6 +56,12 @@ This action is a `composite` action.
     #
     # Required: false
     # Default: 1.32
+
+    single-nat-gateway:
+    # Whether to use a single NAT gateway or not. Default is true for our tests to save on IPs.
+    #
+    # Required: false
+    # Default: true
 
     s3-backend-bucket:
     # Name of the S3 bucket to store Terraform state

--- a/.github/actions/aws-kubernetes-eks-single-region-create/action.yml
+++ b/.github/actions/aws-kubernetes-eks-single-region-create/action.yml
@@ -17,6 +17,9 @@ inputs:
         required: false
         # renovate: datasource=endoflife-date depName=amazon-eks versioning=loose
         default: '1.32'
+    single-nat-gateway:
+        description: Whether to use a single NAT gateway or not. Default is true for our tests to save on IPs.
+        default: 'true'
     s3-backend-bucket:
         description: Name of the S3 bucket to store Terraform state
         required: true
@@ -112,6 +115,7 @@ runs:
               # uses locals for simplicity. Locals cannot be overwritten with the CLI.
               sed -i -e 's/\(eks_cluster_name\s*=\s*"\)[^"]*\("\)/\1${{ inputs.cluster-name }}\2/' \
                      -e 's/\(kubernetes_version\s*=\s*"\)[^"]*\("\)/\1${{ inputs.kubernetes-version }}\2/' \
+                     -e 's/\(single_nat_gateway\s*=\s*\)[^"]*\("\)/\1${{ inputs.single-nat-gateway }}\2/' \
                      cluster.tf
 
               echo "Displaying templated cluster.tf file:"

--- a/.github/actions/aws-kubernetes-eks-single-region-create/action.yml
+++ b/.github/actions/aws-kubernetes-eks-single-region-create/action.yml
@@ -115,7 +115,7 @@ runs:
               # uses locals for simplicity. Locals cannot be overwritten with the CLI.
               sed -i -e 's/\(eks_cluster_name\s*=\s*"\)[^"]*\("\)/\1${{ inputs.cluster-name }}\2/' \
                      -e 's/\(kubernetes_version\s*=\s*"\)[^"]*\("\)/\1${{ inputs.kubernetes-version }}\2/' \
-                     -e 's/\(single_nat_gateway\s*=\s*\)[^"]*\("\)/\1${{ inputs.single-nat-gateway }}\2/' \
+                     -e 's/\(single_nat_gateway\s*=\s*"\)[^"]*\("\)/\1${{ inputs.single-nat-gateway }}\2/' \
                      cluster.tf
 
               echo "Displaying templated cluster.tf file:"

--- a/aws/kubernetes/eks-single-region-irsa/cluster.tf
+++ b/aws/kubernetes/eks-single-region-irsa/cluster.tf
@@ -3,6 +3,8 @@ locals {
   eks_cluster_region = "eu-west-2"         # Change this to your desired AWS region
   # renovate: datasource=endoflife-date depName=amazon-eks versioning=loose
   kubernetes_version = "1.32" # Change this to your desired Kubernetes version (eks - major.minor)
+  # Default - 1 NAT per Subnet = 3 IPs
+  single_nat_gateway = "false" # Change this to true if you want a single NAT gateway (1 IP vs 3 IPs)
 }
 
 module "eks_cluster" {
@@ -20,6 +22,8 @@ module "eks_cluster" {
   # Default node type for the Kubernetes cluster
   np_instance_types     = ["m6i.xlarge"]
   np_desired_node_count = 4
+
+  single_nat_gateway = local.single_nat_gateway
 }
 
 output "cert_manager_arn" {

--- a/aws/kubernetes/eks-single-region/cluster.tf
+++ b/aws/kubernetes/eks-single-region/cluster.tf
@@ -3,6 +3,8 @@ locals {
   eks_cluster_region = "eu-west-2"        # Change this to your desired AWS region
   # renovate: datasource=endoflife-date depName=amazon-eks versioning=loose
   kubernetes_version = "1.32" # Change this to your desired Kubernetes version (eks - major.minor)
+  # Default - 1 NAT per Subnet = 3 IPs
+  single_nat_gateway = "false" # Change this to true if you want a single NAT gateway (1 IP vs 3 IPs)
 }
 
 module "eks_cluster" {
@@ -20,6 +22,8 @@ module "eks_cluster" {
   # Default node type for the Kubernetes cluster
   np_instance_types     = ["m6i.xlarge"]
   np_desired_node_count = 4
+
+  single_nat_gateway = local.single_nat_gateway
 }
 
 output "cert_manager_arn" {

--- a/aws/modules/eks-cluster/README.md
+++ b/aws/modules/eks-cluster/README.md
@@ -72,6 +72,7 @@ module "eks_cluster" {
 | <a name="input_np_max_node_count"></a> [np\_max\_node\_count](#input\_np\_max\_node\_count) | Maximum number of nodes for the default node pool | `number` | `10` | no |
 | <a name="input_np_min_node_count"></a> [np\_min\_node\_count](#input\_np\_min\_node\_count) | Minimum number of nodes for the default node pool | `number` | `1` | no |
 | <a name="input_region"></a> [region](#input\_region) | The region where the cluster and relevant resources should be deployed in | `string` | n/a | yes |
+| <a name="input_single_nat_gateway"></a> [single\_nat\_gateway](#input\_single\_nat\_gateway) | If set to true, a single NAT Gateway will be created for the VPC. If set to false, a NAT Gateway will be created for each subnet and requiring an IP per subnet. | `bool` | `false` | no |
 ## Outputs
 
 | Name | Description |

--- a/aws/modules/eks-cluster/variables.tf
+++ b/aws/modules/eks-cluster/variables.tf
@@ -117,3 +117,9 @@ variable "availability_zones" {
   description = "A list of availability zone names in the region. By default, this is set to `null` and is not used; instead, `availability_zones_count` manages the number of availability zones. This value should not be updated directly. To make changes, please create a new resource."
   default     = null
 }
+
+variable "single_nat_gateway" {
+  type        = bool
+  default     = false
+  description = "If set to true, a single NAT Gateway will be created for the VPC. If set to false, a NAT Gateway will be created for each subnet and requiring an IP per subnet."
+}

--- a/aws/modules/eks-cluster/vpc.tf
+++ b/aws/modules/eks-cluster/vpc.tf
@@ -37,11 +37,14 @@ check "elastic_ip_quota_check" {
 
   # Only check the condition when no existing vpc is there
   assert {
-    condition     = length(data.aws_vpcs.current_vpcs.ids) > 0 || (data.aws_servicequotas_service_quota.elastic_ip_quota.value - length(data.aws_eips.current_usage.public_ips)) >= length(local.azs)
-    error_message = "Not enough available Elastic IPs to cover all local availability zones (need: ${length(local.azs)}, have: ${(data.aws_servicequotas_service_quota.elastic_ip_quota.value - length(data.aws_eips.current_usage.public_ips))})."
+    condition = length(data.aws_vpcs.current_vpcs.ids) > 0 || (
+      (data.aws_servicequotas_service_quota.elastic_ip_quota.value - length(data.aws_eips.current_usage.public_ips)) >= (
+        var.single_nat_gateway ? 1 : length(local.azs)
+      )
+    )
+    error_message = "Not enough available Elastic IPs to cover required NAT gateways (need: ${var.single_nat_gateway ? 1 : length(local.azs)}, have: ${(data.aws_servicequotas_service_quota.elastic_ip_quota.value - length(data.aws_eips.current_usage.public_ips))})."
   }
 }
-
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"

--- a/aws/modules/eks-cluster/vpc.tf
+++ b/aws/modules/eks-cluster/vpc.tf
@@ -72,7 +72,7 @@ module "vpc" {
 
   # Single NATGateway per private subnet
   enable_nat_gateway = true
-  single_nat_gateway = false
+  single_nat_gateway = var.single_nat_gateway
   reuse_nat_ips      = false
 
   # Enable DNS hostnames and DNS support required for VPC Peering

--- a/aws/modules/fixtures/fixtures.default.eks.tfvars
+++ b/aws/modules/fixtures/fixtures.default.eks.tfvars
@@ -10,3 +10,6 @@ cluster_tags = {
 np_labels = {
   Environment = "tests"
 }
+
+# We use a single NAT gateway to save IPs
+single_nat_gateway = true


### PR DESCRIPTION
related to https://github.com/camunda/team-infrastructure-experience/issues/539

- Adds single nat gateway option for EKS (false by default), so preserving the old behaviour
- For the tests we're overwriting it and just using a single nat to save on IPs
- adjusted the IP check to properly reflect usage

![image](https://github.com/user-attachments/assets/c58a1519-67c4-496c-8b36-9f281eb8bbb5)


Skipped module tests for the rerun as they passed and didn't change based on the fix for the eks single-region stuff.

- https://github.com/camunda/camunda-deployment-references/actions/runs/14464748096
- https://github.com/camunda/camunda-deployment-references/actions/runs/14464748108
- https://github.com/camunda/camunda-deployment-references/actions/runs/14466534168