### PR TITLE
fix: only execute vpn export step when private is enabled

### DIFF
--- a/.github/actions/aws-openshift-rosa-hcp-single-region-create/action.yml
+++ b/.github/actions/aws-openshift-rosa-hcp-single-region-create/action.yml
@@ -344,7 +344,15 @@ runs:
               cat vpn.tf
 
               raw_tags='${{ inputs.tags }}'
-              escaped_tags=$(echo "$raw_tags" | jq -r 'to_entries | map("\"" + .key + "\"=\"" + .value + "\"") | join(", ")' | sed 's/.*/{&}/')
+              escaped_tags=$(echo "$raw_tags" | jq -r '
+                to_entries
+                | map("\"" + .key + "\"=\"" + (
+                    .value
+                    | gsub("[^a-zA-Z0-9_.:/=+\\-@ ]"; "-")               # Replace invalid characters
+                    | sub("[-_.:/=+@ ]+$"; "")                           # Remove trailing special characters
+                    ) + "\"")
+                | join(", ")
+                ' | sed 's/.*/{&}/')
 
               terraform plan -no-color \
                 -var="default_tags=$escaped_tags" \

--- a/.github/workflows/aws_openshift_rosa_hcp_single_region_tests.yml
+++ b/.github/workflows/aws_openshift_rosa_hcp_single_region_tests.yml
@@ -226,6 +226,7 @@ jobs:
                   encryption_key: ${{ steps.secrets.outputs.CI_ENCRYPTION_KEY }}
 
             - name: Export VPN config and encrypt it
+              if: ${{ matrix.distro.private_vpc == true }}
               id: export_configs
               uses: ./.github/actions/internal-generic-encrypt-export
               with:


### PR DESCRIPTION
related to [slack](https://camunda.slack.com/archives/C076N4G1162/p1750048595082579) and [errored job](https://github.com/camunda/camunda-deployment-references/actions/runs/15671090483).

This PR fixes two issues in the ROSA single region test:
- in case of non private cluster (no VPN) usage, it failed a step that wasn't skipped
- in case of private cluster (VPN) usage, it failed as the tags were not sanitized in case of `[bot]` users.

- [x] I'll remove the overwrite commit around private before merging.


Run checking that the non VPN fix works:
- https://github.com/camunda/camunda-deployment-references/actions/runs/15674350221/job/44157027502?pr=610

Run that checks the VPN tag sanitization:
- https://github.com/camunda/camunda-deployment-references/actions/runs/15676228331?pr=610