### PR TITLE
fix(openshift-dual-region): update ACM from 2.12 to 2.13 to fix instl…

### DIFF
--- a/.github/workflows/aws_openshift_rosa_hcp_dual_region_tests.yml
+++ b/.github/workflows/aws_openshift_rosa_hcp_dual_region_tests.yml
@@ -572,6 +572,10 @@ jobs:
               run: |
                   set -euo pipefail
 
+                  echo "Debug MCH installation issues"
+                  # https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.13/html/release_notes/acm-release-notes#upgrade-stuck
+                  oc --context="$CLUSTER_1_NAME" get multiclusterhubs -n open-cluster-management -o yaml
+
                   kubectl --context="$CLUSTER_1_NAME" -n "$CAMUNDA_NAMESPACE_1" get po
                   kubectl --context="$CLUSTER_1_NAME" -n "$CAMUNDA_NAMESPACE_1" get po | grep -v "Completed" | awk '/0\//{print $1}' | while read -r pod_name; do
                     echo -e "\n### Failed Pod: ${pod_name} ###\n"

--- a/generic/openshift/dual-region/procedure/acm/install-manifest.yml
+++ b/generic/openshift/dual-region/procedure/acm/install-manifest.yml
@@ -21,7 +21,7 @@ metadata:
     name: advanced-cluster-management
     namespace: open-cluster-management
 spec:
-    channel: release-2.12
+    channel: release-2.13
     installPlanApproval: Automatic
     name: advanced-cluster-management
     source: redhat-operators

--- a/generic/openshift/dual-region/procedure/acm/verify-acm.sh
+++ b/generic/openshift/dual-region/procedure/acm/verify-acm.sh
@@ -14,4 +14,4 @@ done
 
 # Example output:
 # NAME                                  DISPLAY                                      VERSION   REPLACES                              PHASE
-# advanced-cluster-management.v2.12.2   Advanced Cluster Management for Kubernetes   2.12.2    advanced-cluster-management.v2.12.1   Succeeded
+# advanced-cluster-management.v2.13.2   Advanced Cluster Management for Kubernetes   2.13.2    advanced-cluster-management.v2.13.2   Succeeded


### PR DESCRIPTION
backport of https://github.com/camunda/camunda-deployment-references/pull/366

As reported in
https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.13/html/release_notes/acm-release-notes#upgrade-stuck, update 2.13.2 is required to prevent some CRDs not beeing applied correctly.

This PR also adds better debug information