### PR TITLE
chore: lowering maximal age of the cluster

### DIFF
--- a/.github/actions/aws-eks-cleanup-resources/README.md
+++ b/.github/actions/aws-eks-cleanup-resources/README.md
@@ -12,7 +12,7 @@ This GitHub Action automates the deletion of EKS resources using a shell script.
 | `s3-backend-bucket` | <p>Bucket containing the resources states</p> | `true` | `""` |
 | `s3-bucket-region` | <p>Region of the bucket containing the resources states, if not set, will fallback on AWS_REGION</p> | `false` | `""` |
 | `camunda-version` | <p>Camunda version to only clean up certain compatible versions.</p> | `false` | `""` |
-| `max-age-hours` | <p>Maximum age of resources in hours</p> | `false` | `20` |
+| `max-age-hours` | <p>Maximum age of resources in hours</p> | `false` | `12` |
 | `target` | <p>Specify an ID to destroy specific resources or "all" to destroy all resources</p> | `false` | `all` |
 | `temp-dir` | <p>Temporary directory prefix used for storing resource data during processing</p> | `false` | `./tmp/eks-cleanup/` |
 | `module-name` | <p>Name of the module to destroy (e.g., "eks-cluster", "aurora", "opensearch"), or "all" to destroy all modules</p> | `false` | `all` |
@@ -49,7 +49,7 @@ This action is a `composite` action.
     # Maximum age of resources in hours
     #
     # Required: false
-    # Default: 20
+    # Default: 12
 
     target:
     # Specify an ID to destroy specific resources or "all" to destroy all resources

--- a/.github/actions/aws-eks-cleanup-resources/action.yml
+++ b/.github/actions/aws-eks-cleanup-resources/action.yml
@@ -19,7 +19,7 @@ inputs:
 
     max-age-hours:
         description: Maximum age of resources in hours
-        default: '20'
+        default: '12'
 
     target:
         description: Specify an ID to destroy specific resources or "all" to destroy all resources

--- a/.github/actions/aws-kubernetes-eks-single-region-cleanup/README.md
+++ b/.github/actions/aws-kubernetes-eks-single-region-cleanup/README.md
@@ -12,7 +12,7 @@ This GitHub Action automates the deletion of aws/kubernetes/eks-single-region(-i
 | `tf-bucket` | <p>Bucket containing the clusters states</p> | `true` | `""` |
 | `tf-bucket-region` | <p>Region of the bucket containing the resources states, if not set, will fallback on AWS_REGION</p> | `false` | `""` |
 | `tf-bucket-key-prefix` | <p>Key prefix of the bucket containing the resources states. It must contain a / at the end e.g 'my-prefix/'.</p> | `false` | `""` |
-| `max-age-hours-cluster` | <p>Maximum age of clusters in hours</p> | `false` | `20` |
+| `max-age-hours-cluster` | <p>Maximum age of clusters in hours</p> | `false` | `12` |
 | `target` | <p>Specify an ID to destroy specific resources or "all" to destroy all resources</p> | `false` | `all` |
 
 
@@ -47,7 +47,7 @@ This action is a `composite` action.
     # Maximum age of clusters in hours
     #
     # Required: false
-    # Default: 20
+    # Default: 12
 
     target:
     # Specify an ID to destroy specific resources or "all" to destroy all resources

--- a/.github/actions/aws-kubernetes-eks-single-region-cleanup/action.yml
+++ b/.github/actions/aws-kubernetes-eks-single-region-cleanup/action.yml
@@ -18,7 +18,7 @@ inputs:
 
     max-age-hours-cluster:
         description: Maximum age of clusters in hours
-        default: '20'
+        default: '12'
 
     target:
         description: Specify an ID to destroy specific resources or "all" to destroy all resources

--- a/.github/actions/aws-openshift-rosa-hcp-dual-region-cleanup/README.md
+++ b/.github/actions/aws-openshift-rosa-hcp-dual-region-cleanup/README.md
@@ -12,7 +12,7 @@ This GitHub Action automates the deletion of aws/openshift/rosa-hcp-dual-region 
 | `tf-bucket` | <p>Bucket containing the clusters states</p> | `true` | `""` |
 | `tf-bucket-region` | <p>Region of the bucket containing the resources states, if not set, will fallback on AWS_REGION</p> | `false` | `""` |
 | `tf-bucket-key-prefix` | <p>Key prefix of the bucket containing the resources states. It must contain a / at the end e.g 'my-prefix/'.</p> | `false` | `""` |
-| `max-age-hours-cluster` | <p>Maximum age of clusters in hours</p> | `false` | `20` |
+| `max-age-hours-cluster` | <p>Maximum age of clusters in hours</p> | `false` | `12` |
 | `target` | <p>Specify an ID to destroy specific resources or "all" to destroy all resources</p> | `false` | `all` |
 | `rosa-cli-version` | <p>Version of the ROSA CLI to use</p> | `false` | `latest` |
 | `openshift-version` | <p>Version of the OpenShift to install</p> | `true` | `4.18.4` |
@@ -49,7 +49,7 @@ This action is a `composite` action.
     # Maximum age of clusters in hours
     #
     # Required: false
-    # Default: 20
+    # Default: 12
 
     target:
     # Specify an ID to destroy specific resources or "all" to destroy all resources

--- a/.github/actions/aws-openshift-rosa-hcp-dual-region-cleanup/action.yml
+++ b/.github/actions/aws-openshift-rosa-hcp-dual-region-cleanup/action.yml
@@ -18,7 +18,7 @@ inputs:
 
     max-age-hours-cluster:
         description: Maximum age of clusters in hours
-        default: '20'
+        default: '12'
 
     target:
         description: Specify an ID to destroy specific resources or "all" to destroy all resources

--- a/.github/actions/aws-openshift-rosa-hcp-single-region-cleanup/README.md
+++ b/.github/actions/aws-openshift-rosa-hcp-single-region-cleanup/README.md
@@ -12,7 +12,7 @@ This GitHub Action automates the deletion of aws/openshift/rosa-hcp-single-regio
 | `tf-bucket` | <p>Bucket containing the clusters states</p> | `true` | `""` |
 | `tf-bucket-region` | <p>Region of the bucket containing the resources states, if not set, will fallback on AWS_REGION</p> | `false` | `""` |
 | `tf-bucket-key-prefix` | <p>Key prefix of the bucket containing the resources states. It must contain a / at the end e.g 'my-prefix/'.</p> | `false` | `""` |
-| `max-age-hours-cluster` | <p>Maximum age of clusters in hours</p> | `false` | `20` |
+| `max-age-hours-cluster` | <p>Maximum age of clusters in hours</p> | `false` | `12` |
 | `target` | <p>Specify an ID to destroy specific resources or "all" to destroy all resources</p> | `false` | `all` |
 | `rosa-cli-version` | <p>Version of the ROSA CLI to use</p> | `false` | `latest` |
 | `openshift-version` | <p>Version of the OpenShift to install</p> | `true` | `4.18.5` |
@@ -50,7 +50,7 @@ This action is a `composite` action.
     # Maximum age of clusters in hours
     #
     # Required: false
-    # Default: 20
+    # Default: 12
 
     target:
     # Specify an ID to destroy specific resources or "all" to destroy all resources

--- a/.github/actions/aws-openshift-rosa-hcp-single-region-cleanup/action.yml
+++ b/.github/actions/aws-openshift-rosa-hcp-single-region-cleanup/action.yml
@@ -18,7 +18,7 @@ inputs:
 
     max-age-hours-cluster:
         description: Maximum age of clusters in hours
-        default: '20'
+        default: '12'
 
     target:
         description: Specify an ID to destroy specific resources or "all" to destroy all resources

--- a/.github/workflows/aws_modules_eks_rds_os_daily_cleanup.yml
+++ b/.github/workflows/aws_modules_eks_rds_os_daily_cleanup.yml
@@ -7,7 +7,7 @@ on:
             max_age_hours:
                 description: Maximum age of resources in hours
                 required: true
-                default: '20'
+                default: '12'
     pull_request:
         # the paths should be synced with ../labeler.yml
         paths:
@@ -28,7 +28,7 @@ concurrency:
 env:
     IS_SCHEDULE: ${{ contains(github.ref, 'refs/heads/schedules/') || github.event_name == 'schedule' && 'true' || 'false' }}
 
-    MAX_AGE_HOURS: ${{ github.event.inputs.max_age_hours || '20' }}
+    MAX_AGE_HOURS: ${{ github.event.inputs.max_age_hours || '12' }}
     AWS_PROFILE: infex
 
     # please keep those variables synced with tests.yml

--- a/.github/workflows/aws_openshift_rosa_hcp_dual_region_daily_cleanup.yml
+++ b/.github/workflows/aws_openshift_rosa_hcp_dual_region_daily_cleanup.yml
@@ -7,7 +7,7 @@ on:
             max_age_hours_cluster:
                 description: Maximum age of clusters in hours
                 required: true
-                default: '20'
+                default: '12'
     pull_request:
         paths:
             - .github/workflows/aws_openshift_rosa_hcp_dual_region_daily_cleanup.yml
@@ -30,7 +30,7 @@ concurrency:
 env:
     IS_SCHEDULE: ${{ contains(github.ref, 'refs/heads/schedules/') || github.event_name == 'schedule' && 'true' || 'false' }}
 
-    MAX_AGE_HOURS_CLUSTER: ${{ github.event.inputs.max_age_hours_cluster || '20' }}
+    MAX_AGE_HOURS_CLUSTER: ${{ github.event.inputs.max_age_hours_cluster || '12' }}
 
     # please keep those variables synced with aws_rosa_hcp_tests.yml
     AWS_PROFILE: infex

--- a/.github/workflows/aws_openshift_rosa_hcp_single_region_daily_cleanup.yml
+++ b/.github/workflows/aws_openshift_rosa_hcp_single_region_daily_cleanup.yml
@@ -7,7 +7,7 @@ on:
             max_age_hours_cluster:
                 description: Maximum age of clusters in hours
                 required: true
-                default: '20'
+                default: '12'
     pull_request:
         paths:
             - .github/workflows/aws_openshift_rosa_hcp_single_region_daily_cleanup.yml
@@ -30,7 +30,7 @@ concurrency:
 env:
     IS_SCHEDULE: ${{ contains(github.ref, 'refs/heads/schedules/') || github.event_name == 'schedule' && 'true' || 'false' }}
 
-    MAX_AGE_HOURS_CLUSTER: ${{ github.event.inputs.max_age_hours_cluster || '20' }}
+    MAX_AGE_HOURS_CLUSTER: ${{ github.event.inputs.max_age_hours_cluster || '12' }}
 
     # please keep those variables synced with aws_rosa_hcp_tests.yml
     AWS_PROFILE: infex


### PR DESCRIPTION
This PR addresses the issue of the max age of the cluster is leading to a never criteria-matching destruction due to the script updating the latest age of the cluster (example:
https://github.com/camunda/camunda-deployment-references/actions/runs/14565448154/job/40854025348)

By reducing it from 20 hours to 12 hours, remaining clusters will be cleaned-up.