### PR TITLE
chore: rosa downgrade to 1 AZ to limit IP usage

### DIFF
--- a/.github/actions/aws-openshift-rosa-hcp-dual-region-create/README.md
+++ b/.github/actions/aws-openshift-rosa-hcp-dual-region-create/README.md
@@ -21,8 +21,8 @@ Each cluster will be added to the kube config with the name of the cluster as co
 | `admin-username-cluster-2` | <p>Admin username for the ROSA cluster 2</p> | `false` | `kube-admin` |
 | `aws-region-cluster-1` | <p>AWS region where the ROSA cluster 1 will be deployed</p> | `true` | `""` |
 | `aws-region-cluster-2` | <p>AWS region where the ROSA cluster 2 will be deployed</p> | `true` | `""` |
-| `availability-zones-cluster-1` | <p>Comma separated list of availability zones for cluster 1 (letters only, e.g., a,b,c)</p> | `false` | `a,b,c` |
-| `availability-zones-cluster-2` | <p>Comma separated list of availability zones for cluster 2 (letters only, e.g., a,b,c)</p> | `false` | `a,b,c` |
+| `availability-zones-cluster-1` | <p>Comma separated list of availability zones for cluster 1 (letters only, e.g., a,b,c)</p> | `false` | `a` |
+| `availability-zones-cluster-2` | <p>Comma separated list of availability zones for cluster 2 (letters only, e.g., a,b,c)</p> | `false` | `a` |
 | `rosa-cli-version` | <p>Version of the ROSA CLI to use</p> | `false` | `latest` |
 | `openshift-version-cluster-1` | <p>Version of the OpenShift to install</p> | `false` | `4.18.5` |
 | `openshift-version-cluster-2` | <p>Version of the OpenShift to install</p> | `false` | `4.18.5` |
@@ -122,13 +122,13 @@ This action is a `composite` action.
     # Comma separated list of availability zones for cluster 1 (letters only, e.g., a,b,c)
     #
     # Required: false
-    # Default: a,b,c
+    # Default: a
 
     availability-zones-cluster-2:
     # Comma separated list of availability zones for cluster 2 (letters only, e.g., a,b,c)
     #
     # Required: false
-    # Default: a,b,c
+    # Default: a
 
     rosa-cli-version:
     # Version of the ROSA CLI to use

--- a/.github/actions/aws-openshift-rosa-hcp-dual-region-create/action.yml
+++ b/.github/actions/aws-openshift-rosa-hcp-dual-region-create/action.yml
@@ -273,6 +273,15 @@ runs:
                      -e "s/\(rosa_cluster_1_zones\s*=\s*\)[^]]*\]/\1[$FULL_AZS_CLUSTER_1]/" \
                      cluster_region_1.tf
 
+              if [[ "${{ inputs.availability-zones-cluster-1 }}" == "a" ]]; then
+                # The VPC module of ROSA does a bad cidr calculation with single zones
+                echo "Patching cluster.tf for single AZ deployment"
+                sed -i -e 's/\(machine_cidr_block\s*=\s*"\)[^"]*\("\)/\110.0.64.0\/20\2/' \
+                       -e 's/\(service_cidr_block\s*=\s*"\)[^"]*\("\)/\110.0.80.0\/20\2/' \
+                       -e 's/\(pod_cidr_block\s*=\s*"\)[^"]*\("\)/\110.0.96.0\/20\2/' \
+                       cluster_region_1.tf
+              fi
+
               if [ -n "${{ inputs.replicas-cluster-1 }}" ]; then
                 sed -i -e 's/\(replicas\s*=\s*\)[0-9]\+/\1${{ inputs.replicas-cluster-1 }}/' cluster_region_1.tf
               else
@@ -292,6 +301,15 @@ runs:
                      -e 's/\(openshift_version\s*=\s*"\)[^"]*\("\)/\1${{ inputs.openshift-version-cluster-2 }}\2/' \
                      -e "s/\(rosa_cluster_2_zones\s*=\s*\)[^]]*\]/\1[$FULL_AZS_CLUSTER_2]/" \
                      cluster_region_2.tf
+
+              if [[ "${{ inputs.availability-zones-cluster-2 }}" == "a" ]]; then
+                # The VPC module of ROSA does a bad cidr calculation with single zones
+                echo "Patching cluster.tf for single AZ deployment"
+                sed -i -e 's/\(machine_cidr_block\s*=\s*"\)[^"]*\("\)/\110.1.64.0\/20\2/' \
+                       -e 's/\(service_cidr_block\s*=\s*"\)[^"]*\("\)/\110.1.80.0\/20\2/' \
+                       -e 's/\(pod_cidr_block\s*=\s*"\)[^"]*\("\)/\110.1.96.0\/20\2/' \
+                       cluster_region_2.tf
+              fi
 
               if [ -n "${{ inputs.replicas-cluster-2 }}" ]; then
                 sed -i -e 's/\(replicas\s*=\s*\)[0-9]\+/\1${{ inputs.replicas-cluster-2 }}/' cluster_region_2.tf

--- a/.github/actions/aws-openshift-rosa-hcp-dual-region-create/action.yml
+++ b/.github/actions/aws-openshift-rosa-hcp-dual-region-create/action.yml
@@ -35,12 +35,13 @@ inputs:
     aws-region-cluster-2:
         description: AWS region where the ROSA cluster 2 will be deployed
         required: true
+    # We're limiting the AZs to 1 within tests as each consumes 1 IP for NAT
     availability-zones-cluster-1:
         description: Comma separated list of availability zones for cluster 1 (letters only, e.g., a,b,c)
-        default: a,b,c
+        default: a
     availability-zones-cluster-2:
         description: Comma separated list of availability zones for cluster 2 (letters only, e.g., a,b,c)
-        default: a,b,c
+        default: a
     rosa-cli-version:
         description: Version of the ROSA CLI to use
         default: latest

--- a/.github/actions/aws-openshift-rosa-hcp-single-region-create/README.md
+++ b/.github/actions/aws-openshift-rosa-hcp-single-region-create/README.md
@@ -16,7 +16,7 @@ The kube context will be set on the created cluster.
 | `admin-password` | <p>Admin password for the ROSA cluster</p> | `true` | `""` |
 | `admin-username` | <p>Admin username for the ROSA cluster</p> | `true` | `kube-admin` |
 | `aws-region` | <p>AWS region where the ROSA cluster will be deployed</p> | `true` | `""` |
-| `availability-zones` | <p>Comma separated list of availability zones (letters only, e.g., a,b,c)</p> | `true` | `a,b,c` |
+| `availability-zones` | <p>Comma separated list of availability zones (letters only, e.g., a,b,c)</p> | `true` | `a` |
 | `rosa-cli-version` | <p>Version of the ROSA CLI to use</p> | `true` | `latest` |
 | `openshift-version` | <p>Version of the OpenShift to install</p> | `true` | `4.18.5` |
 | `replicas` | <p>Number of replicas for the ROSA cluster (empty will fallback on default value of the module)</p> | `false` | `""` |
@@ -81,7 +81,7 @@ This action is a `composite` action.
     # Comma separated list of availability zones (letters only, e.g., a,b,c)
     #
     # Required: true
-    # Default: a,b,c
+    # Default: a
 
     rosa-cli-version:
     # Version of the ROSA CLI to use

--- a/.github/actions/aws-openshift-rosa-hcp-single-region-create/action.yml
+++ b/.github/actions/aws-openshift-rosa-hcp-single-region-create/action.yml
@@ -23,10 +23,11 @@ inputs:
     aws-region:
         description: AWS region where the ROSA cluster will be deployed
         required: true
+    # We're limiting the AZs to 1 within tests as each consumes 1 IP for NAT
     availability-zones:
         description: Comma separated list of availability zones (letters only, e.g., a,b,c)
         required: true
-        default: a,b,c
+        default: a
     rosa-cli-version:
         description: Version of the ROSA CLI to use
         required: true

--- a/.github/actions/aws-openshift-rosa-hcp-single-region-create/action.yml
+++ b/.github/actions/aws-openshift-rosa-hcp-single-region-create/action.yml
@@ -236,6 +236,7 @@ runs:
                 sed -i -e 's/\(machine_cidr_block\s*=\s*"\)[^"]*\("\)/\110.0.64.0\/20\2/' \
                        -e 's/\(service_cidr_block\s*=\s*"\)[^"]*\("\)/\110.0.80.0\/20\2/' \
                        -e 's/\(pod_cidr_block\s*=\s*"\)[^"]*\("\)/\110.0.96.0\/20\2/' \
+                       -e 's/\(host_prefix\s*=\s*"\)[^"]*\("\)/\125\2/' \
                        cluster.tf
               fi
 

--- a/.github/actions/aws-openshift-rosa-hcp-single-region-create/action.yml
+++ b/.github/actions/aws-openshift-rosa-hcp-single-region-create/action.yml
@@ -230,6 +230,15 @@ runs:
                      -e "s/\(rosa_cluster_zones\s*=\s*\)[^]]*\]/\1[$FULL_AZS]/" \
                      cluster.tf
 
+              if [[ "${{ inputs.availability-zones }}" == "a" ]]; then
+                # The VPC module of ROSA does a bad cidr calculation with single zones
+                echo "Patching cluster.tf for single AZ deployment"
+                sed -i -e 's/\(machine_cidr_block\s*=\s*"\)[^"]*\("\)/\110.0.64.0\/20\2/' \
+                       -e 's/\(service_cidr_block\s*=\s*"\)[^"]*\("\)/\110.0.80.0\/20\2/' \
+                       -e 's/\(pod_cidr_block\s*=\s*"\)[^"]*\("\)/\110.0.96.0\/20\2/' \
+                       cluster.tf
+              fi
+
               if [ -n "${{ inputs.replicas }}" ]; then
                 sed -i -e 's/\(replicas\s*=\s*\)[0-9]\+/\1${{ inputs.replicas }}/' cluster.tf
               else

--- a/aws/openshift/rosa-hcp-dual-region/terraform/clusters/cluster_region_1.tf
+++ b/aws/openshift/rosa-hcp-dual-region/terraform/clusters/cluster_region_1.tf
@@ -10,6 +10,8 @@ locals {
   rosa_cluster_1_machine_cidr_block = "10.0.0.0/18"
   rosa_cluster_1_service_cidr_block = "10.0.128.0/18"
   rosa_cluster_1_pod_cidr_block     = "10.0.64.0/18"
+
+  host_prefix = "23" # The host prefix is the number of bits used for the host portion of the IP address. A smaller number means more hosts per subnet, while a larger number means fewer hosts per subnet. The default value is 23.
 }
 
 module "rosa_cluster_1" {
@@ -28,6 +30,8 @@ module "rosa_cluster_1" {
   machine_cidr_block = local.rosa_cluster_1_machine_cidr_block
   service_cidr_block = local.rosa_cluster_1_service_cidr_block
   pod_cidr_block     = local.rosa_cluster_1_pod_cidr_block
+
+  host_prefix = local.host_prefix
 
   # admin access
   htpasswd_username = local.rosa_cluster_1_admin_username

--- a/aws/openshift/rosa-hcp-dual-region/terraform/clusters/cluster_region_2.tf
+++ b/aws/openshift/rosa-hcp-dual-region/terraform/clusters/cluster_region_2.tf
@@ -10,6 +10,8 @@ locals {
   rosa_cluster_2_machine_cidr_block = "10.1.0.0/18"
   rosa_cluster_2_service_cidr_block = "10.1.128.0/18"
   rosa_cluster_2_pod_cidr_block     = "10.1.64.0/18"
+
+  host_prefix = "23" # The host prefix is the number of bits used for the host portion of the IP address. A smaller number means more hosts per subnet, while a larger number means fewer hosts per subnet. The default value is 23.
 }
 
 module "rosa_cluster_2" {
@@ -28,6 +30,8 @@ module "rosa_cluster_2" {
   machine_cidr_block = local.rosa_cluster_2_machine_cidr_block
   service_cidr_block = local.rosa_cluster_2_service_cidr_block
   pod_cidr_block     = local.rosa_cluster_2_pod_cidr_block
+
+  host_prefix = local.host_prefix
 
   # admin access
   htpasswd_username = local.rosa_cluster_2_admin_username

--- a/aws/openshift/rosa-hcp-single-region/cluster.tf
+++ b/aws/openshift/rosa-hcp-single-region/cluster.tf
@@ -20,6 +20,8 @@ module "rosa_cluster" {
   service_cidr_block = "10.0.128.0/18"
   pod_cidr_block     = "10.0.64.0/18"
 
+  host_prefix = "23"
+
   # admin access
   htpasswd_username = local.rosa_admin_username
   htpasswd_password = local.rosa_admin_password


### PR DESCRIPTION
related to https://github.com/camunda/team-infrastructure-experience/issues/539

Keeping it separate as for ROSA there's no perfect solution except downscaling the AZs as the TF module of ROSA has a hard dependency on the AZs to use for scaling the NAT Gateways. 

So it's just a proposal.