### PR TITLE
chore: outsource sanatizing of tags to extra action

### DIFF
--- a/.github/actions/aws-aurora-manage-cluster/action.yml
+++ b/.github/actions/aws-aurora-manage-cluster/action.yml
@@ -154,9 +154,9 @@ runs:
                 -backend-config="region=${{ steps.utility.outputs.TFSTATE_REGION }}"
               terraform validate -no-color
 
-        - name: Sanatize Tags
+        - name: Sanitize Tags
           id: sanitize-tags
-          uses: ./.github/actions/internal-sanatize-tags
+          uses: ./.github/actions/internal-sanitize-tags
           with:
               raw-tags: ${{ inputs.tags }}
 

--- a/.github/actions/aws-eks-manage-cluster/action.yml
+++ b/.github/actions/aws-eks-manage-cluster/action.yml
@@ -136,9 +136,9 @@ runs:
                 -backend-config="key=${{ steps.utility.outputs.TFSTATE_KEY }}" -backend-config="region=${{ steps.utility.outputs.TFSTATE_REGION }}"
               terraform validate -no-color
 
-        - name: Sanatize Tags
+        - name: Sanitize Tags
           id: sanitize-tags
-          uses: ./.github/actions/internal-sanatize-tags
+          uses: ./.github/actions/internal-sanitize-tags
           with:
               raw-tags: ${{ inputs.tags }}
 

--- a/.github/actions/aws-kubernetes-eks-single-region-create/action.yml
+++ b/.github/actions/aws-kubernetes-eks-single-region-create/action.yml
@@ -104,9 +104,9 @@ runs:
 
               terraform validate -no-color
 
-        - name: Sanatize Tags
+        - name: Sanitize Tags
           id: sanitize-tags
-          uses: ./.github/actions/internal-sanatize-tags
+          uses: ./.github/actions/internal-sanitize-tags
           with:
               raw-tags: ${{ inputs.tags }}
 

--- a/.github/actions/aws-opensearch-manage-cluster/action.yml
+++ b/.github/actions/aws-opensearch-manage-cluster/action.yml
@@ -150,9 +150,9 @@ runs:
                 -backend-config="region=${{ steps.utility.outputs.TFSTATE_REGION }}"
               terraform validate -no-color
 
-        - name: Sanatize Tags
+        - name: Sanitize Tags
           id: sanitize-tags
-          uses: ./.github/actions/internal-sanatize-tags
+          uses: ./.github/actions/internal-sanitize-tags
           with:
               raw-tags: ${{ inputs.tags }}
 

--- a/.github/actions/aws-openshift-rosa-hcp-dual-region-create/action.yml
+++ b/.github/actions/aws-openshift-rosa-hcp-dual-region-create/action.yml
@@ -259,9 +259,9 @@ runs:
 
               terraform validate -no-color
 
-        - name: Sanatize Tags
+        - name: Sanitize Tags
           id: sanitize-tags
-          uses: ./.github/actions/internal-sanatize-tags
+          uses: ./.github/actions/internal-sanitize-tags
           with:
               raw-tags: ${{ inputs.tags }}
 

--- a/.github/actions/aws-openshift-rosa-hcp-single-region-create/action.yml
+++ b/.github/actions/aws-openshift-rosa-hcp-single-region-create/action.yml
@@ -233,9 +233,9 @@ runs:
 
               terraform validate -no-color
 
-        - name: Sanatize Tags
+        - name: Sanitize Tags
           id: sanitize-tags
-          uses: ./.github/actions/internal-sanatize-tags
+          uses: ./.github/actions/internal-sanitize-tags
           with:
               raw-tags: ${{ inputs.tags }}
 

--- a/.github/actions/azure-kubernetes-aks-single-region-create/action.yml
+++ b/.github/actions/azure-kubernetes-aks-single-region-create/action.yml
@@ -158,9 +158,9 @@ runs:
               combined_tags=$(jq -c -s '.[0] + .[1]' <(echo "$raw_tags") <(echo "$static_tags"))
               echo "COMBINED_TAGS=$combined_tags" | tee -a "$GITHUB_OUTPUT"
 
-        - name: Sanatize Tags
+        - name: Sanitize Tags
           id: sanitize-tags
-          uses: ./.github/actions/internal-sanatize-tags
+          uses: ./.github/actions/internal-sanitize-tags
           with:
               raw-tags: ${{ steps.prepare.outputs.COMBINED_TAGS }}
 

--- a/.github/actions/internal-sanitize-tags/README.md
+++ b/.github/actions/internal-sanitize-tags/README.md
@@ -1,4 +1,4 @@
-# Sanatize Tags
+# Sanitize Tags
 
 ## Description
 
@@ -26,7 +26,7 @@ This action is a `composite` action.
 ## Usage
 
 ```yaml
-- uses: camunda/camunda-deployment-references/.github/actions/internal-sanatize-tags@main
+- uses: camunda/camunda-deployment-references/.github/actions/internal-sanitize-tags@main
   with:
     raw-tags:
     # Raw tags to sanitize

--- a/.github/actions/internal-sanitize-tags/action.yml
+++ b/.github/actions/internal-sanitize-tags/action.yml
@@ -1,5 +1,5 @@
 ---
-name: Sanatize Tags
+name: Sanitize Tags
 
 description: >
     This GitHub Action sanitizes the tags given as input and outputs a sanitized version.

--- a/.github/workflows/aws_modules_eks_rds_os_tests.yml
+++ b/.github/workflows/aws_modules_eks_rds_os_tests.yml
@@ -182,9 +182,9 @@ jobs:
 
                   echo "CI_METADATA=$ci_metadata" | tee -a "$GITHUB_ENV"
 
-            - name: Sanatize Tags
+            - name: Sanitize Tags
               id: sanitize-tags
-              uses: ./.github/actions/internal-sanatize-tags
+              uses: ./.github/actions/internal-sanitize-tags
               with:
                   raw-tags: ${{ env.CI_METADATA }}
 


### PR DESCRIPTION
related to https://camunda.slack.com/archives/C076N4G1162/p1750061166618019?thread_ts=1750048595.082579&cid=C076N4G1162

Pulls out the escaping as github action.

- Backport
- [x] 8.6
- [x] 8.7