### PR TITLE
Backport 8.6 tls cluster membership if domain

### DIFF
--- a/aws/openshift/rosa-hcp-dual-region/procedure/export_environment_prerequisites.sh
+++ b/aws/openshift/rosa-hcp-dual-region/procedure/export_environment_prerequisites.sh
@@ -30,4 +30,4 @@ export AWS_ES_BUCKET_REGION=""
 # The Helm release name used for installing Camunda 8 in both Kubernetes clusters
 export HELM_RELEASE_NAME=camunda
 # renovate: datasource=helm depName=camunda-platform registryUrl=https://helm.camunda.io
-export HELM_CHART_VERSION=11.3.0
+export HELM_CHART_VERSION=11.3.2

--- a/generic/openshift/single-region/helm-values/operate-route.yml
+++ b/generic/openshift/single-region/helm-values/operate-route.yml
@@ -6,13 +6,29 @@ operate:
         - name: CAMUNDA_OPERATE_ZEEBE_CERTIFICATEPATH
           value: /usr/local/operate/config/tls.crt
         - name: CAMUNDA_OPERATE_ZEEBE_GATEWAYADDRESS
-          # camunda-zeebe-gateway.<namespace>.svc.cluster.local
+          # <release-name>-zeebe-gateway.<namespace>.svc.cluster.local
           value: camunda-zeebe-gateway.camunda.svc.cluster.local:26500
+        - name: ZEEBE_GATEWAY_CLUSTER_SECURITY_ENABLED
+          value: 'true'
+        - name: ZEEBE_GATEWAY_CLUSTER_SECURITY_CERTIFICATECHAINPATH
+          value: /usr/local/operate/config/tls.crt
+        - name: ZEEBE_GATEWAY_CLUSTER_SECURITY_PRIVATEKEYPATH
+          value: /usr/local/operate/config/tls.key
     extraVolumeMounts:
         - name: certificate
           mountPath: /usr/local/operate/config/tls.crt
           subPath: tls.crt
+        - name: key
+          mountPath: /usr/local/operate/config/tls.key
+          subPath: tls.key
     extraVolumes:
+        - name: key
+          secret:
+              secretName: camunda-platform-internal-service-certificate
+              items:
+                  - key: tls.key
+                    path: tls.key
+              defaultMode: 420
         - name: certificate
           secret:
               secretName: camunda-platform-internal-service-certificate

--- a/generic/openshift/single-region/helm-values/tasklist-route.yml
+++ b/generic/openshift/single-region/helm-values/tasklist-route.yml
@@ -6,12 +6,29 @@ tasklist:
         - name: CAMUNDA_TASKLIST_ZEEBE_CERTIFICATEPATH
           value: /usr/local/tasklist/config/tls.crt
         - name: CAMUNDA_TASKLIST_ZEEBE_GATEWAYADDRESS
+          # <release-name>-zeebe-gateway.<namespace>.svc.cluster.local
           value: camunda-zeebe-gateway.camunda.svc.cluster.local:26500
+        - name: ZEEBE_GATEWAY_CLUSTER_SECURITY_ENABLED
+          value: 'true'
+        - name: ZEEBE_GATEWAY_CLUSTER_SECURITY_CERTIFICATECHAINPATH
+          value: /usr/local/tasklist/config/tls.crt
+        - name: ZEEBE_GATEWAY_CLUSTER_SECURITY_PRIVATEKEYPATH
+          value: /usr/local/tasklist/config/tls.key
     extraVolumeMounts:
         - name: certificate
           mountPath: /usr/local/tasklist/config/tls.crt
           subPath: tls.crt
+        - name: key
+          mountPath: /usr/local/tasklist/config/tls.key
+          subPath: tls.key
     extraVolumes:
+        - name: key
+          secret:
+              secretName: camunda-platform-internal-service-certificate
+              items:
+                  - key: tls.key
+                    path: tls.key
+              defaultMode: 420
         - name: certificate
           secret:
               secretName: camunda-platform-internal-service-certificate

--- a/generic/openshift/single-region/procedure/chart-env.sh
+++ b/generic/openshift/single-region/procedure/chart-env.sh
@@ -2,4 +2,4 @@
 
 # The Camunda 8 Helm Chart version
 # renovate: datasource=helm depName=camunda-platform versioning=regex:^11(\.(?<minor>\d+))?(\.(?<patch>\d+))?$ registryUrl=https://helm.camunda.io
-export CAMUNDA_HELM_CHART_VERSION="11.2.2"
+export CAMUNDA_HELM_CHART_VERSION="11.3.2"


### PR DESCRIPTION
backport of https://github.com/camunda/camunda-deployment-references/pull/508 for 8.6

// note to self, fix renovate for the helm chart.