### PR TITLE
fix: sanatize tags

### DIFF
--- a/.github/actions/aws-aurora-manage-cluster/action.yml
+++ b/.github/actions/aws-aurora-manage-cluster/action.yml
@@ -165,7 +165,15 @@ runs:
               echo "::add-mask::${{ inputs.password }}"
 
               raw_tags='${{ inputs.tags }}'
-              escaped_tags=$(echo "$raw_tags" | jq -r 'to_entries | map("\"" + .key + "\"=\"" + .value + "\"") | join(", ")' | sed 's/.*/{&}/')
+              escaped_tags=$(echo "$raw_tags" | jq -r '
+                to_entries
+                | map("\"" + .key + "\"=\"" + (
+                    .value
+                    | gsub("[^a-zA-Z0-9_.:/=+\\-@ ]"; "-")               # Replace invalid characters
+                    | sub("[-_.:/=+@ ]+$"; "")                           # Remove trailing special characters
+                    ) + "\"")
+                | join(", ")
+                ' | sed 's/.*/{&}/')
 
               echo '${{ inputs.additional-terraform-vars }}' > /tmp/var.tfvars.json
               terraform plan -no-color -out aurora.plan \

--- a/.github/actions/aws-eks-manage-cluster/action.yml
+++ b/.github/actions/aws-eks-manage-cluster/action.yml
@@ -144,7 +144,15 @@ runs:
               set -euo pipefail
 
               raw_tags='${{ inputs.tags }}'
-              escaped_tags=$(echo "$raw_tags" | jq -r 'to_entries | map("\"" + .key + "\"=\"" + .value + "\"") | join(", ")' | sed 's/.*/{&}/')
+              escaped_tags=$(echo "$raw_tags" | jq -r '
+                to_entries
+                | map("\"" + .key + "\"=\"" + (
+                    .value
+                    | gsub("[^a-zA-Z0-9_.:/=+\\-@ ]"; "-")               # Replace invalid characters
+                    | sub("[-_.:/=+@ ]+$"; "")                           # Remove trailing special characters
+                    ) + "\"")
+                | join(", ")
+                ' | sed 's/.*/{&}/')
 
               echo '${{ inputs.additional-terraform-vars }}' > /tmp/var.tfvars.json
               terraform plan -no-color -out eks.plan \

--- a/.github/actions/aws-kubernetes-eks-single-region-create/action.yml
+++ b/.github/actions/aws-kubernetes-eks-single-region-create/action.yml
@@ -137,7 +137,15 @@ runs:
               cat opensearch.tf
 
               raw_tags='${{ inputs.tags }}'
-              escaped_tags=$(echo "$raw_tags" | jq -r 'to_entries | map("\"" + .key + "\"=\"" + .value + "\"") | join(", ")' | sed 's/.*/{&}/')
+              escaped_tags=$(echo "$raw_tags" | jq -r '
+                to_entries
+                | map("\"" + .key + "\"=\"" + (
+                    .value
+                    | gsub("[^a-zA-Z0-9_.:/=+\\-@ ]"; "-")               # Replace invalid characters
+                    | sub("[-_.:/=+@ ]+$"; "")                           # Remove trailing special characters
+                    ) + "\"")
+                | join(", ")
+                ' | sed 's/.*/{&}/')
 
               terraform plan -no-color -var="default_tags=$escaped_tags" -out tf.plan
 

--- a/.github/actions/aws-opensearch-manage-cluster/action.yml
+++ b/.github/actions/aws-opensearch-manage-cluster/action.yml
@@ -158,7 +158,15 @@ runs:
               set -euo pipefail
 
               raw_tags='${{ inputs.tags }}'
-              escaped_tags=$(echo "$raw_tags" | jq -r 'to_entries | map("\"" + .key + "\"=\"" + .value + "\"") | join(", ")' | sed 's/.*/{&}/')
+              escaped_tags=$(echo "$raw_tags" | jq -r '
+                to_entries
+                | map("\"" + .key + "\"=\"" + (
+                    .value
+                    | gsub("[^a-zA-Z0-9_.:/=+\\-@ ]"; "-")               # Replace invalid characters
+                    | sub("[-_.:/=+@ ]+$"; "")                           # Remove trailing special characters
+                    ) + "\"")
+                | join(", ")
+                ' | sed 's/.*/{&}/')
 
               echo '${{ inputs.additional-terraform-vars }}' > /tmp/var.tfvars.json
               terraform plan -no-color -out opensearch.plan \

--- a/.github/actions/aws-openshift-rosa-hcp-dual-region-create/action.yml
+++ b/.github/actions/aws-openshift-rosa-hcp-dual-region-create/action.yml
@@ -307,7 +307,15 @@ runs:
               cat cluster_region_2.tf
 
               raw_tags='${{ inputs.tags }}'
-              escaped_tags=$(echo "$raw_tags" | jq -r 'to_entries | map("\"" + .key + "\"=\"" + .value + "\"") | join(", ")' | sed 's/.*/{&}/')
+              escaped_tags=$(echo "$raw_tags" | jq -r '
+                to_entries
+                | map("\"" + .key + "\"=\"" + (
+                    .value
+                    | gsub("[^a-zA-Z0-9_.:/=+\\-@ ]"; "-")               # Replace invalid characters
+                    | sub("[-_.:/=+@ ]+$"; "")                           # Remove trailing special characters
+                    ) + "\"")
+                | join(", ")
+                ' | sed 's/.*/{&}/')
 
               terraform plan -no-color -out clusters.plan  \
                 -var="default_tags=$escaped_tags" \
@@ -421,7 +429,15 @@ runs:
               set -euo pipefail
 
               raw_tags='${{ inputs.tags }}'
-              escaped_tags=$(echo "$raw_tags" | jq -r 'to_entries | map("\"" + .key + "\"=\"" + .value + "\"") | join(", ")' | sed 's/.*/{&}/')
+              escaped_tags=$(echo "$raw_tags" | jq -r '
+                to_entries
+                | map("\"" + .key + "\"=\"" + (
+                    .value
+                    | gsub("[^a-zA-Z0-9_.:/=+\\-@ ]"; "-")               # Replace invalid characters
+                    | sub("[-_.:/=+@ ]+$"; "")                           # Remove trailing special characters
+                    ) + "\"")
+                | join(", ")
+                ' | sed 's/.*/{&}/')
 
               terraform plan -no-color -out peering.plan \
                 -var="default_tags=$escaped_tags" \
@@ -474,7 +490,15 @@ runs:
               hash=$(echo -n "${{ inputs.cluster-name-1 }}-oOo-${{ inputs.cluster-name-2 }}" | sha256sum | cut -c1-8)
 
               raw_tags='${{ inputs.tags }}'
-              escaped_tags=$(echo "$raw_tags" | jq -r 'to_entries | map("\"" + .key + "\"=\"" + .value + "\"") | join(", ")' | sed 's/.*/{&}/')
+              escaped_tags=$(echo "$raw_tags" | jq -r '
+                to_entries
+                | map("\"" + .key + "\"=\"" + (
+                    .value
+                    | gsub("[^a-zA-Z0-9_.:/=+\\-@ ]"; "-")               # Replace invalid characters
+                    | sub("[-_.:/=+@ ]+$"; "")                           # Remove trailing special characters
+                    ) + "\"")
+                | join(", ")
+                ' | sed 's/.*/{&}/')
 
               terraform plan -no-color -out  backup_bucket.plan \
                 -var="default_tags=$escaped_tags" \

--- a/.github/actions/aws-openshift-rosa-hcp-single-region-create/action.yml
+++ b/.github/actions/aws-openshift-rosa-hcp-single-region-create/action.yml
@@ -242,7 +242,15 @@ runs:
               cat cluster.tf
 
               raw_tags='${{ inputs.tags }}'
-              escaped_tags=$(echo "$raw_tags" | jq -r 'to_entries | map("\"" + .key + "\"=\"" + .value + "\"") | join(", ")' | sed 's/.*/{&}/')
+              escaped_tags=$(echo "$raw_tags" | jq -r '
+                to_entries
+                | map("\"" + .key + "\"=\"" + (
+                    .value
+                    | gsub("[^a-zA-Z0-9_.:/=+\\-@ ]"; "-")               # Replace invalid characters
+                    | sub("[-_.:/=+@ ]+$"; "")                           # Remove trailing special characters
+                    ) + "\"")
+                | join(", ")
+                ' | sed 's/.*/{&}/')
 
               terraform plan -no-color -var="default_tags=$escaped_tags" -out rosa.plan
 

--- a/.github/actions/azure-kubernetes-aks-single-region-create/action.yml
+++ b/.github/actions/azure-kubernetes-aks-single-region-create/action.yml
@@ -154,7 +154,15 @@ runs:
               }'
 
               combined_tags=$(jq -s '.[0] + .[1]' <(echo "$raw_tags") <(echo "$static_tags"))
-              escaped_tags=$(echo "$combined_tags" | jq -r 'to_entries | map("\"" + .key + "\"=\"" + .value + "\"") | join(", ")' | sed 's/.*/{&}/')
+              escaped_tags=$(echo "$combined_tags" | jq -r '
+                to_entries
+                | map("\"" + .key + "\"=\"" + (
+                    .value
+                    | gsub("[^a-zA-Z0-9_.:/=+\\-@ ]"; "-")               # Replace invalid characters
+                    | sub("[-_.:/=+@ ]+$"; "")                           # Remove trailing special characters
+                    ) + "\"")
+                | join(", ")
+                ' | sed 's/.*/{&}/')
 
               terraform plan \
                 -no-color \

--- a/.github/workflows/aws_kubernetes_eks_single_region_tests.yml
+++ b/.github/workflows/aws_kubernetes_eks_single_region_tests.yml
@@ -223,7 +223,7 @@ jobs:
                       {
                         "ci-run-id": "${{ github.run_id }}",
                         "ci-run-number": "${{ github.run_number }}",
-                        "ci-workflow": "eks-single-region-${{ matrix.scenario.name }}",
+                        "ci-workflow": "${{ github.workflow }}",
                         "ci-actor": "${{ github.actor }}",
                         "ci-ref": "${{ github.ref }}",
                         "ci-commit": "${{ github.sha }}",

--- a/.github/workflows/aws_modules_eks_rds_os_tests.yml
+++ b/.github/workflows/aws_modules_eks_rds_os_tests.yml
@@ -179,7 +179,15 @@ jobs:
                     }')
 
                   # Convert to Terraform format: "key"="value", ... wrapped in braces
-                  escaped_tags=$(echo "$ci_metadata" | jq -r 'to_entries | map("\"" + .key + "\"=\"" + .value + "\"") | join(", ")' | sed 's/.*/{&}/')
+                  escaped_tags=$(echo "$ci_metadata" | jq -r '
+                    to_entries
+                    | map("\"" + .key + "\"=\"" + (
+                        .value
+                        | gsub("[^a-zA-Z0-9_.:/=+\\-@ ]"; "-")               # Replace invalid characters
+                        | sub("[-_.:/=+@ ]+$"; "")                           # Remove trailing special characters
+                        ) + "\"")
+                    | join(", ")
+                    ' | sed 's/.*/{&}/')
 
                   echo "Final tags: $escaped_tags"
                   export TF_VAR_default_tags="$escaped_tags"


### PR DESCRIPTION
Sanitizes the tags to comply with AWS allowed characters.

I've also applied the same logic to Azure. It didn't fail but it also didn't run with `[bot]`, so just to be on the safe side.

Input:

```
{
    "ci-run-id": "15148822809",
    "ci-run-number": "244",
    "ci-workflow": "Tests - Integration - AWS EKS Cluster with an AuroraDB and OpenSearch creation and destruction",
    "ci-actor": "infraex-misc[bot]",
    "ci-ref": "refs/pull/472/merge",
    "ci-commit": "e578c9488c247fc62ef23b62d776671db5686352",
    "ci-repo": "camunda/camunda-deployment-references",
    "ci-event": "pull_request"
  }
```

Output sanitzed:

```
{"ci-run-id"="15148822809", "ci-run-number"="244", "ci-workflow"="Tests - Integration - AWS EKS Cluster with an AuroraDB and OpenSearch creation and destruction", "ci-actor"="infraex-misc-bot", "ci-ref"="refs/pull/472/merge", "ci-commit"="e578c9488c247fc62ef23b62d776671db5686352", "ci-repo"="camunda/camunda-deployment-references", "ci-event"="pull_request"}
```

Output not sanitzed:

```
{"ci-run-id"="15148822809", "ci-run-number"="244", "ci-workflow"="Tests - Integration - AWS EKS Cluster with an AuroraDB and OpenSearch creation and destruction", "ci-actor"="infraex-misc[bot]", "ci-ref"="refs/pull/472/merge", "ci-commit"="e578c9488c247fc62ef23b62d776671db5686352", "ci-repo"="camunda/camunda-deployment-references", "ci-event"="pull_request"}
```

Diff:

```diff
- "ci-actor"="infraex-misc[bot]"
+ "ci-actor"="infraex-misc-bot"
```

Backport:
- [ ] 8.7
- [ ] 8.6