### PR TITLE
fix: retry acm cleanup

### DIFF
--- a/.github/workflows/aws_openshift_rosa_hcp_dual_region_tests.yml
+++ b/.github/workflows/aws_openshift_rosa_hcp_dual_region_tests.yml
@@ -368,8 +368,9 @@ jobs:
                   ./aws/openshift/${{ matrix.scenario.name }}/procedure/get-your-copy.sh
                   tree
 
-            - name: Ensure ACM and associated MultiCluster are not installed (in case of retry)
-              if: fromJson(github.run_attempt) > 1
+            # It's expected to always run in case an existing cluster is present.
+            # E.g. manual development deployment.
+            - name: Ensure ACM and associated MultiCluster are not installed
               timeout-minutes: 25
               run: |
                   set -euo pipefail
@@ -446,33 +447,40 @@ jobs:
                   echo "Uninstalling ACM Install Manifest..."
                   oc --context="$CLUSTER_1_NAME" delete -f ./generic/openshift/dual-region/procedure/acm/install-manifest.yml || true
 
-                  echo "⏳ Waiting for MultiClusterEngine to be deleted..."
-                  SECONDS=0
-                  while true; do
-                    output=$(oc --context="$CLUSTER_1_NAME" get multiclusterengine -n open-cluster-management -o yaml 2>/dev/null)
+                  # Check if the CRD exists before attempting to delete a resource
+                  if oc --context="$CLUSTER_1_NAME" get crd multiclusterengines.multicluster.openshift.io >/dev/null 2>&1; then
+                    echo "CRD found, attempting to delete MultiClusterEngine..."
 
-                    if [[ -z "$output" || "$output" == *"items: []"* ]]; then
-                      echo "✅ MultiClusterEngine resource deleted or not found."
-                      break
-                    fi
+                    echo "⏳ Waiting for MultiClusterEngine to be deleted..."
+                    SECONDS=0
+                    while true; do
+                      output=$(oc --context="$CLUSTER_1_NAME" get multiclusterengine -n open-cluster-management -o yaml 2>/dev/null)
 
-                    echo "MultiClusterEngine still exists, fetching details:"
-                    echo "$output"
+                      if [[ -z "$output" || "$output" == *"items: []"* ]]; then
+                        echo "✅ MultiClusterEngine resource deleted or not found."
+                        break
+                      fi
 
-                    if [ "$SECONDS" -ge "$TIMEOUT_SECONDS" ]; then
-                      echo "⛔ Timeout reached — enforcing MultiClusterEngine finalizer removal!"
+                      echo "MultiClusterEngine still exists, fetching details:"
+                      echo "$output"
 
-                      for mce in $(oc --context="$CLUSTER_1_NAME" get multiclusterengine -n open-cluster-management -o jsonpath='{.items[*].metadata.name}'); do
-                        oc --context="$CLUSTER_1_NAME" patch multiclusterengine "$mce" \
-                          --type='merge' -p '{"metadata":{"finalizers":[]}}' -n open-cluster-management
-                      done
-                      break
-                    fi
+                      if [ "$SECONDS" -ge "$TIMEOUT_SECONDS" ]; then
+                        echo "⛔ Timeout reached — enforcing MultiClusterEngine finalizer removal!"
 
-                    echo "Still waiting for MultiClusterEngine to be deleted..."
-                    sleep 10
+                        for mce in $(oc --context="$CLUSTER_1_NAME" get multiclusterengine -n open-cluster-management -o jsonpath='{.items[*].metadata.name}'); do
+                          oc --context="$CLUSTER_1_NAME" patch multiclusterengine "$mce" \
+                            --type='merge' -p '{"metadata":{"finalizers":[]}}' -n open-cluster-management
+                        done
+                        break
+                      fi
 
-                  done
+                      echo "Still waiting for MultiClusterEngine to be deleted..."
+                      sleep 10
+
+                    done
+                  else
+                    echo "MultiClusterEngine CRD not found. Skipping deletion."
+                  fi
 
                   echo "✅ ACM and related resources successfully uninstalled (with finalizer enforcement if needed)."
 


### PR DESCRIPTION
Two things that were breaking:

1. The while loop didn't make sense and would always run till the timeout. I adjusted it to be the same as the other while loops used in that script part. Tried it out locally with `kubectl get pods` and worked as expected.

2. The while loop was the actual problem. Afterwards we tried to delete a `multiclusternegine` with finalizers based on an assumed name. The resource didn't exist. Nevertheless, I changed it up to use a for loop now to clean up any `multiclusterengine` regardless of the name. 

This is not a breaking one, just an addition.
3. Added an if check to only run on retries. There's no need to run it on the first try. It also wasn't working anyway since the CRDS aren't installed yet.

Dummy job that showcasing it:
The state is based on an older commit but contains the `for mce...` to show that it doesn't fail at least. I only notice afterwards that the while loop didn't make sense based on the outcome of the job.

https://github.com/camunda/camunda-deployment-references/actions/runs/15418592876/job/43391069932?pr=548

```
⏳ Waiting for MultiClusterEngine to be deleted...
Still waiting...
Still waiting...
Still waiting...
Still waiting...
Still waiting...
Still waiting...
Still waiting...
Still waiting...
Still waiting...
Still waiting...
Still waiting...
Still waiting...
Still waiting...
Still waiting...
Still waiting...
Still waiting...
Still waiting...
Still waiting...
Still waiting...
Still waiting...
Still waiting...
Still waiting...
Still waiting...
Still waiting...
Still waiting...
Still waiting...
Still waiting...
Still waiting...
Still waiting...
⛔ Timeout reached — enforcing MultiClusterEngine finalizer removal!
No resources found
```

- [x] backport to 8.7