### PR TITLE
chore: add eks focused cleanup job

### DIFF
--- a/.github/actions/aws-kubernetes-eks-single-region-cleanup/action.yml
+++ b/.github/actions/aws-kubernetes-eks-single-region-cleanup/action.yml
@@ -66,10 +66,19 @@ runs:
                 ${{ inputs.max-age-hours-cluster }} ${{ inputs.target }} ${{ inputs.tf-bucket-key-prefix }} \
                 $([[ "${{ inputs.fail-on-not-found }}" == "true" ]] && echo "--fail-on-not-found")
 
+        # Required for matrix jobs
+        - name: Convert key prefix into slug
+          id: key-prefix-slug
+          shell: bash
+          run: |
+              set -euo pipefail
+              SLUG=$(echo "${{ inputs.tf-bucket-key-prefix }}" | tr '/' '-' | tr -d '[:space:]' | tr '[:upper:]' '[:lower:]')
+              echo "PREFIX_SLUG=${SLUG::-1}" | tee -a "$GITHUB_OUTPUT"
+
         - name: Upload cleanup logs
           if: always()
           uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
           with:
-              name: logs-${{ github.action }}-${{ github.job }}-${{ inputs.target }}
+              name: logs-${{ github.action }}-${{ github.job }}-${{ inputs.target }}-${{ steps.key-prefix-slug.outputs.PREFIX_SLUG }}
               path: ./logs/
               retention-days: 7

--- a/.github/workflows-config/workflow-scheduler.yml
+++ b/.github/workflows-config/workflow-scheduler.yml
@@ -39,3 +39,4 @@ schedules:
           - .github/workflows/aws_openshift_rosa_hcp_single_region_daily_cleanup.yml
           - .github/workflows/aws_openshift_rosa_hcp_dual_region_daily_cleanup.yml
           - .github/workflows/aws_modules_eks_rds_os_daily_cleanup.yml
+          - .github/workflows/aws_kubernetes_eks_single_region_cleanup.yml

--- a/.github/workflows/aws_kubernetes_eks_single_region_cleanup.yml
+++ b/.github/workflows/aws_kubernetes_eks_single_region_cleanup.yml
@@ -1,0 +1,139 @@
+---
+name: Tests - Daily Cleanup - AWS Kubernetes EKS Single Region (IRSA)
+
+on:
+    push:
+    workflow_dispatch:
+        inputs:
+            max_age_hours_cluster:
+                description: Maximum age of clusters in hours
+                required: true
+                default: '12'
+    pull_request:
+        paths:
+            - .github/workflows/aws_kubernetes_eks_single_region_cleanup.yml
+            - .tool-versions
+            - aws/kubernetes/eks-single-region*/**
+            - '!aws/kubernetes/eks-single-region/test/golden/**'
+            - '!aws/kubernetes/eks-single-region-irsa/test/golden/**'
+            - .github/actions/aws-kubernetes-eks-single-region-cleanup/**
+            - .github/actions/aws-configure-cli/**
+
+    schedule:
+        - cron: 0 1 * * * # At 01:00 everyday.
+
+# limit to a single execution per actor of this workflow
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    # in case of renovate we don't cancel the previous run, so it can finish it
+    # otherwise weekly renovate PRs with tf docs updates result in broken clusters
+    cancel-in-progress: ${{ !contains('renovate[bot]', github.actor) }}
+
+env:
+    IS_SCHEDULE: ${{ contains(github.head_ref, 'schedules/') || github.event_name == 'schedule' && 'true' || 'false' }}
+
+    MAX_AGE_HOURS_CLUSTER: ${{ github.event.inputs.max_age_hours_cluster || '12' }}
+
+    # please keep those variables synced with aws_kubernetes_eks_single_region_tests.yml
+    AWS_PROFILE: infex
+    S3_BACKEND_BUCKET: tests-ra-aws-rosa-hcp-tf-state-eu-central-1
+    S3_BUCKET_REGION: eu-central-1
+    AWS_REGION: eu-west-2
+
+jobs:
+    triage:
+        runs-on: ubuntu-latest
+        outputs:
+            should_skip: ${{ steps.skip_check.outputs.should_skip }}
+        steps:
+            - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+            - name: Check labels
+              id: skip_check
+              uses: ./.github/actions/internal-triage-skip
+
+    cleanup-clusters:
+        needs:
+            - triage
+        if: needs.triage.outputs.should_skip == 'false'
+        strategy:
+            fail-fast: false
+            matrix:
+                scenario:
+                    - name: eks-single-region
+                    - name: eks-single-region-irsa
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+              with:
+                  ref: ${{ github.ref }}
+                  fetch-depth: 0
+
+            - name: Install asdf tools with cache
+              uses: camunda/infraex-common-config/./.github/actions/asdf-install-tooling@239465f4beb942805dd11ed602a85fd13bd48c03 # 1.3.5
+
+            - name: Use repo .tool-version as global version
+              run: cp .tool-versions ~/.tool-versions
+
+            - name: Set current Camunda version
+              id: camunda-version
+              run: |
+                  set -euo pipefail
+
+                  CAMUNDA_VERSION=$(cat .camunda-version)
+                  echo "CAMUNDA_VERSION=$CAMUNDA_VERSION" | tee -a "$GITHUB_OUTPUT"
+
+            - name: Configure AWS CLI
+              uses: ./.github/actions/aws-configure-cli
+              with:
+                  vault-addr: ${{ secrets.VAULT_ADDR }}
+                  vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+                  vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+                  aws-profile: ${{ env.AWS_PROFILE }}
+                  aws-region: ${{ env.AWS_REGION }}
+
+            - name: Export S3_BACKEND_BUCKET based on matrix
+              id: s3_prefix
+              run: |
+                  set -euo pipefail
+                  echo "S3_BACKEND_BUCKET_PREFIX=aws/kubernetes/${{ matrix.scenario.name }}/" | tee -a "$GITHUB_OUTPUT"
+
+            - name: Delete clusters
+              id: delete_clusters
+              timeout-minutes: 125
+              uses: ./.github/actions/aws-kubernetes-eks-single-region-cleanup
+              with:
+                  tf-bucket: ${{ env.S3_BACKEND_BUCKET }}
+                  tf-bucket-region: ${{ env.S3_BUCKET_REGION }}
+                  max-age-hours-cluster: ${{ env.MAX_AGE_HOURS_CLUSTER }}
+                  tf-bucket-key-prefix: ${{ steps.s3_prefix.outputs.S3_BACKEND_BUCKET_PREFIX }}${{ steps.camunda-version.outputs.CAMUNDA_VERSION }}/
+
+            # There are cases where the deletion of resources fails due to dependencies.
+            - name: Retry delete clusters (schedule only)
+              id: retry_delete_clusters
+              if: failure() && steps.delete_clusters.outcome == 'failure' && env.IS_SCHEDULE == 'true'
+              timeout-minutes: 125
+              uses: ./.github/actions/aws-kubernetes-eks-single-region-cleanup
+              env:
+                  RETRY_DESTROY: 'true' # trigger cloud nuke
+              with:
+                  tf-bucket: ${{ env.S3_BACKEND_BUCKET }}
+                  tf-bucket-region: ${{ env.S3_BUCKET_REGION }}
+                  max-age-hours-cluster: 0 # the previous step alters the age and resets it to 0
+                  tf-bucket-key-prefix: ${{ steps.s3_prefix.outputs.S3_BACKEND_BUCKET_PREFIX }}${{ steps.camunda-version.outputs.CAMUNDA_VERSION }}/
+
+    report-failure:
+        name: Report failures
+        if: failure()
+        runs-on: ubuntu-latest
+        needs:
+            - cleanup-clusters
+        steps:
+            - name: Notify in Slack in case of failure
+              id: slack-notification
+              if: ${{ env.IS_SCHEDULE == 'true' }}
+              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@239465f4beb942805dd11ed602a85fd13bd48c03 # 1.3.5
+              with:
+                  vault_addr: ${{ secrets.VAULT_ADDR }}
+                  vault_role_id: ${{ secrets.VAULT_ROLE_ID }}
+                  vault_secret_id: ${{ secrets.VAULT_SECRET_ID }}

--- a/.github/workflows/aws_kubernetes_eks_single_region_cleanup.yml
+++ b/.github/workflows/aws_kubernetes_eks_single_region_cleanup.yml
@@ -2,7 +2,6 @@
 name: Tests - Daily Cleanup - AWS Kubernetes EKS Single Region (IRSA)
 
 on:
-    push:
     workflow_dispatch:
         inputs:
             max_age_hours_cluster:


### PR DESCRIPTION
Before it was cleaned up by the daily cleanup.
This is focused on the EKS ref arch and was missing so far.
Also makes it easier to trigger manually afterwards, similar to our other cleanups.
Will afterwards be backported to 8.7.

For simplicity, did not do a dynamic matrix but just cleanup all.

Example execution:
https://github.com/camunda/camunda-deployment-references/actions/runs/14666718799