### PR TITLE
fix: tests don't select the proper key of the matrix

### DIFF
--- a/.github/workflows/aws_kubernetes_eks_single_region_tests.yml
+++ b/.github/workflows/aws_kubernetes_eks_single_region_tests.yml
@@ -136,14 +136,14 @@ jobs:
                     platform_matrix="$(yq '.matrix' --indent=0 --output-format json ${CI_MATRIX_FILE})"
                   else
                     # shellcheck disable=SC2086
-                    platform_matrix="$(yq '.matrix |= (.scenario |= map(select(.schedule_only == null or .schedule_only == false)))' \
+                    platform_matrix="$(yq '(.matrix |= (.scenario |= map(select(.schedule_only == null or .schedule_only == false))) | .matrix)' \
                       --indent=0 --output-format json ${CI_MATRIX_FILE})"
                   fi
 
                   if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
                     echo "Filtering based on supplied ref-arch ${{ inputs.ref-arch }}"
                     # shellcheck disable=SC2086
-                    platform_matrix="$(yq '.matrix |= (.scenario |= map(select(.name == env(ref_arch))))' \
+                    platform_matrix="$(yq '(.matrix |= (.scenario |= map(select(.name == env(ref_arch)))) | .matrix)' \
                       --indent=0 --output-format json ${CI_MATRIX_FILE})"
                   fi
 

--- a/.github/workflows/aws_openshift_rosa_hcp_dual_region_tests.yml
+++ b/.github/workflows/aws_openshift_rosa_hcp_dual_region_tests.yml
@@ -123,7 +123,7 @@ jobs:
                     platform_matrix="$(yq '.matrix' --indent=0 --output-format json ${CI_MATRIX_FILE})"
                   else
                     # shellcheck disable=SC2086
-                    platform_matrix="$(yq '.matrix |= (.distro |= map(select(.schedule_only == null or .schedule_only == false)))' \
+                    platform_matrix="$(yq '(.matrix |= (.distro |= map(select(.schedule_only == null or .schedule_only == false))) | .matrix)' \
                       --indent=0 --output-format json ${CI_MATRIX_FILE})"
                   fi
 

--- a/.github/workflows/aws_openshift_rosa_hcp_single_region_tests.yml
+++ b/.github/workflows/aws_openshift_rosa_hcp_single_region_tests.yml
@@ -127,8 +127,8 @@ jobs:
                     platform_matrix="$(yq '.matrix' --indent=0 --output-format json ${CI_MATRIX_FILE})"
                   else
                     # shellcheck disable=SC2086
-                    platform_matrix="$(yq '.matrix |= (.distro |= map(select(.schedule_only == null or .schedule_only == false)))' \
-                      --indent=0 --output-format json ${CI_MATRIX_FILE})"
+                    platform_matrix="$(yq '(.matrix |= (.distro |= map(select(.schedule_only == null or .schedule_only == false)))) | .matrix)' \
+                      --indent=0 --output-format json "${CI_MATRIX_FILE}")"
                   fi
 
                   echo "${platform_matrix}" | jq


### PR DESCRIPTION
This PR fixes the selection of the matrix, currently the matrix is part of the output, which fails the matrix to be built.