### PR TITLE
chore: add release-duty and versioning to helm chart renovate

### DIFF
--- a/generic/kubernetes/single-region/procedure/chart-env.sh
+++ b/generic/kubernetes/single-region/procedure/chart-env.sh
@@ -4,3 +4,4 @@
 # renovate: datasource=helm depName=camunda-platform versioning=regex:^12(\.(?<minor>\d+))?(\.(?<patch>\d+))?$ registryUrl=https://helm.camunda.io
 export CAMUNDA_HELM_CHART_VERSION="0.0.0-snapshot-latest"
 # TODO: [release-duty] before the release, update this!
+# TODO: [release-duty] adjust renovate comment to bump the major version

--- a/generic/openshift/dual-region/procedure/chart-env.sh
+++ b/generic/openshift/dual-region/procedure/chart-env.sh
@@ -29,6 +29,7 @@ export AWS_ES_BUCKET_REGION=""
 
 # The Helm release name used for installing Camunda 8 in both Kubernetes clusters
 export HELM_RELEASE_NAME=camunda
-# renovate: datasource=helm depName=camunda-platform registryUrl=https://helm.camunda.io
+# renovate: datasource=helm depName=camunda-platform versioning=regex:^12(\.(?<minor>\d+))?(\.(?<patch>\d+))?$ registryUrl=https://helm.camunda.io
 export HELM_CHART_VERSION="0.0.0-snapshot-latest"
 # TODO: [release-duty] before the release, update this!
+# TODO: [release-duty] adjust renovate comment to bump the major version

--- a/generic/openshift/single-region/procedure/chart-env.sh
+++ b/generic/openshift/single-region/procedure/chart-env.sh
@@ -4,3 +4,4 @@
 # renovate: datasource=helm depName=camunda-platform versioning=regex:^12(\.(?<minor>\d+))?(\.(?<patch>\d+))?$ registryUrl=https://helm.camunda.io
 export CAMUNDA_HELM_CHART_VERSION="0.0.0-snapshot-latest"
 # TODO: [release-duty] before the release, update this!
+# TODO: [release-duty] adjust renovate comment to bump the major version


### PR DESCRIPTION
fixes https://github.com/camunda/camunda-deployment-references/pull/232

adding `versioning` will result in Renovate not processing it as `0.0.0....` != `12....` + added release-duty comment to update.

