### PR TITLE
fix: reduce false positive alerts for cleanup jobs (#552) [ci skip]

### DIFF
--- a/.github/workflows/aws_openshift_rosa_hcp_single_region_daily_cleanup.yml
+++ b/.github/workflows/aws_openshift_rosa_hcp_single_region_daily_cleanup.yml
@@ -84,6 +84,7 @@ jobs:
 
             - name: Delete clusters
               id: delete_clusters
+              continue-on-error: ${{ env.IS_SCHEDULE == 'true' }} # don't fail the workflow in case of schedule run
               timeout-minutes: 125
               uses: ./.github/actions/aws-openshift-rosa-hcp-single-region-cleanup
               env:
@@ -94,10 +95,16 @@ jobs:
                   max-age-hours-cluster: ${{ env.MAX_AGE_HOURS_CLUSTER }}
                   tf-bucket-key-prefix: ${{ steps.camunda-version.outputs.CAMUNDA_VERSION }}/
 
+            # The previous step has a continue-on-error set to true in case of schedule run.
+            # This means that the workflow is not marked as failed, but the step is.
+            # We can't use the `if: failure()` condition here, as the overall job is succeeding.
+            # Instead, we check the outcome of the previous step and if it failed, we retry the deletion.
+            # If the retry fails, then the slack notification will be triggered as normally.
+
             # There are cases where the deletion of resources fails due to dependencies.
             - name: Retry delete clusters
               id: retry_delete_clusters
-              if: failure() && steps.delete_clusters.outcome == 'failure'
+              if: steps.delete_clusters.outcome == 'failure' && env.IS_SCHEDULE == 'true'
               timeout-minutes: 125
               uses: ./.github/actions/aws-openshift-rosa-hcp-single-region-cleanup
               env:


### PR DESCRIPTION
backport of https://github.com/camunda/camunda-deployment-references/pull/552