### PR TITLE
fix: is schedule branch detection

### DIFF
--- a/.github/workflows/aws_common_procedure_s3_bucket.yml
+++ b/.github/workflows/aws_common_procedure_s3_bucket.yml
@@ -20,7 +20,7 @@ concurrency:
     cancel-in-progress: true
 
 env:
-    IS_SCHEDULE: ${{ contains(github.ref, 'refs/heads/schedules/') || github.event_name == 'schedule' && 'true' || 'false' }}
+    IS_SCHEDULE: ${{ contains(github.head_ref, 'schedules/') || github.event_name == 'schedule' && 'true' || 'false' }}
     IS_RENOVATE_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.user.login == 'renovate[bot]' }}
 
     AWS_PROFILE: infraex

--- a/.github/workflows/aws_compute_ec2_single_region_golden.yml
+++ b/.github/workflows/aws_compute_ec2_single_region_golden.yml
@@ -16,7 +16,7 @@ concurrency:
     cancel-in-progress: true
 
 env:
-    IS_SCHEDULE: ${{ contains(github.ref, 'refs/heads/schedules/') || github.event_name == 'schedule' && 'true' || 'false' }}
+    IS_SCHEDULE: ${{ contains(github.head_ref, 'schedules/') || github.event_name == 'schedule' && 'true' || 'false' }}
 
     AWS_PROFILE: infex
     AWS_REGION: eu-west-2

--- a/.github/workflows/aws_compute_ec2_single_region_tests.yml
+++ b/.github/workflows/aws_compute_ec2_single_region_tests.yml
@@ -24,7 +24,7 @@ concurrency:
     cancel-in-progress: ${{ !contains('renovate[bot]', github.actor) }}
 
 env:
-    IS_SCHEDULE: ${{ contains(github.ref, 'refs/heads/schedules/') || github.event_name == 'schedule' && 'true' || 'false' }}
+    IS_SCHEDULE: ${{ contains(github.head_ref, 'schedules/') || github.event_name == 'schedule' && 'true' || 'false' }}
     IS_RENOVATE_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.user.login == 'renovate[bot]' }}
 
     AWS_PROFILE: infex

--- a/.github/workflows/aws_kubernetes_eks_single_region_golden.yml
+++ b/.github/workflows/aws_kubernetes_eks_single_region_golden.yml
@@ -20,7 +20,7 @@ concurrency:
     cancel-in-progress: true
 
 env:
-    IS_SCHEDULE: ${{ contains(github.ref, 'refs/heads/schedules/') || github.event_name == 'schedule' && 'true' || 'false' }}
+    IS_SCHEDULE: ${{ contains(github.head_ref, 'schedules/') || github.event_name == 'schedule' && 'true' || 'false' }}
 
     # keep this synced with other workflows
     AWS_PROFILE: infraex

--- a/.github/workflows/aws_kubernetes_eks_single_region_tests.yml
+++ b/.github/workflows/aws_kubernetes_eks_single_region_tests.yml
@@ -48,7 +48,7 @@ concurrency:
     cancel-in-progress: ${{ !contains('renovate[bot]', github.actor) }}
 
 env:
-    IS_SCHEDULE: ${{ contains(github.ref, 'refs/heads/schedules/') || github.event_name == 'schedule' && 'true' || 'false' }}
+    IS_SCHEDULE: ${{ contains(github.head_ref, 'schedules/') || github.event_name == 'schedule' && 'true' || 'false' }}
     IS_RENOVATE_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.user.login == 'renovate[bot]' }}
 
     AWS_PROFILE: infraex

--- a/.github/workflows/aws_modules_eks_rds_os_create_destruct_tests.yml
+++ b/.github/workflows/aws_modules_eks_rds_os_create_destruct_tests.yml
@@ -63,7 +63,7 @@ concurrency:
     cancel-in-progress: ${{ !contains('renovate[bot]', github.actor) }}
 
 env:
-    IS_SCHEDULE: ${{ contains(github.ref, 'refs/heads/schedules/') || github.event_name == 'schedule' && 'true' || 'false' }}
+    IS_SCHEDULE: ${{ contains(github.head_ref, 'schedules/') || github.event_name == 'schedule' && 'true' || 'false' }}
     IS_RENOVATE_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.user.login == 'renovate[bot]' }}
 
     AWS_PROFILE: infex

--- a/.github/workflows/aws_modules_eks_rds_os_daily_cleanup.yml
+++ b/.github/workflows/aws_modules_eks_rds_os_daily_cleanup.yml
@@ -26,7 +26,7 @@ concurrency:
     cancel-in-progress: ${{ !contains('renovate[bot]', github.actor) }}
 
 env:
-    IS_SCHEDULE: ${{ contains(github.ref, 'refs/heads/schedules/') || github.event_name == 'schedule' && 'true' || 'false' }}
+    IS_SCHEDULE: ${{ contains(github.head_ref, 'schedules/') || github.event_name == 'schedule' && 'true' || 'false' }}
 
     MAX_AGE_HOURS: ${{ github.event.inputs.max_age_hours || '12' }}
     AWS_PROFILE: infex

--- a/.github/workflows/aws_modules_eks_rds_os_tests.yml
+++ b/.github/workflows/aws_modules_eks_rds_os_tests.yml
@@ -26,7 +26,7 @@ concurrency:
     cancel-in-progress: ${{ !contains('renovate[bot]', github.actor) }}
 
 env:
-    IS_SCHEDULE: ${{ contains(github.ref, 'refs/heads/schedules/') || github.event_name == 'schedule' && 'true' || 'false' }}
+    IS_SCHEDULE: ${{ contains(github.head_ref, 'schedules/') || github.event_name == 'schedule' && 'true' || 'false' }}
     IS_RENOVATE_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.user.login == 'renovate[bot]' }}
 
     # please keep those variables synced with daily-cleanup.yml

--- a/.github/workflows/aws_openshift_rosa_hcp_dual_region_daily_cleanup.yml
+++ b/.github/workflows/aws_openshift_rosa_hcp_dual_region_daily_cleanup.yml
@@ -28,7 +28,7 @@ concurrency:
     cancel-in-progress: ${{ !contains('renovate[bot]', github.actor) }}
 
 env:
-    IS_SCHEDULE: ${{ contains(github.ref, 'refs/heads/schedules/') || github.event_name == 'schedule' && 'true' || 'false' }}
+    IS_SCHEDULE: ${{ contains(github.head_ref, 'schedules/') || github.event_name == 'schedule' && 'true' || 'false' }}
 
     MAX_AGE_HOURS_CLUSTER: ${{ github.event.inputs.max_age_hours_cluster || '12' }}
 

--- a/.github/workflows/aws_openshift_rosa_hcp_dual_region_golden.yml
+++ b/.github/workflows/aws_openshift_rosa_hcp_dual_region_golden.yml
@@ -17,7 +17,7 @@ concurrency:
     cancel-in-progress: true
 
 env:
-    IS_SCHEDULE: ${{ contains(github.ref, 'refs/heads/schedules/') || github.event_name == 'schedule' && 'true' || 'false' }}
+    IS_SCHEDULE: ${{ contains(github.head_ref, 'schedules/') || github.event_name == 'schedule' && 'true' || 'false' }}
 
     # keep this synced with other workflows
     AWS_PROFILE: infex

--- a/.github/workflows/aws_openshift_rosa_hcp_dual_region_tests.yml
+++ b/.github/workflows/aws_openshift_rosa_hcp_dual_region_tests.yml
@@ -41,7 +41,7 @@ concurrency:
     cancel-in-progress: ${{ !contains('renovate[bot]', github.actor) }}
 
 env:
-    IS_SCHEDULE: ${{ contains(github.ref, 'refs/heads/schedules/') || github.event_name == 'schedule' && 'true' || 'false' }}
+    IS_SCHEDULE: ${{ contains(github.head_ref, 'schedules/') || github.event_name == 'schedule' && 'true' || 'false' }}
     IS_RENOVATE_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.user.login == 'renovate[bot]' }}
 
     AWS_PROFILE: infex

--- a/.github/workflows/aws_openshift_rosa_hcp_single_region_daily_cleanup.yml
+++ b/.github/workflows/aws_openshift_rosa_hcp_single_region_daily_cleanup.yml
@@ -28,7 +28,7 @@ concurrency:
     cancel-in-progress: ${{ !contains('renovate[bot]', github.actor) }}
 
 env:
-    IS_SCHEDULE: ${{ contains(github.ref, 'refs/heads/schedules/') || github.event_name == 'schedule' && 'true' || 'false' }}
+    IS_SCHEDULE: ${{ contains(github.head_ref, 'schedules/') || github.event_name == 'schedule' && 'true' || 'false' }}
 
     MAX_AGE_HOURS_CLUSTER: ${{ github.event.inputs.max_age_hours_cluster || '12' }}
 

--- a/.github/workflows/aws_openshift_rosa_hcp_single_region_golden.yml
+++ b/.github/workflows/aws_openshift_rosa_hcp_single_region_golden.yml
@@ -17,7 +17,7 @@ concurrency:
     cancel-in-progress: true
 
 env:
-    IS_SCHEDULE: ${{ contains(github.ref, 'refs/heads/schedules/') || github.event_name == 'schedule' && 'true' || 'false' }}
+    IS_SCHEDULE: ${{ contains(github.head_ref, 'schedules/') || github.event_name == 'schedule' && 'true' || 'false' }}
 
     # keep this synced with other workflows
     AWS_PROFILE: infex

--- a/.github/workflows/aws_openshift_rosa_hcp_single_region_tests.yml
+++ b/.github/workflows/aws_openshift_rosa_hcp_single_region_tests.yml
@@ -42,7 +42,7 @@ concurrency:
     cancel-in-progress: ${{ !contains('renovate[bot]', github.actor) }}
 
 env:
-    IS_SCHEDULE: ${{ contains(github.ref, 'refs/heads/schedules/') || github.event_name == 'schedule' && 'true' || 'false' }}
+    IS_SCHEDULE: ${{ contains(github.head_ref, 'schedules/') || github.event_name == 'schedule' && 'true' || 'false' }}
     IS_RENOVATE_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.user.login == 'renovate[bot]' }}
 
     AWS_PROFILE: infex

--- a/.github/workflows/internal_global_links.yml
+++ b/.github/workflows/internal_global_links.yml
@@ -11,7 +11,7 @@ on:
             - .github/workflows/internal_global_links.yml
 
 env:
-    IS_SCHEDULE: ${{ contains(github.ref, 'refs/heads/schedules/') || github.event_name == 'schedule' && 'true' || 'false' }}
+    IS_SCHEDULE: ${{ contains(github.head_ref, 'schedules/') || github.event_name == 'schedule' && 'true' || 'false' }}
 
 jobs:
     lint:


### PR DESCRIPTION
This PR fixes the detection of a schedule as github uses a different branch name in PRs, it was not working as expected

See https://stackoverflow.com/questions/60300169/how-to-get-branch-name-on-github-action


Tested here: 
- https://github.com/camunda/camunda-deployment-references/pull/324
- https://productionresultssa18.blob.core.windows.net/actions-results/b12b59e4-7305-44fd-8f62-67298a5930bc/workflow-job-run-97177f48-1003-5b21-734c-976eeef6ed97/logs/job/job-logs.txt?rsct=text%2Fplain&se=2025-04-23T10%3A44%3A32Z&sig=GCf8qIPGiEJGJeMCSZCH0OqQ%2BGIQkXDZsBy00bWjjEY%3D&ske=2025-04-23T21%3A20%3A08Z&skoid=ca7593d4-ee42-46cd-af88-8b886a2f84eb&sks=b&skt=2025-04-23T09%3A20%3A08Z&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skv=2025-01-05&sp=r&spr=https&sr=b&st=2025-04-23T10%3A34%3A27Z&sv=2025-01-05

