### PR TITLE
chore: remove snapshot, will be superseeded

### DIFF
--- a/.github/workflows/aws_compute_ec2_single_region_tests.yml
+++ b/.github/workflows/aws_compute_ec2_single_region_tests.yml
@@ -59,7 +59,6 @@ jobs:
                 camunda:
                     # renovate: datasource=github-releases depName=camunda/camunda versioning=regex:^8\.6?(\.(?<patch>\d+))?$
                     - 8.6.18
-                    - 8.7.0-SNAPSHOT
                 architecture:
                     - x86_64
                     - arm64
@@ -67,10 +66,6 @@ jobs:
                     - ${{ github.event_name == 'pull_request' && !contains(github.head_ref, 'SNAPSHOT') }}
                 previous_camunda:
                     - 8.6.2
-                # we don't include SNAPSHOT in PR due to the instability of its nature except if it's explicitly mentioned
-                exclude:
-                    - camunda: 8.7.0-SNAPSHOT
-                      isPR: true
 
         steps:
             - name: Checkout repository


### PR DESCRIPTION
related to https://github.com/camunda/camunda/issues/30477

I'm throwing it out for now. The Epic was paused in January and since then the whole folder and test structure has changed.
I'll have to rework this part anyway for 8.8 since neither 8.6 nor 8.7 are officially supported, it just worked to some degree.