### PR TITLE
chore: rename chart dir from alpha to 8.7

### DIFF
--- a/generic/kubernetes/single-region/tests/helm-values/identity.yml
+++ b/generic/kubernetes/single-region/tests/helm-values/identity.yml
@@ -1,5 +1,6 @@
 ---
-# keep it synced with https://github.com/camunda/camunda-platform-helm/blob/main/charts/camunda-platform-8.7/test/integration/scenarios/common/values-integration-test.yaml
+# TODO: [release-duty] when release update the link with the related Camunda version of the release
+# keep it synced with https://github.com/camunda/camunda-platform-helm/blob/main/charts/camunda-platform-8.8/test/integration/scenarios/common/values-integration-test.yaml
 # it generates the CI user used to connect to the platform
 
 identity:

--- a/generic/kubernetes/single-region/tests/helm-values/identity.yml
+++ b/generic/kubernetes/single-region/tests/helm-values/identity.yml
@@ -1,6 +1,5 @@
 ---
-# TODO: [release-duty] when release update the link with 8.7
-# keep it synced with https://github.com/camunda/camunda-platform-helm/blob/main/charts/camunda-platform-alpha/test/integration/scenarios/common/values-integration-test.yaml
+# keep it synced with https://github.com/camunda/camunda-platform-helm/blob/main/charts/camunda-platform-8.7/test/integration/scenarios/common/values-integration-test.yaml
 # it generates the CI user used to connect to the platform
 
 identity:


### PR DESCRIPTION
A quick clean up for any reference to the old `camunda-platform-alpha` dir.
Related to: https://github.com/camunda/team-distribution/issues/499