### PR TITLE
Update instance type in variables.tf

### DIFF
--- a/aws/modules/opensearch/variables.tf
+++ b/aws/modules/opensearch/variables.tf
@@ -35,7 +35,7 @@ variable "security_group_ids" {
 
 variable "instance_type" {
   type        = string
-  default     = "t3.small.search"
+  default     = "t4g.small.search"
   description = "Instance type of data nodes in the cluster."
 }
 


### PR DESCRIPTION
updated the instance type, as t3 and t2 instances aren't able to be used for data nodes if warm storage is enabled. See documentation: https://docs.aws.amazon.com/opensearch-service/latest/developerguide/ultrawarm.html#ultrawarm-pp