### PR TITLE
fix: rosa dual-reg retry finalizer duplicate removal

### DIFF
--- a/.github/workflows/aws_openshift_rosa_hcp_dual_region_tests.yml
+++ b/.github/workflows/aws_openshift_rosa_hcp_dual_region_tests.yml
@@ -374,8 +374,6 @@ jobs:
                   while oc --context="$CLUSTER_1_NAME" get managedclusterset --all-namespaces | grep -q .; do
                     echo "Still waiting for ManagedClusterSet to be deleted..."
                     sleep 10
-
-                    oc --context="$CLUSTER_1_NAME" patch mch MultiClusterHub --type='merge' -p '{"metadata":{"finalizers":[]}}' -n open-cluster-management
                   done
 
                   echo "Uninstalling MultiClusterHub..."


### PR DESCRIPTION
related to retry error - https://github.com/camunda/camunda-deployment-references/actions/runs/15110208195/job/42471369892

We were deleting a MultiClusterSet but trying to add finalizers to a different resource that didn't need it yet. 

Backport
- [ ] stable/8.7