### PR TITLE
fix: rosa delete and re-create context

### DIFF
--- a/.github/actions/aws-openshift-rosa-hcp-dual-region-create/action.yml
+++ b/.github/actions/aws-openshift-rosa-hcp-dual-region-create/action.yml
@@ -386,9 +386,11 @@ runs:
                   oc whoami
                   echo "Show existing contexts"
                   kubectl config get-contexts
-                  if kubectl config get-contexts | awk '{print $2}' | grep -q '^${{ inputs.cluster-name-1 }}$'; then
+                  if kubectl config get-contexts -o name | grep -qx '${{ inputs.cluster-name-1 }}'; then
                       echo "Context '${{ inputs.cluster-name-1 }}' already exists. No changes made."
                   else
+                      echo "Renaming oc config current context to '${{ inputs.cluster-name-1 }}'"
+                      kubectl config delete-context '${{ inputs.cluster-name-1 }}' 2>/dev/null || true
                       kubectl config rename-context "$(oc config current-context)" "${{ inputs.cluster-name-1 }}"
                   fi
 
@@ -407,9 +409,11 @@ runs:
                   oc whoami
                   echo "Show existing contexts"
                   kubectl config get-contexts
-                  if kubectl config get-contexts | awk '{print $2}' | grep -q '^${{ inputs.cluster-name-2 }}$'; then
+                  if kubectl config get-contexts -o name | grep -qx '${{ inputs.cluster-name-2 }}'; then
                       echo "Context '${{ inputs.cluster-name-2 }}' already exists. No changes made."
                   else
+                      echo "Renaming oc config current context to '${{ inputs.cluster-name-2 }}'"
+                      kubectl config delete-context '${{ inputs.cluster-name-2 }}' 2>/dev/null || true
                       kubectl config rename-context "$(oc config current-context)" "${{ inputs.cluster-name-2 }}"
                   fi
 

--- a/.github/actions/aws-openshift-rosa-hcp-single-region-create/action.yml
+++ b/.github/actions/aws-openshift-rosa-hcp-single-region-create/action.yml
@@ -444,9 +444,11 @@ runs:
 
                   echo "Show existing contexts"
                   kubectl config get-contexts
-                  if kubectl config get-contexts | awk '{print $2}' | grep -q '^${{ inputs.cluster-name }}$'; then
+                  if kubectl config get-contexts -o name | grep -qx '${{ inputs.cluster-name }}'; then
                       echo "Context '${{ inputs.cluster-name }}' already exists. No changes made."
                   else
+                      echo "Renaming oc config current context to '${{ inputs.cluster-name }}'"
+                      kubectl config delete-context '${{ inputs.cluster-name }}' 2>/dev/null || true
                       kubectl config rename-context "$(oc config current-context)" "${{ inputs.cluster-name }}"
                   fi
 


### PR DESCRIPTION
as well as skip awk in favour of k8s supported name returnal

related to https://camunda.slack.com/archives/C076N4G1162/p1750115840775489 and https://camunda.slack.com/archives/C076N4G1162/p1750140003725549 on slack.

I simplifies the `k8s get context` by removing the awk and just return names as is from the beginning.
I could imagine that maybe with the `awk` a space is in there and the `^$` won't work. `-x` option of grep is just an alias for `^$`.

Also I added removal of the old context just in case to allow recreating it, in case it still jumps into that line.

Backport:
- [ ] 8.6
- [ ] 8.7 if not possible the pending PR of VPN backport