### PR TITLE
fix: copy .tool-versions one directory higher to apply to all integra…

### DIFF
--- a/.github/actions/internal-camunda-chart-tests/action.yml
+++ b/.github/actions/internal-camunda-chart-tests/action.yml
@@ -228,7 +228,7 @@ runs:
                 -i "$TEST_CHART_DIR_STATIC/test/integration/testsuites/core/patches/job.yaml"
 
               echo "Ensure asdf tool is available in the test suite by using our global one"
-              cp .tool-versions "$TEST_VALUES_BASE_DIR"
+              cp .tool-versions "$TEST_VALUES_BASE_DIR/.."
 
         - name: 🧪 TESTS - Run Preflight TestSuite
           if: ${{ inputs.enable-helm-chart-tests == 'true' }}


### PR DESCRIPTION
…tion tests

The issue stems from `kustomize` not being available due to a missing or mismatched `.tool-versions` file. Although version 5.6.0 is installed and present in the cache, the path where the error occurs (`testsuites/vars`) lacks a `.tool-versions` file. The file that does exist (with 5.6.0) is copied to a different directory (`scenarios`). Meanwhile, the Helm chart expects version 5.7.0, which isn’t installed. Since `.tool-versions` higher up the directory tree don’t help due to version mismatch, the fix is to add a `.tool-versions` with the correct version (5.6.0) to `test/integration/` so it applies to all subfolders.
