### PR TITLE
fix: delete resource types before group removal

### DIFF
--- a/.github/actions/azure-kubernetes-aks-single-region-cleanup/scripts/destroy-clusters.sh
+++ b/.github/actions/azure-kubernetes-aks-single-region-cleanup/scripts/destroy-clusters.sh
@@ -81,11 +81,15 @@ destroy_cluster() {
         | where createdTime < ago(${MIN_AGE_IN_HOURS}h)
         | project name
     " -o tsv); do
+      echo "Deleting Azure resource group: $rg"
+      resource_ids=$(az resource list --resource-group "$rg" --query "[].id" -o tsv)
+      for resource_id in $resource_ids; do
+        echo "Deleting resource: $resource_id"
+        az resource delete --ids "$resource_id"
+      done
+
       az group delete --name "$rg" --yes --no-wait
     done
-  else
-    # run init again later, before destroy()
-    :
   fi
 
   echo "tf state: bucket=$BUCKET key=$key region=$AWS_S3_REGION"


### PR DESCRIPTION
following adds the fix to remove identified resources of a resource groups before trying to delete.
Otherwise those will be blocking removal of the resource group.