### PR TITLE
fix: configure TLS for cluster membership of Tasklist/Operate

### DIFF
--- a/generic/openshift/single-region/helm-values/operate-route.yml
+++ b/generic/openshift/single-region/helm-values/operate-route.yml
@@ -8,6 +8,12 @@ operate:
         - name: CAMUNDA_OPERATE_ZEEBE_GATEWAYADDRESS
           # <release-name>-zeebe-gateway.<namespace>.svc.cluster.local
           value: ${CAMUNDA_RELEASE_NAME}-zeebe-gateway.${CAMUNDA_NAMESPACE}.svc.cluster.local:26500
+        - name: ZEEBE_GATEWAY_CLUSTER_SECURITY_ENABLED
+          value: 'true'
+        - name: ZEEBE_GATEWAY_CLUSTER_SECURITY_CERTIFICATECHAINPATH
+          value: /usr/local/zeebe/config/tls.crt
+        - name: ZEEBE_GATEWAY_CLUSTER_SECURITY_PRIVATEKEYPATH
+          value: /usr/local/zeebe/config/tls.key
     extraVolumeMounts:
         - name: certificate
           mountPath: /usr/local/operate/config/tls.crt

--- a/generic/openshift/single-region/helm-values/tasklist-route.yml
+++ b/generic/openshift/single-region/helm-values/tasklist-route.yml
@@ -7,6 +7,12 @@ tasklist:
           value: /usr/local/tasklist/config/tls.crt
         - name: CAMUNDA_TASKLIST_ZEEBE_GATEWAYADDRESS
           value: ${CAMUNDA_RELEASE_NAME}-zeebe-gateway.${CAMUNDA_NAMESPACE}.svc.cluster.local:26500
+        - name: ZEEBE_GATEWAY_CLUSTER_SECURITY_ENABLED
+          value: 'true'
+        - name: ZEEBE_GATEWAY_CLUSTER_SECURITY_CERTIFICATECHAINPATH
+          value: /usr/local/zeebe/config/tls.crt
+        - name: ZEEBE_GATEWAY_CLUSTER_SECURITY_PRIVATEKEYPATH
+          value: /usr/local/zeebe/config/tls.key
     extraVolumeMounts:
         - name: certificate
           mountPath: /usr/local/tasklist/config/tls.crt


### PR DESCRIPTION
# Description

This PR updates the documentation example to configure Tasklist/Operate for intra-cluster secured communication.

Related to: https://github.com/camunda/camunda-docs/issues/5869