### PR TITLE
chore: downgrade ingress-nginx again

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,4 +2,11 @@
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: ["github>camunda/infraex-common-config:default.json5"],
   groupName: "mono-update-renovate", // we keep all updates in a single renovate branch in order to save CI tests
+  packageRules: [
+    {
+      // we're temporarily ignoring ingress-nginx 4.13.0 as it's been broken for weeks
+      matchPackageNames: ["ingress-nginx"],
+      allowedVersions: "!/^4\\.13\\.0$/"
+    }
+  ]
 }

--- a/generic/kubernetes/single-region/procedure/export-ingress-setup-vars.sh
+++ b/generic/kubernetes/single-region/procedure/export-ingress-setup-vars.sh
@@ -7,7 +7,7 @@ export MAIL=admin@camunda.example.com
 # Helm chart versions for Ingress components
 
 # renovate: datasource=helm depName=ingress-nginx registryUrl=https://kubernetes.github.io/ingress-nginx
-export INGRESS_HELM_CHART_VERSION="4.13.0"
+export INGRESS_HELM_CHART_VERSION="4.12.4"
 # renovate: datasource=helm depName=external-dns registryUrl=https://kubernetes-sigs.github.io/external-dns/
 export EXTERNAL_DNS_HELM_CHART_VERSION="1.18.0"
 # renovate: datasource=helm depName=cert-manager registryUrl=https://charts.jetstack.io


### PR DESCRIPTION
4.13.0 introduced a change that broke the default certificate behaviour.
They have already fixed the issue but they have yet to release a new version with the fix.

I've so far always downgraded it in the renovate PR as it broke. But sometimes it gets in after all as my commit on Monday was somehow completely removed + if pushing quickly after one another then the automerge will bypass all checks.
I've also tried in the past to close the Renovate PR but didn't do anything as we group all dependencies otherwise it would automatically ignore it from Renovate side.

This will ignore this particular version in the renovate config, so it shouldn't appear again + downgrade again.