### PR TITLE
fix: skip single in dual-region zeebe check

### DIFF
--- a/.github/actions/internal-camunda-chart-tests/action.yml
+++ b/.github/actions/internal-camunda-chart-tests/action.yml
@@ -292,7 +292,8 @@ runs:
 
               PORT_FORWARD_PIDS=()
 
-              if [[ "$DOMAIN_NAME" == "" ]]; then
+              # Dual-Region includes the portforwarding itself, therefore skipping it here
+              if [[ -z "$DOMAIN_NAME" && -z "$CLUSTER_2_NAME" ]]; then
                 # Without domain:
                 source ./generic/kubernetes/single-region/procedure/export-verify-zeebe-local.sh
 


### PR DESCRIPTION
fixes an issue that in case of dual-region openshift triggered both port-forwardings and failed.