### PR TITLE
fix: add TF_STATE_BUCKET_REGION value for the s3 bucket

### DIFF
--- a/.github/workflows/aws_modules_eks_rds_os_tests.yml
+++ b/.github/workflows/aws_modules_eks_rds_os_tests.yml
@@ -158,10 +158,12 @@ jobs:
               run: |
                   set -euo pipefail
 
-                  export TESTS_CLUSTER_ID="${{ needs.configure-tests.outputs.cluster_id }}"
-                  export TESTS_CLUSTER_REGION="${{ env.AWS_REGION }}"
-                  export TESTS_TF_BINARY_NAME="${{ env.TESTS_TF_BINARY_NAME }}"
                   just aws-tf-modules-test ${{ matrix.test_function }} "--junitfile ${{ matrix.test_function }}_unit-tests.xml"
+              env:
+                  TF_STATE_BUCKET_REGION: ${{ env.S3_BUCKET_REGION }}
+                  TESTS_CLUSTER_REGION: ${{ env.AWS_REGION }}
+                  TESTS_TF_BINARY_NAME: ${{ env.TESTS_TF_BINARY_NAME }}
+                  TESTS_CLUSTER_ID: ${{ needs.configure-tests.outputs.cluster_id }}
 
             # this is a workaround for test report not working as expected due to https://github.com/test-summary/action/issues/5
             - name: Filter logger.go from the test report (too large)


### PR DESCRIPTION
currently it was default to a different region (eu-west-2), while the suggested bucket is `eu-central-1`.
Resulting in the cleanup not kicking in since it was looking in the wrong bucket. 
And scheduled cleanup wouldn't find the resources either, till ultimately nightly cleanup would remove the resources.

- Added the env variable to set the bucket region correctly.

Should definitely help also with renovate as those resources would be blocking a couple of IPs as well till nightly nuke.

Will afterwards port to 8.7.