### PR TITLE
chore: update retry action commit and add whole workflow option

### DIFF
--- a/.github/workflows/aws_openshift_rosa_hcp_dual_region_tests.yml
+++ b/.github/workflows/aws_openshift_rosa_hcp_dual_region_tests.yml
@@ -843,9 +843,10 @@ jobs:
             - cleanup-clusters
         steps:
             - name: Retrigger job
-              uses: camunda/infra-global-github-actions/rerun-failed-run@4c0c3611b80ac8e147f7991092a0e282b52c48fa # main
+              uses: camunda/infra-global-github-actions/rerun-failed-run@4cd17df5142f2645ea896135ff2d7791822a9aaf # main
               with:
                   error-messages: '' # retry no matter the error as we want to ensure that the last retries will trigger the cleanup
+                  rerun-whole-workflow: 'true' # we want to rerun the whole workflow instead of just the failed job, to recreate a new cluster
                   run-id: ${{ github.run_id }}
                   repository: ${{ github.repository }}
                   vault-addr: ${{ secrets.VAULT_ADDR }}


### PR DESCRIPTION
adds the new rerun whole workflow option instead of just rerunning failed jobs.