### PR TITLE
fix(aws): sg descriptions were not getting applied

### DIFF
--- a/aws/modules/eks-cluster/vpc.tf
+++ b/aws/modules/eks-cluster/vpc.tf
@@ -90,12 +90,20 @@ module "vpc" {
   default_security_group_ingress = [
     {
       description = "${local.vpc_name} default SG Ingress"
+      from_port   = 0
+      to_port     = 0
+      protocol    = "-1"
+      self        = true
     }
   ]
 
   default_security_group_egress = [
     {
       description = "${local.vpc_name} default SG Egress"
+      from_port   = 0
+      to_port     = 0
+      protocol    = "-1"
+      cidr_blocks = ["0.0.0.0/0"]
     }
   ]
 }

--- a/aws/modules/eks-cluster/vpc.tf
+++ b/aws/modules/eks-cluster/vpc.tf
@@ -103,7 +103,7 @@ module "vpc" {
       from_port   = 0
       to_port     = 0
       protocol    = "-1"
-      cidr_blocks = ["0.0.0.0/0"]
+      cidr_blocks = "0.0.0.0/0"
     }
   ]
 }


### PR DESCRIPTION
Trivy is still throwing errors due to no description on the SGs, it seems that all required parameters need to be defined in order for the description to apply properly.

Failing pre-commit due to trivy in c8-multi-region referencing this repo:
https://github.com/camunda/c8-multi-region/actions/runs/14589817334/job/40922289488?pr=567