### PR TITLE
fix: empty matrix stable 8.6

### DIFF
--- a/.github/workflows/aws_openshift_rosa_hcp_single_region_tests.yml
+++ b/.github/workflows/aws_openshift_rosa_hcp_single_region_tests.yml
@@ -116,7 +116,6 @@ jobs:
                       --indent=0 --output-format json ${CI_MATRIX_FILE})"
                   fi
 
-                  platform_matrix="$(echo "$platform_matrix" | yq '.matrix' --indent=0 --output-format json)"
                   echo "${platform_matrix}" | jq
                   echo "platform-matrix=${platform_matrix}" > "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
backport of https://github.com/camunda/camunda-deployment-references/pull/289