### PR TITLE
fix: add name to the logs

### DIFF
--- a/.github/actions/aws-kubernetes-eks-single-region-cleanup/action.yml
+++ b/.github/actions/aws-kubernetes-eks-single-region-cleanup/action.yml
@@ -65,6 +65,6 @@ runs:
           if: always()
           uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
           with:
-              name: logs-${{ github.action }}-${{ github.job }}
+              name: logs-${{ github.action }}-${{ github.job }}-${{ inputs.target }}
               path: ./logs/
               retention-days: 7

--- a/.github/actions/aws-openshift-rosa-hcp-dual-region-cleanup/action.yml
+++ b/.github/actions/aws-openshift-rosa-hcp-dual-region-cleanup/action.yml
@@ -90,6 +90,6 @@ runs:
           if: always()
           uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
           with:
-              name: logs-${{ github.action }}-${{ github.job }}
+              name: logs-${{ github.action }}-${{ github.job }}-${{ inputs.target }}
               path: ./logs/
               retention-days: 7

--- a/.github/actions/aws-openshift-rosa-hcp-single-region-cleanup/action.yml
+++ b/.github/actions/aws-openshift-rosa-hcp-single-region-cleanup/action.yml
@@ -106,6 +106,6 @@ runs:
           if: always()
           uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
           with:
-              name: logs-${{ github.action }}-${{ github.job }}
+              name: logs-${{ github.action }}-${{ github.job }}-${{ inputs.target }}
               path: ./logs/
               retention-days: 7


### PR DESCRIPTION
This PR prevents duplicates artifacts names like
https://github.com/camunda/camunda-deployment-references/actions/runs/14621505454/job/41026498488?pr=250

This will **not** be backported to 8.7 and 8.6 as the parallel deletion is not implemented for those