### PR TITLE
fix: login to Azure again before retry

### DIFF
--- a/.github/actions/azure-kubernetes-aks-single-region-cleanup/action.yml
+++ b/.github/actions/azure-kubernetes-aks-single-region-cleanup/action.yml
@@ -50,3 +50,11 @@ runs:
 
               ${{ github.action_path }}/scripts/destroy-clusters.sh "${{ inputs.tf-bucket }}" \
                 ${{ inputs.max-age-hours-cluster }} ${{ inputs.target }} ${{ inputs.tf-bucket-key-prefix }}
+
+        - name: Upload cleanup logs
+          if: always()
+          uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+          with:
+              name: logs-${{ github.action }}-${{ github.job }}-${{ inputs.target }}
+              path: ./logs/
+              retention-days: 7

--- a/.github/workflows-config/workflow-scheduler.yml
+++ b/.github/workflows-config/workflow-scheduler.yml
@@ -39,4 +39,4 @@ schedules:
           - .github/workflows/aws_openshift_rosa_hcp_single_region_daily_cleanup.yml
           - .github/workflows/aws_openshift_rosa_hcp_dual_region_daily_cleanup.yml
           - .github/workflows/aws_modules_eks_rds_os_daily_cleanup.yml
-          - .github/workflows/aws_kubernetes_eks_single_region_cleanup.yml
+          - .github/workflows/aws_kubernetes_eks_single_region_daily_cleanup.yml

--- a/.github/workflows/aws_kubernetes_eks_single_region_daily_cleanup.yml
+++ b/.github/workflows/aws_kubernetes_eks_single_region_daily_cleanup.yml
@@ -10,7 +10,7 @@ on:
                 default: '12'
     pull_request:
         paths:
-            - .github/workflows/aws_kubernetes_eks_single_region_cleanup.yml
+            - .github/workflows/aws_kubernetes_eks_single_region_daily_cleanup.yml
             - .tool-versions
             - aws/kubernetes/eks-single-region*/**
             - '!aws/kubernetes/eks-single-region/test/golden/**'

--- a/.github/workflows/azure_kubernetes_aks_single_region_cleanup.yml
+++ b/.github/workflows/azure_kubernetes_aks_single_region_cleanup.yml
@@ -116,13 +116,22 @@ jobs:
 
             - name: Delete clusters
               id: delete_clusters
-              timeout-minutes: 125
+              timeout-minutes: 90 # Auth token have a max lifetime of 60 - 90 minutes
               uses: ./.github/actions/azure-kubernetes-aks-single-region-cleanup
               with:
                   tf-bucket: ${{ env.S3_BACKEND_BUCKET }}
                   tf-bucket-region: ${{ env.S3_BUCKET_REGION }}
                   max-age-hours-cluster: ${{ env.MAX_AGE_HOURS_CLUSTER }}
                   tf-bucket-key-prefix: ${{ steps.s3_prefix.outputs.S3_BACKEND_BUCKET_PREFIX }}${{ steps.camunda-version.outputs.CAMUNDA_VERSION }}/
+
+            # Login again to Azure with OIDC to gain a new token
+            - name: Azure Login with OIDC
+              if: failure() && steps.delete_clusters.outcome == 'failure' && env.IS_SCHEDULE == 'true'
+              uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
+              with:
+                  client-id: ${{ steps.secrets.outputs.AZURE_CLIENT_ID }}
+                  tenant-id: ${{ steps.secrets.outputs.AZURE_TENANT_ID }}
+                  subscription-id: ${{ steps.secrets.outputs.AZURE_SUBSCRIPTION_ID }}
 
             # There are cases where the deletion of resources fails due to dependencies.
             - name: Retry delete clusters (schedule only)

--- a/.github/workflows/azure_kubernetes_aks_single_region_daily_cleanup.yml
+++ b/.github/workflows/azure_kubernetes_aks_single_region_daily_cleanup.yml
@@ -14,7 +14,7 @@ on:
                 default: '12'
     pull_request:
         paths:
-            - .github/workflows/azure_kubernetes_eks_single_region_cleanup.yml
+            - .github/workflows/azure_kubernetes_aks_single_region_daily_cleanup.yml
             - .tool-versions
             - azure/kubernetes/aks-single-region*/**
             - '!azure/kubernetes/aks-single-region/test/golden/**'


### PR DESCRIPTION
precaution in case the token has expired as otherwise the retry will fail as well.

Related to [failed report](https://camunda.slack.com/archives/C076N4G1162/p1747794617662809).
The Slack thread linked above contains more alternative approaches.
For now the quick and easy one to re-authenticate before the retry.

On average it needs ~ 10 minutes to teardown everything, if it can't manage to delete everything within 60 then the extended token would not be able to solve that either and anyway the retry would be the way to go forward.

Backport - file rename of EKS daily cleanup job.
- [ ] 8.7