### PR TITLE
chore: bump timeput for aws_ec2_client_vpn_authorization_rule (#740)

### DIFF
--- a/aws/modules/vpn/endpoint.tf
+++ b/aws/modules/vpn/endpoint.tf
@@ -72,7 +72,7 @@ resource "aws_ec2_client_vpn_authorization_rule" "vpn_auth_rule" {
   authorize_all_groups   = true
 
   timeouts {
-    create = "10m"
+    create = "15m"
     delete = "20m"
   }
 }


### PR DESCRIPTION
backport of https://github.com/camunda/camunda-deployment-references/pull/740