### PR TITLE
fix: backport to 8.6 matrix definition fix

### DIFF
--- a/.github/workflows/aws_openshift_rosa_hcp_single_region_tests.yml
+++ b/.github/workflows/aws_openshift_rosa_hcp_single_region_tests.yml
@@ -112,7 +112,7 @@ jobs:
                     platform_matrix="$(yq '.matrix' --indent=0 --output-format json ${CI_MATRIX_FILE})"
                   else
                     # shellcheck disable=SC2086
-                    platform_matrix="$(yq '.matrix |= (.distro |= map(select(.schedule_only == null or .schedule_only == false)))' \
+                    platform_matrix="$(yq '(.matrix |= (.distro |= map(select(.schedule_only == null or .schedule_only == false)))) | .matrix' \
                       --indent=0 --output-format json ${CI_MATRIX_FILE})"
                   fi
 


### PR DESCRIPTION
backport of https://github.com/camunda/camunda-deployment-references/pull/318 + https://github.com/camunda/camunda-deployment-references/pull/317