### PR TITLE
chore: bump timeput for aws_ec2_client_vpn_authorization_rule

### DIFF
--- a/aws/modules/vpn/endpoint.tf
+++ b/aws/modules/vpn/endpoint.tf
@@ -72,7 +72,7 @@ resource "aws_ec2_client_vpn_authorization_rule" "vpn_auth_rule" {
   authorize_all_groups   = true
 
   timeouts {
-    create = "10m"
+    create = "15m"
     delete = "20m"
   }
 }


### PR DESCRIPTION
related to [slack alert](https://camunda.slack.com/archives/C076N4G1162/p1752469789617669).

Typically creation time is about 8 minutes, I'd suggest bumping it a bit to see whether it helps. Likely something on AWS side took too long.

- [ ] backport to 8.7