### PR TITLE
fix: prevent multiple comments when label is already applied

### DIFF
--- a/.github/workflows/aws_common_procedure_s3_bucket.yml
+++ b/.github/workflows/aws_common_procedure_s3_bucket.yml
@@ -139,7 +139,7 @@ jobs:
             - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
             - name: Prevent other runs for renovate
-              # if: ${{ env.IS_RENOVATE_PR == 'true' }}
+              if: ${{ env.IS_RENOVATE_PR == 'true' }}
               env:
                   GH_TOKEN: ${{ github.token }}
               uses: ./.github/actions/internal-apply-skip-label


### PR DESCRIPTION
This PR prevents having multiple comments posted when the label has already been applied

Tested:
- 1rst run: https://github.com/camunda/camunda-deployment-references/actions/runs/14539470305/job/40794460771?pr=285
- 2nd run https://github.com/camunda/camunda-deployment-references/actions/runs/14539470305/job/40794506413