### PR TITLE
chore: outsource sanatizing of tags to extra action (#611)

### DIFF
--- a/.github/actions/aws-openshift-rosa-hcp-single-region-create/action.yml
+++ b/.github/actions/aws-openshift-rosa-hcp-single-region-create/action.yml
@@ -191,6 +191,12 @@ runs:
 
               terraform validate -no-color
 
+        - name: Sanitize Tags
+          id: sanitize-tags
+          uses: ./.github/actions/internal-sanitize-tags
+          with:
+              raw-tags: ${{ inputs.tags }}
+
         - name: Terraform Plan
           id: plan
           working-directory: ${{ inputs.tf-modules-path }}/aws/openshift/rosa-hcp-single-region/
@@ -220,18 +226,7 @@ runs:
               echo "Displaying templated cluster.tf file:"
               cat cluster.tf
 
-              raw_tags='${{ inputs.tags }}'
-              escaped_tags=$(echo "$raw_tags" | jq -r '
-                to_entries
-                | map("\"" + .key + "\"=\"" + (
-                    .value
-                    | gsub("[^a-zA-Z0-9_.:/=+\\-@ ]"; "-")               # Replace invalid characters
-                    | sub("[-_.:/=+@ ]+$"; "")                           # Remove trailing special characters
-                    ) + "\"")
-                | join(", ")
-                ' | sed 's/.*/{&}/')
-
-              terraform plan -no-color -var="default_tags=$escaped_tags" -out rosa.plan
+              terraform plan -no-color -var='default_tags=${{ steps.sanitize-tags.outputs.sanitized_tags }}' -out rosa.plan
 
         - name: Terraform Apply
           id: apply

--- a/.github/actions/internal-sanitize-tags/README.md
+++ b/.github/actions/internal-sanitize-tags/README.md
@@ -1,0 +1,36 @@
+# Sanitize Tags
+
+## Description
+
+This GitHub Action sanitizes the tags given as input and outputs a sanitized version. It's based on the AWS guidelines for tag keys and values, ensuring that tags are compliant with the expected format.
+
+
+## Inputs
+
+| name | description | required | default |
+| --- | --- | --- | --- |
+| `raw-tags` | <p>Raw tags to sanitize</p> | `false` | `{}` |
+
+
+## Outputs
+
+| name | description |
+| --- | --- |
+| `sanitized_tags` | <p>Sanitized tags</p> |
+
+
+## Runs
+
+This action is a `composite` action.
+
+## Usage
+
+```yaml
+- uses: camunda/camunda-deployment-references/.github/actions/internal-sanitize-tags@main
+  with:
+    raw-tags:
+    # Raw tags to sanitize
+    #
+    # Required: false
+    # Default: {}
+```

--- a/.github/actions/internal-sanitize-tags/action.yml
+++ b/.github/actions/internal-sanitize-tags/action.yml
@@ -1,0 +1,38 @@
+---
+name: Sanitize Tags
+
+description: >
+    This GitHub Action sanitizes the tags given as input and outputs a sanitized version.
+    It's based on the AWS guidelines for tag keys and values, ensuring that tags are compliant with the expected format.
+
+inputs:
+    raw-tags:
+        description: Raw tags to sanitize
+        default: '{}'
+
+outputs:
+    sanitized_tags:
+        description: Sanitized tags
+        value: ${{ steps.sanitize-tags.outputs.sanitized_tags }}
+
+runs:
+    using: composite
+    steps:
+        - name: Sanitize Tags
+          shell: bash
+          id: sanitize-tags
+          run: |
+              set -euo pipefail
+
+              raw_tags='${{ inputs.raw-tags }}'
+              escaped_tags=$(echo "$raw_tags" | jq -r '
+                    to_entries
+                    | map("\"" + .key + "\"=\"" + (
+                        .value
+                        | gsub("[^a-zA-Z0-9_.:/=+\\-@ ]"; "-")               # Replace all invalid characters
+                        | sub("[-_.:/=+@ ]+$"; "")                           # Remove trailing special characters
+                        | .[0:255]                                           # Truncate to 255 characters
+                        ) + "\"")
+                    | join(", ")
+                    ' | sed 's/.*/{&}/')
+              echo "sanitized_tags=${escaped_tags}" | tee -a "$GITHUB_OUTPUT"


### PR DESCRIPTION
* chore: outsource sanatizing of tags to extra action

* fix: combined tags exception on azure

* chore: fix spelling error for sanitize

backport of https://github.com/camunda/camunda-deployment-references/pull/611#issuecomment-2979726366