### PR TITLE
fix(tests): cleanup of dual-region clusters with name

### DIFF
--- a/.github/actions/aws-openshift-rosa-hcp-dual-region-cleanup/scripts/destroy-clusters.sh
+++ b/.github/actions/aws-openshift-rosa-hcp-dual-region-cleanup/scripts/destroy-clusters.sh
@@ -197,7 +197,7 @@ fi
 if [ "$ID_OR_ALL" == "all" ]; then
   groups=$(echo "$all_objects" | awk '{print $2}' | sed -n 's#^tfstate-\(.*\)/$#\1#p')
 else
-  groups=$(echo "$all_objects" | awk '{print $2}' | grep "tfstate-$ID_OR_ALL/" | sed -n 's#^tfstate-\(.*\)/$#\1#p')
+  groups=$(echo "$all_objects" | awk '{print $2}' | grep "tfstate-$ID_OR_ALL-1-oOo-$ID_OR_ALL-2/" | sed -n 's#^tfstate-\(.*\)/$#\1#p')
 fi
 
 if [ -z "$groups" ]; then

--- a/.github/workflows/aws_openshift_rosa_hcp_dual_region_tests.yml
+++ b/.github/workflows/aws_openshift_rosa_hcp_dual_region_tests.yml
@@ -621,7 +621,7 @@ jobs:
                   tf-bucket-region: ${{ env.S3_BUCKET_REGION }}
                   max-age-hours-cluster: 0
                   target: ${{ matrix.distro.clusterName }}
-                  tf-bucket-key-prefix: ${{ steps.camunda-version.outputs.CAMUNDA_VERSION }}/
+                  tf-bucket-key-prefix: ${{ env.S3_BACKEND_BUCKET_PREFIX }}${{ steps.camunda-version.outputs.CAMUNDA_VERSION }}/
 
     report-success:
         name: Report success


### PR DESCRIPTION
When a dual region cluster of OpenShift is deleted using the identifier, the deletion silently  fails due to improper implementation of the prefix selection.

I've tested it locally and it works now, this also explain why we had so many dual region clusters not deleted...

The following run https://github.com/camunda/camunda-deployment-references/actions/runs/14627153205/job/41041386992?pr=250 contains the fix, if the cluster is deleted, it means it's working