### PR TITLE
Add log4j2.xml for troubleshooting azure backups logs.

### DIFF
--- a/generic/troubeshooting/log4j2.xml
+++ b/generic/troubeshooting/log4j2.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration xmlns="https://logging.apache.org/xml/ns"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="
+                   https://logging.apache.org/xml/ns
+                   https://logging.apache.org/xml/ns/log4j-config-2.xsd" status="WARN" shutdownHook="disable">
+    <Properties>
+        <Property name="log.path" value="${sys:app.home}/logs" />
+        <Property name="log.pattern" value="[%d{yyyy-MM-dd HH:mm:ss.SSS}] [%t] %notEmpty{[%X] }%-5level%n\t%logger{36} - %msg%n" />
+        <Property name="log.stackdriver.serviceName" value="${env:ZEEBE_LOG_STACKDRIVER_SERVICENAME:-${env:OPERATE_LOG_STACKDRIVER_SERVICENAME:-${env:TASKLIST_LOG_STACKDRIVER_SERVICENAME:-}}}}"/>
+        <Property name="log.stackdriver.serviceVersion" value="${env:ZEEBE_LOG_STACKDRIVER_SERVICEVERSION:-${env:OPERATE_LOG_STACKDRIVER_SERVICEVERSION:-${env:TASKLIST_LOG_STACKDRIVER_SERVICEVERSION:-}}}}"/>
+    </Properties>
+
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout
+                    pattern="${log.pattern}"/>
+        </Console>
+
+        <Console name="Stackdriver" target="SYSTEM_OUT">
+            <StackdriverLayout serviceName="${log.stackdriver.serviceName}"
+                               serviceVersion="${log.stackdriver.serviceVersion}"/>
+        </Console>
+
+        <!--
+          The conditional inclusion of the appender is done here, and not on the AppenderRef, because if
+          we only do it on the AppenderRef, the declaration of the appender here still causes Log4j2 to
+          create the directory structure, the log file, etc., though we won't write to it.
+
+          By conditionally including the appender itself, and providing a dummy `Null` otherwise, we can
+          then avoid this altogether.
+          -->
+        <Select>
+            <EnvironmentArbiter propertyName="CAMUNDA_LOG_FILE_APPENDER_ENABLED" propertyValue="false">
+                <Null name="RollingFile" />
+            </EnvironmentArbiter>
+            <DefaultArbiter>
+                <RollingFile name="RollingFile" fileName="${log.path}/zeebe.log"
+                             filePattern="${log.path}/zeebe-%d{yyyy-MM-dd}-%i.log.gz">
+                    <PatternLayout pattern="${log.pattern}" />
+                    <Policies>
+                        <TimeBasedTriggeringPolicy/>
+                        <SizeBasedTriggeringPolicy size="250 MB"/>
+                    </Policies>
+                </RollingFile>
+            </DefaultArbiter>
+        </Select>
+    </Appenders>
+
+    <Loggers>
+        <Logger name="io.camunda" level="${env:CAMUNDA_LOG_LEVEL:-INFO}" />
+        <Logger name="io.camunda.zeebe" level="${env:ZEEBE_LOG_LEVEL:-${env:CAMUNDA_LOG_LEVEL:-INFO}}" />
+        <Logger name="io.atomix" level="${env:ATOMIX_LOG_LEVEL:-${env:CAMUNDA_LOG_LEVEL:-INFO}}" />
+        <Logger name="org.elasticsearch" level="${env:ES_LOG_LEVEL:-WARN}" />
+        <Logger name="org.springframework" level="INFO" />
+        <Logger name="com.azure" level="DEBUG" />
+
+        <Root level="WARN">
+            <AppenderRef ref="RollingFile" />
+
+            <!-- remove to disable console logging -->
+            <AppenderRef ref="${env:ZEEBE_LOG_APPENDER:-${env:OPERATE_LOG_APPENDER:-${env:TASKLIST_LOG_APPENDER:-Console}}}"/>
+        </Root>
+    </Loggers>
+
+</Configuration>


### PR DESCRIPTION
This will be referenced in this docs pull request https://github.com/camunda/camunda-docs/pull/6399.

This reference is going to be used as a file reference in the Camunda docs troubleshooting section to enable to debug Azure logs during Azure backups.

This file was created under generic -> troubleshooting directory, hopefully this makes sense.