### PR TITLE
fix: rename eks daily cleanup worklow (#476)

### DIFF
--- a/.github/workflows/aws_kubernetes_eks_single_region_daily_cleanup.yml
+++ b/.github/workflows/aws_kubernetes_eks_single_region_daily_cleanup.yml
@@ -10,7 +10,7 @@ on:
                 default: '12'
     pull_request:
         paths:
-            - .github/workflows/aws_kubernetes_eks_single_region_cleanup.yml
+            - .github/workflows/aws_kubernetes_eks_single_region_daily_cleanup.yml
             - .tool-versions
             - aws/kubernetes/eks-single-region*/**
             - '!aws/kubernetes/eks-single-region/test/golden/**'


### PR DESCRIPTION
* fix: login to Azure again before retry

precaution in case the token has expired as otherwise the retry will fail as well

* fix: rename workflows and add upload logs for azure

backport of https://github.com/camunda/camunda-deployment-references/pull/476

Real change is the filename change.