### PR TITLE
fix(tests): parallel tests matrix

### DIFF
--- a/.github/workflows/aws_openshift_rosa_hcp_single_region_tests.yml
+++ b/.github/workflows/aws_openshift_rosa_hcp_single_region_tests.yml
@@ -44,8 +44,7 @@ concurrency:
 env:
     IS_SCHEDULE: ${{ contains(github.head_ref, 'schedules/') || github.event_name == 'schedule' && 'true' || 'false' }}
 
-    IS_RENOVATE_PR: true
-    # IS_RENOVATE_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.user.login == 'renovate[bot]' }}
+    IS_RENOVATE_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.user.login == 'renovate[bot]' }}
 
     AWS_PROFILE: infex
     AWS_REGION: eu-west-2


### PR DESCRIPTION
This PR fixes the single region tests of OpenShift that are currently cancelled
https://github.com/camunda/camunda-deployment-references/actions/runs/14687083604/workflow

EDIT: in order to simulate multiple version, I tested it with RENOVATE flag, this is the reason why the bug wasn't spotted before (https://github.com/camunda/camunda-deployment-references/actions/runs/14704698042/job/41262179567)

## TODO:
- [ ] backport to stable/8.7