### PR TITLE
fix: terraform regenerate golden files

### DIFF
--- a/justfile
+++ b/justfile
@@ -29,6 +29,8 @@ regenerate-golden-file module_dir backend_bucket_region backend_bucket_name back
 
   cd {{ justfile_directory() }}/{{ module_dir }}
 
+  rm -Rf {{ justfile_directory() }}/{{ module_dir }}/.terraform*
+
   # Copy *.tf files from tests/fixtures/ to the current directory before running the plan
   if ls test/fixtures/fixture_*.tf 1> /dev/null 2>&1; then
     cp test/fixtures/fixture_*.tf ./


### PR DESCRIPTION
This PR fixes the regenerate command, it deletes the terraform state and locally downloaded modules, preventing situation where the CI uses a more recent module than the one locally present.

### Backports
- [ ] 8.6
- [ ] 8.7 https://github.com/camunda/camunda-deployment-references/pull/564