### PR TITLE
fix: eks cluster cleanup, typo

### DIFF
--- a/.github/actions/aws-kubernetes-eks-single-region-cleanup/scripts/destroy-clusters.sh
+++ b/.github/actions/aws-kubernetes-eks-single-region-cleanup/scripts/destroy-clusters.sh
@@ -122,7 +122,7 @@ if [ "$ID_OR_ALL" == "all" ]; then
 else
   clusters=$(echo "$all_objects" | awk '{print $NF}' | grep "tfstate-$ID_OR_ALL/" | sed -n 's#.*/tfstate-\([^/]*\)/.*#\1#p')
 
-  if [ -z "$resources" ] && [ "$FAIL_ON_NOT_FOUND" = true ]; then
+  if [ -z "$clusters" ] && [ "$FAIL_ON_NOT_FOUND" = true ]; then
     echo "Error: No object found for ID '$ID_OR_ALL'"
     exit 1
   fi


### PR DESCRIPTION
small typo, we call it `resources`, `groups`, and `clusters` 😅 , depending on the context.
Didn't see it in the first review.
Tried it out locally, works now again correctly.