### PR TITLE
fix: reduce false positive alerts for cleanup jobs

### DIFF
--- a/.github/workflows/aws_kubernetes_eks_single_region_daily_cleanup.yml
+++ b/.github/workflows/aws_kubernetes_eks_single_region_daily_cleanup.yml
@@ -99,6 +99,7 @@ jobs:
 
             - name: Delete clusters
               id: delete_clusters
+              continue-on-error: ${{ env.IS_SCHEDULE == 'true' }} # don't fail the workflow in case of schedule run
               timeout-minutes: 125
               uses: ./.github/actions/aws-kubernetes-eks-single-region-cleanup
               with:
@@ -107,10 +108,16 @@ jobs:
                   max-age-hours-cluster: ${{ env.MAX_AGE_HOURS_CLUSTER }}
                   tf-bucket-key-prefix: ${{ steps.s3_prefix.outputs.S3_BACKEND_BUCKET_PREFIX }}${{ steps.camunda-version.outputs.CAMUNDA_VERSION }}/
 
+            # The previous step has a continue-on-error set to true in case of schedule run.
+            # This means that the workflow is not marked as failed, but the step is.
+            # We can't use the `if: failure()` condition here, as the overall job is succeeding.
+            # Instead, we check the outcome of the previous step and if it failed, we retry the deletion.
+            # If the retry fails, then the report-failure job will be triggered as normally.
+
             # There are cases where the deletion of resources fails due to dependencies.
             - name: Retry delete clusters (schedule only)
               id: retry_delete_clusters
-              if: failure() && steps.delete_clusters.outcome == 'failure' && env.IS_SCHEDULE == 'true'
+              if: steps.delete_clusters.outcome == 'failure' && env.IS_SCHEDULE == 'true'
               timeout-minutes: 125
               uses: ./.github/actions/aws-kubernetes-eks-single-region-cleanup
               env:

--- a/.github/workflows/aws_modules_eks_rds_os_daily_cleanup.yml
+++ b/.github/workflows/aws_modules_eks_rds_os_daily_cleanup.yml
@@ -84,6 +84,7 @@ jobs:
 
             - name: Delete orphaned resources
               id: delete-orphaned-resources
+              continue-on-error: ${{ env.IS_SCHEDULE == 'true' }} # don't fail the workflow in case of schedule run
               timeout-minutes: 360
               if: always()
               uses: ./.github/actions/aws-eks-cleanup-resources
@@ -94,11 +95,17 @@ jobs:
                   max-age-hours: ${{ env.MAX_AGE_HOURS }}
                   target: all
 
+            # The previous step has a continue-on-error set to true in case of schedule run.
+            # This means that the workflow is not marked as failed, but the step is.
+            # We can't use the `if: failure()` condition here, as the overall job is succeeding.
+            # Instead, we check the outcome of the previous step and if it failed, we retry the deletion.
+            # If the retry fails, then the slack notification will be triggered as normally.
+
             # There are cases where the deletion of resources fails due to dependencies.
             - name: Retry delete orphaned resources (schedule only)
               id: retry-delete-orphaned-resources
               timeout-minutes: 360
-              if: failure() && steps.delete-orphaned-resources.outcome == 'failure' && env.IS_SCHEDULE == 'true'
+              if: steps.delete-orphaned-resources.outcome == 'failure' && env.IS_SCHEDULE == 'true'
               uses: ./.github/actions/aws-eks-cleanup-resources
               with:
                   s3-backend-bucket: ${{ env.S3_BACKEND_BUCKET }}

--- a/.github/workflows/aws_openshift_rosa_hcp_dual_region_daily_cleanup.yml
+++ b/.github/workflows/aws_openshift_rosa_hcp_dual_region_daily_cleanup.yml
@@ -100,6 +100,7 @@ jobs:
 
             - name: Delete clusters
               id: delete_clusters
+              continue-on-error: ${{ env.IS_SCHEDULE == 'true' }} # don't fail the workflow in case of schedule run
               timeout-minutes: 125
               uses: ./.github/actions/aws-openshift-rosa-hcp-dual-region-cleanup
               env:
@@ -110,10 +111,16 @@ jobs:
                   max-age-hours-cluster: ${{ env.MAX_AGE_HOURS_CLUSTER }}
                   tf-bucket-key-prefix: ${{ env.S3_BACKEND_BUCKET_PREFIX }}${{ steps.camunda-version.outputs.CAMUNDA_VERSION }}/
 
+            # The previous step has a continue-on-error set to true in case of schedule run.
+            # This means that the workflow is not marked as failed, but the step is.
+            # We can't use the `if: failure()` condition here, as the overall job is succeeding.
+            # Instead, we check the outcome of the previous step and if it failed, we retry the deletion.
+            # If the retry fails, then the slack notification will be triggered as normally.
+
             # There are cases where the deletion of resources fails due to dependencies.
             - name: Retry delete clusters (schedule only)
               id: retry_delete_clusters
-              if: failure() && steps.delete_clusters.outcome == 'failure' && env.IS_SCHEDULE == 'true'
+              if: steps.delete_clusters.outcome == 'failure' && env.IS_SCHEDULE == 'true'
               timeout-minutes: 125
               uses: ./.github/actions/aws-openshift-rosa-hcp-dual-region-cleanup
               env:

--- a/.github/workflows/aws_openshift_rosa_hcp_single_region_daily_cleanup.yml
+++ b/.github/workflows/aws_openshift_rosa_hcp_single_region_daily_cleanup.yml
@@ -100,6 +100,7 @@ jobs:
 
             - name: Delete clusters
               id: delete_clusters
+              continue-on-error: ${{ env.IS_SCHEDULE == 'true' }} # don't fail the workflow in case of schedule run
               timeout-minutes: 125
               uses: ./.github/actions/aws-openshift-rosa-hcp-single-region-cleanup
               env:
@@ -110,10 +111,16 @@ jobs:
                   max-age-hours-cluster: ${{ env.MAX_AGE_HOURS_CLUSTER }}
                   tf-bucket-key-prefix: ${{ env.S3_BACKEND_BUCKET_PREFIX }}${{ steps.camunda-version.outputs.CAMUNDA_VERSION }}/
 
+            # The previous step has a continue-on-error set to true in case of schedule run.
+            # This means that the workflow is not marked as failed, but the step is.
+            # We can't use the `if: failure()` condition here, as the overall job is succeeding.
+            # Instead, we check the outcome of the previous step and if it failed, we retry the deletion.
+            # If the retry fails, then the slack notification will be triggered as normally.
+
             # There are cases where the deletion of resources fails due to dependencies.
             - name: Retry delete clusters (schedule only)
               id: retry_delete_clusters
-              if: failure() && steps.delete_clusters.outcome == 'failure' && env.IS_SCHEDULE == 'true'
+              if: steps.delete_clusters.outcome == 'failure' && env.IS_SCHEDULE == 'true'
               timeout-minutes: 125
               uses: ./.github/actions/aws-openshift-rosa-hcp-single-region-cleanup
               env:

--- a/.github/workflows/azure_kubernetes_aks_single_region_daily_cleanup.yml
+++ b/.github/workflows/azure_kubernetes_aks_single_region_daily_cleanup.yml
@@ -120,6 +120,7 @@ jobs:
 
             - name: Delete clusters
               id: delete_clusters
+              continue-on-error: ${{ env.IS_SCHEDULE == 'true' }} # don't fail the workflow in case of schedule run
               timeout-minutes: 90 # Auth token have a max lifetime of 60 - 90 minutes
               uses: ./.github/actions/azure-kubernetes-aks-single-region-cleanup
               with:
@@ -128,9 +129,15 @@ jobs:
                   max-age-hours-cluster: ${{ env.MAX_AGE_HOURS_CLUSTER }}
                   tf-bucket-key-prefix: ${{ steps.s3_prefix.outputs.S3_BACKEND_BUCKET_PREFIX }}${{ steps.camunda-version.outputs.CAMUNDA_VERSION }}/
 
+            # The previous step has a continue-on-error set to true in case of schedule run.
+            # This means that the workflow is not marked as failed, but the step is.
+            # We can't use the `if: failure()` condition here, as the overall job is succeeding.
+            # Instead, we check the outcome of the previous step and if it failed, we retry the deletion.
+            # If the retry fails, then the report-failure job will be triggered as normally.
+
             # Login again to Azure with OIDC to gain a new token
             - name: Azure Login with OIDC
-              if: failure() && steps.delete_clusters.outcome == 'failure' && env.IS_SCHEDULE == 'true'
+              if: steps.delete_clusters.outcome == 'failure' && env.IS_SCHEDULE == 'true'
               uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
               with:
                   client-id: ${{ steps.secrets.outputs.AZURE_CLIENT_ID }}
@@ -140,7 +147,7 @@ jobs:
             # There are cases where the deletion of resources fails due to dependencies.
             - name: Retry delete clusters (schedule only)
               id: retry_delete_clusters
-              if: failure() && steps.delete_clusters.outcome == 'failure' && env.IS_SCHEDULE == 'true'
+              if: steps.delete_clusters.outcome == 'failure' && env.IS_SCHEDULE == 'true'
               timeout-minutes: 125
               uses: ./.github/actions/azure-kubernetes-aks-single-region-cleanup
               env:


### PR DESCRIPTION
Related to [slack alert](https://camunda.slack.com/archives/C076N4G1162/p1749001665633689) and [workflow run](https://github.com/camunda/camunda-deployment-references/actions/runs/15431466832).

This PR intends to reduce the amount of false positive alerts of daily cleanup jobs.
If the retry succeeds we should not report errors. The way it's implemented now, it will also not result in failure mails to users as the overall workflow is succeeding.

In case of a scheduled run, the initial delete will not overwrite the outcome of the workflow.
The retry in this case is not running on `failure()` condition but normal `success()`.
If the retry fails then it's business as usual.

If it's not a scheduled run, then nothing changes. If it fails, the workflow is marked as failed. The retry won't run since we have the if conditions in there.