### PR TITLE
feat: add config flap / drift detection for tf

### DIFF
--- a/.github/actions/aws-aurora-manage-cluster/action.yml
+++ b/.github/actions/aws-aurora-manage-cluster/action.yml
@@ -160,9 +160,9 @@ runs:
           with:
               raw-tags: ${{ inputs.tags }}
 
-        - name: Terraform Plan
+        - name: Generate tfvars file
+          id: generate-tfvars
           shell: bash
-          id: plan
           working-directory: ${{ inputs.tf-modules-path }}/aws/modules/aurora/
           run: |
               set -euo pipefail
@@ -170,17 +170,28 @@ runs:
               # protect sensitive values
               echo "::add-mask::${{ inputs.password }}"
 
+              cat > terraform.tfvars <<EOF
+              default_tags = ${{ steps.sanitize-tags.outputs.sanitized_tags }}
+              cluster_name = "${{ inputs.cluster-name }}"
+              username     = "${{ inputs.username }}"
+              password     = "${{ inputs.password }}"
+              availability_zones = ${{ inputs.availability-zones }}
+              vpc_id       = "${{ inputs.vpc-id }}"
+              subnet_ids   = ${{ inputs.subnet-ids }}
+              cidr_blocks  = ${{ inputs.cidr-blocks }}
+              EOF
+
+        - name: Terraform Plan
+          shell: bash
+          id: plan
+          working-directory: ${{ inputs.tf-modules-path }}/aws/modules/aurora/
+          run: |
+              set -euo pipefail
+
               echo '${{ inputs.additional-terraform-vars }}' > /tmp/var.tfvars.json
               terraform plan -no-color -out aurora.plan \
-                -var 'default_tags=${{ steps.sanitize-tags.outputs.sanitized_tags }}' \
                 -var-file=/tmp/var.tfvars.json \
-                -var "cluster_name=${{ inputs.cluster-name }}" \
-                -var "username=${{ inputs.username }}" \
-                -var "password=${{ inputs.password }}" \
-                -var 'availability_zones=${{ inputs.availability-zones }}' \
-                -var "vpc_id=${{ inputs.vpc-id }}" \
-                -var 'subnet_ids=${{ inputs.subnet-ids }}' \
-                -var 'cidr_blocks=${{ inputs.cidr-blocks }}'
+                -var-file=terraform.tfvars
 
         - name: Terraform Apply
           shell: bash
@@ -199,15 +210,8 @@ runs:
           with:
               working-directory: ${{ inputs.tf-modules-path }}/aws/modules/aurora/
               plan-extra-args: |
-                  -var 'default_tags=${{ steps.sanitize-tags.outputs.sanitized_tags }}' \
                   -var-file=/tmp/var.tfvars.json \
-                  -var 'cluster_name=${{ inputs.cluster-name }}' \
-                  -var 'username=${{ inputs.username }}' \
-                  -var 'password=${{ inputs.password }}' \
-                  -var 'availability_zones=${{ inputs.availability-zones }}' \
-                  -var 'vpc_id=${{ inputs.vpc-id }}' \
-                  -var 'subnet_ids=${{ inputs.subnet-ids }}' \
-                  -var 'cidr_blocks=${{ inputs.cidr-blocks }}' \
+                  -var-file=terraform.tfvars \
 
         - name: Fetch Terraform Outputs
           shell: bash

--- a/.github/actions/aws-aurora-manage-cluster/action.yml
+++ b/.github/actions/aws-aurora-manage-cluster/action.yml
@@ -193,6 +193,41 @@ runs:
               export aurora_endpoint="$(terraform output -raw aurora_endpoint)"
               echo "aurora_endpoint=$aurora_endpoint" >> "$GITHUB_OUTPUT"
 
+        - name: Terraform Drift Detection
+          id: drift-detect
+          working-directory: ${{ inputs.tf-modules-path }}/aws/modules/aurora/
+          shell: bash
+          run: |
+              set -euo pipefail
+              echo "Running post-apply drift detection..."
+              # Re-run a plan with detailed exit code to see if anything still wants to change.
+              # Exit codes: 0 = no changes, 2 = changes present, 1 = error
+              set +e
+              terraform plan -no-color -detailed-exitcode \
+                -var 'default_tags=${{ steps.sanitize-tags.outputs.sanitized_tags }}' \
+                -var-file=/tmp/var.tfvars.json \
+                -var "cluster_name=${{ inputs.cluster-name }}" \
+                -var "username=${{ inputs.username }}" \
+                -var "password=${{ inputs.password }}" \
+                -var 'availability_zones=${{ inputs.availability-zones }}' \
+                -var "vpc_id=${{ inputs.vpc-id }}" \
+                -var 'subnet_ids=${{ inputs.subnet-ids }}' \
+                -var 'cidr_blocks=${{ inputs.cidr-blocks }}' > drift.plan.out 2>&1
+              code=$?
+              set -e
+              echo '--- Drift Plan Output Start ---'
+              cat drift.plan.out
+              echo '--- Drift Plan Output End ---'
+              if [ $code -eq 0 ]; then
+                  echo "No drift detected after apply.";
+              elif [ $code -eq 2 ]; then
+                  echo "::error::Drift detected immediately after apply (configuration flapping). Failing the workflow.";
+                  exit 1
+              else
+                  echo "::error::Drift detection plan failed (exit code $code).";
+                  exit $code
+              fi
+
         - name: Fetch Terraform Outputs
           shell: bash
           id: fetch_outputs

--- a/.github/actions/aws-aurora-manage-cluster/action.yml
+++ b/.github/actions/aws-aurora-manage-cluster/action.yml
@@ -207,7 +207,7 @@ runs:
                   -var 'availability_zones=${{ inputs.availability-zones }}' \
                   -var "vpc_id=${{ inputs.vpc-id }}" \
                   -var 'subnet_ids=${{ inputs.subnet-ids }}' \
-                  -var 'cidr_blocks=${{ inputs.cidr-blocks }}'
+                  -var 'cidr_blocks=${{ inputs.cidr-blocks }}' \
 
         - name: Fetch Terraform Outputs
           shell: bash

--- a/.github/actions/aws-aurora-manage-cluster/action.yml
+++ b/.github/actions/aws-aurora-manage-cluster/action.yml
@@ -194,39 +194,20 @@ runs:
               echo "aurora_endpoint=$aurora_endpoint" >> "$GITHUB_OUTPUT"
 
         - name: Terraform Drift Detection
+          uses: ./.github/actions/internal-terraform-drift-detect
           id: drift-detect
-          working-directory: ${{ inputs.tf-modules-path }}/aws/modules/aurora/
-          shell: bash
-          run: |
-              set -euo pipefail
-              echo "Running post-apply drift detection..."
-              # Re-run a plan with detailed exit code to see if anything still wants to change.
-              # Exit codes: 0 = no changes, 2 = changes present, 1 = error
-              set +e
-              terraform plan -no-color -detailed-exitcode \
-                -var 'default_tags=${{ steps.sanitize-tags.outputs.sanitized_tags }}' \
-                -var-file=/tmp/var.tfvars.json \
-                -var "cluster_name=${{ inputs.cluster-name }}" \
-                -var "username=${{ inputs.username }}" \
-                -var "password=${{ inputs.password }}" \
-                -var 'availability_zones=${{ inputs.availability-zones }}' \
-                -var "vpc_id=${{ inputs.vpc-id }}" \
-                -var 'subnet_ids=${{ inputs.subnet-ids }}' \
-                -var 'cidr_blocks=${{ inputs.cidr-blocks }}' > drift.plan.out 2>&1
-              code=$?
-              set -e
-              echo '--- Drift Plan Output Start ---'
-              cat drift.plan.out
-              echo '--- Drift Plan Output End ---'
-              if [ $code -eq 0 ]; then
-                  echo "No drift detected after apply.";
-              elif [ $code -eq 2 ]; then
-                  echo "::error::Drift detected immediately after apply (configuration flapping). Failing the workflow.";
-                  exit 1
-              else
-                  echo "::error::Drift detection plan failed (exit code $code).";
-                  exit $code
-              fi
+          with:
+              working-directory: ${{ inputs.tf-modules-path }}/aws/modules/aurora/
+              plan-extra-args: |
+                  -var 'default_tags=${{ steps.sanitize-tags.outputs.sanitized_tags }}' \
+                  -var-file=/tmp/var.tfvars.json \
+                  -var "cluster_name=${{ inputs.cluster-name }}" \
+                  -var "username=${{ inputs.username }}" \
+                  -var "password=${{ inputs.password }}" \
+                  -var 'availability_zones=${{ inputs.availability-zones }}' \
+                  -var "vpc_id=${{ inputs.vpc-id }}" \
+                  -var 'subnet_ids=${{ inputs.subnet-ids }}' \
+                  -var 'cidr_blocks=${{ inputs.cidr-blocks }}'
 
         - name: Fetch Terraform Outputs
           shell: bash

--- a/.github/actions/aws-aurora-manage-cluster/action.yml
+++ b/.github/actions/aws-aurora-manage-cluster/action.yml
@@ -201,11 +201,11 @@ runs:
               plan-extra-args: |
                   -var 'default_tags=${{ steps.sanitize-tags.outputs.sanitized_tags }}' \
                   -var-file=/tmp/var.tfvars.json \
-                  -var "cluster_name=${{ inputs.cluster-name }}" \
-                  -var "username=${{ inputs.username }}" \
-                  -var "password=${{ inputs.password }}" \
+                  -var 'cluster_name=${{ inputs.cluster-name }}' \
+                  -var 'username=${{ inputs.username }}' \
+                  -var 'password=${{ inputs.password }}' \
                   -var 'availability_zones=${{ inputs.availability-zones }}' \
-                  -var "vpc_id=${{ inputs.vpc-id }}" \
+                  -var 'vpc_id=${{ inputs.vpc-id }}' \
                   -var 'subnet_ids=${{ inputs.subnet-ids }}' \
                   -var 'cidr_blocks=${{ inputs.cidr-blocks }}' \
 

--- a/.github/actions/aws-compute-ec2-single-region-create/action.yml
+++ b/.github/actions/aws-compute-ec2-single-region-create/action.yml
@@ -104,6 +104,18 @@ runs:
           with:
               raw-tags: ${{ inputs.tags }}
 
+        - name: Generate tfvars file
+          id: generate-tfvars
+          shell: bash
+          working-directory: ${{ inputs.tf-modules-path }}/aws/compute/${{ inputs.ref-arch }}/terraform/${{ inputs.tf-modules-name }}
+          run: |
+              set -euo pipefail
+
+              cat > terraform.tfvars <<EOF
+              default_tags = ${{ steps.sanitize-tags.outputs.sanitized_tags }}
+              prefix       = "${{ inputs.cluster-name }}"
+              EOF
+
         - name: Terraform Plan
           id: plan
           working-directory: ${{ inputs.tf-modules-path }}/aws/compute/${{ inputs.ref-arch }}/terraform/${{ inputs.tf-modules-name }}
@@ -113,8 +125,7 @@ runs:
               export AWS_REGION="${{ inputs.aws-region }}"
 
               terraform plan -no-color \
-                -var='default_tags=${{ steps.sanitize-tags.outputs.sanitized_tags }}' \
-                -var='prefix=${{ inputs.cluster-name }}' \
+                -var-file=terraform.tfvars \
                 -out tf.plan
 
         - name: Terraform Apply
@@ -131,5 +142,4 @@ runs:
           with:
               working-directory: ${{ inputs.tf-modules-path }}/aws/compute/${{ inputs.ref-arch }}/terraform/${{ inputs.tf-modules-name }}
               plan-extra-args: |
-                  -var='default_tags=${{ steps.sanitize-tags.outputs.sanitized_tags }}' \
-                  -var='prefix=${{ inputs.cluster-name }}' \
+                  -var-file=terraform.tfvars \

--- a/.github/actions/aws-compute-ec2-single-region-create/action.yml
+++ b/.github/actions/aws-compute-ec2-single-region-create/action.yml
@@ -132,4 +132,4 @@ runs:
               working-directory: ${{ inputs.tf-modules-path }}/aws/compute/${{ inputs.ref-arch }}/terraform/${{ inputs.tf-modules-name }}
               plan-extra-args: |
                   -var='default_tags=${{ steps.sanitize-tags.outputs.sanitized_tags }}' \
-                  -var='prefix=${{ inputs.cluster-name }}'
+                  -var='prefix=${{ inputs.cluster-name }}' \

--- a/.github/actions/aws-compute-ec2-single-region-create/action.yml
+++ b/.github/actions/aws-compute-ec2-single-region-create/action.yml
@@ -126,29 +126,10 @@ runs:
               terraform apply -no-color tf.plan
 
         - name: Terraform Drift Detection
+          uses: ./.github/actions/internal-terraform-drift-detect
           id: drift-detect
-          working-directory: ${{ inputs.tf-modules-path }}/aws/compute/${{ inputs.ref-arch }}/terraform/${{ inputs.tf-modules-name }}
-          shell: bash
-          run: |
-              set -euo pipefail
-              echo "Running post-apply drift detection..."
-              # Re-run a plan with detailed exit code to see if anything still wants to change.
-              # Exit codes: 0 = no changes, 2 = changes present, 1 = error
-              set +e
-              terraform plan -no-color -detailed-exitcode \
+          with:
+              working-directory: ${{ inputs.tf-modules-path }}/aws/compute/${{ inputs.ref-arch }}/terraform/${{ inputs.tf-modules-name }}
+              plan-extra-args: |
                   -var='default_tags=${{ steps.sanitize-tags.outputs.sanitized_tags }}' \
-                  -var='prefix=${{ inputs.cluster-name }}' > drift.plan.out 2>&1
-              code=$?
-              set -e
-              echo '--- Drift Plan Output Start ---'
-              cat drift.plan.out
-              echo '--- Drift Plan Output End ---'
-              if [ $code -eq 0 ]; then
-                  echo "No drift detected after apply.";
-              elif [ $code -eq 2 ]; then
-                  echo "::error::Drift detected immediately after apply (configuration flapping). Failing the workflow.";
-                  exit 1
-              else
-                  echo "::error::Drift detection plan failed (exit code $code).";
-                  exit $code
-              fi
+                  -var='prefix=${{ inputs.cluster-name }}'

--- a/.github/actions/aws-compute-ec2-single-region-create/action.yml
+++ b/.github/actions/aws-compute-ec2-single-region-create/action.yml
@@ -124,3 +124,31 @@ runs:
           run: |
               set -euo pipefail
               terraform apply -no-color tf.plan
+
+        - name: Terraform Drift Detection
+          id: drift-detect
+          working-directory: ${{ inputs.tf-modules-path }}/aws/compute/${{ inputs.ref-arch }}/terraform/${{ inputs.tf-modules-name }}
+          shell: bash
+          run: |
+              set -euo pipefail
+              echo "Running post-apply drift detection..."
+              # Re-run a plan with detailed exit code to see if anything still wants to change.
+              # Exit codes: 0 = no changes, 2 = changes present, 1 = error
+              set +e
+              terraform plan -no-color -detailed-exitcode \
+                  -var='default_tags=${{ steps.sanitize-tags.outputs.sanitized_tags }}' \
+                  -var='prefix=${{ inputs.cluster-name }}' > drift.plan.out 2>&1
+              code=$?
+              set -e
+              echo '--- Drift Plan Output Start ---'
+              cat drift.plan.out
+              echo '--- Drift Plan Output End ---'
+              if [ $code -eq 0 ]; then
+                  echo "No drift detected after apply.";
+              elif [ $code -eq 2 ]; then
+                  echo "::error::Drift detected immediately after apply (configuration flapping). Failing the workflow.";
+                  exit 1
+              else
+                  echo "::error::Drift detection plan failed (exit code $code).";
+                  exit $code
+              fi

--- a/.github/actions/aws-kubernetes-eks-single-region-create/action.yml
+++ b/.github/actions/aws-kubernetes-eks-single-region-create/action.yml
@@ -153,6 +153,33 @@ runs:
               set -euo pipefail
               terraform apply -no-color tf.plan
 
+        - name: Terraform Drift Detection
+          id: drift-detect
+          working-directory: ${{ inputs.tf-modules-path }}/aws/kubernetes/${{ inputs.ref-arch }}/
+          shell: bash
+          run: |
+              set -euo pipefail
+              echo "Running post-apply drift detection..."
+              # Re-run a plan with detailed exit code to see if anything still wants to change.
+              # Exit codes: 0 = no changes, 2 = changes present, 1 = error
+              set +e
+              terraform plan -no-color -detailed-exitcode \
+                  -var='default_tags=${{ steps.sanitize-tags.outputs.sanitized_tags }}' > drift.plan.out 2>&1
+              code=$?
+              set -e
+              echo '--- Drift Plan Output Start ---'
+              cat drift.plan.out
+              echo '--- Drift Plan Output End ---'
+              if [ $code -eq 0 ]; then
+                  echo "No drift detected after apply.";
+              elif [ $code -eq 2 ]; then
+                  echo "::error::Drift detected immediately after apply (configuration flapping). Failing the workflow.";
+                  exit 1
+              else
+                  echo "::error::Drift detection plan failed (exit code $code).";
+                  exit $code
+              fi
+
         - name: Login and generate kubeconfig
           if: inputs.login == 'true'
           shell: bash

--- a/.github/actions/aws-kubernetes-eks-single-region-create/action.yml
+++ b/.github/actions/aws-kubernetes-eks-single-region-create/action.yml
@@ -159,7 +159,7 @@ runs:
           with:
               working-directory: ${{ inputs.tf-modules-path }}/aws/kubernetes/${{ inputs.ref-arch }}/
               plan-extra-args: |
-                  -var="default_tags=${{ steps.sanitize-tags.outputs.sanitized_tags }}" \
+                  -var='default_tags=${{ steps.sanitize-tags.outputs.sanitized_tags }}' \
 
         - name: Login and generate kubeconfig
           if: inputs.login == 'true'

--- a/.github/actions/aws-kubernetes-eks-single-region-create/action.yml
+++ b/.github/actions/aws-kubernetes-eks-single-region-create/action.yml
@@ -57,7 +57,7 @@ runs:
     using: composite
     steps:
         - name: Checkout Repository
-          uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+          uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
           with:
               repository: camunda/camunda-deployment-references
               ref: ${{ inputs.tf-modules-revision }}
@@ -154,31 +154,12 @@ runs:
               terraform apply -no-color tf.plan
 
         - name: Terraform Drift Detection
+          uses: ./.github/actions/internal-terraform-drift-detect
           id: drift-detect
-          working-directory: ${{ inputs.tf-modules-path }}/aws/kubernetes/${{ inputs.ref-arch }}/
-          shell: bash
-          run: |
-              set -euo pipefail
-              echo "Running post-apply drift detection..."
-              # Re-run a plan with detailed exit code to see if anything still wants to change.
-              # Exit codes: 0 = no changes, 2 = changes present, 1 = error
-              set +e
-              terraform plan -no-color -detailed-exitcode \
-                  -var='default_tags=${{ steps.sanitize-tags.outputs.sanitized_tags }}' > drift.plan.out 2>&1
-              code=$?
-              set -e
-              echo '--- Drift Plan Output Start ---'
-              cat drift.plan.out
-              echo '--- Drift Plan Output End ---'
-              if [ $code -eq 0 ]; then
-                  echo "No drift detected after apply.";
-              elif [ $code -eq 2 ]; then
-                  echo "::error::Drift detected immediately after apply (configuration flapping). Failing the workflow.";
-                  exit 1
-              else
-                  echo "::error::Drift detection plan failed (exit code $code).";
-                  exit $code
-              fi
+          with:
+              working-directory: ${{ inputs.tf-modules-path }}/aws/kubernetes/${{ inputs.ref-arch }}/
+              plan-extra-args: |
+                  -var="default_tags=${{ steps.sanitize-tags.outputs.sanitized_tags }}"
 
         - name: Login and generate kubeconfig
           if: inputs.login == 'true'

--- a/.github/actions/aws-kubernetes-eks-single-region-create/action.yml
+++ b/.github/actions/aws-kubernetes-eks-single-region-create/action.yml
@@ -110,6 +110,17 @@ runs:
           with:
               raw-tags: ${{ inputs.tags }}
 
+        - name: Generate tfvars file
+          id: generate-tfvars
+          shell: bash
+          working-directory: ${{ inputs.tf-modules-path }}/aws/kubernetes/${{ inputs.ref-arch }}/
+          run: |
+              set -euo pipefail
+
+              cat > terraform.tfvars <<EOF
+              default_tags = ${{ steps.sanitize-tags.outputs.sanitized_tags }}
+              EOF
+
         - name: Terraform Plan
           id: plan
           working-directory: ${{ inputs.tf-modules-path }}/aws/kubernetes/${{ inputs.ref-arch }}/
@@ -143,7 +154,7 @@ runs:
               echo "Displaying templated opensearch.tf file:"
               cat opensearch.tf
 
-              terraform plan -no-color -var='default_tags=${{ steps.sanitize-tags.outputs.sanitized_tags }}' -out tf.plan
+              terraform plan -no-color -var-file=terraform.tfvars -out tf.plan
 
         - name: Terraform Apply
           id: apply
@@ -159,7 +170,7 @@ runs:
           with:
               working-directory: ${{ inputs.tf-modules-path }}/aws/kubernetes/${{ inputs.ref-arch }}/
               plan-extra-args: |
-                  -var='default_tags=${{ steps.sanitize-tags.outputs.sanitized_tags }}' \
+                  -var-file=terraform.tfvars \
 
         - name: Login and generate kubeconfig
           if: inputs.login == 'true'

--- a/.github/actions/aws-kubernetes-eks-single-region-create/action.yml
+++ b/.github/actions/aws-kubernetes-eks-single-region-create/action.yml
@@ -159,7 +159,7 @@ runs:
           with:
               working-directory: ${{ inputs.tf-modules-path }}/aws/kubernetes/${{ inputs.ref-arch }}/
               plan-extra-args: |
-                  -var="default_tags=${{ steps.sanitize-tags.outputs.sanitized_tags }}"
+                  -var="default_tags=${{ steps.sanitize-tags.outputs.sanitized_tags }}" \
 
         - name: Login and generate kubeconfig
           if: inputs.login == 'true'

--- a/.github/actions/aws-kubernetes-eks-single-region-create/action.yml
+++ b/.github/actions/aws-kubernetes-eks-single-region-create/action.yml
@@ -57,7 +57,7 @@ runs:
     using: composite
     steps:
         - name: Checkout Repository
-          uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+          uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
           with:
               repository: camunda/camunda-deployment-references
               ref: ${{ inputs.tf-modules-revision }}

--- a/.github/actions/aws-openshift-rosa-hcp-dual-region-create/action.yml
+++ b/.github/actions/aws-openshift-rosa-hcp-dual-region-create/action.yml
@@ -353,34 +353,15 @@ runs:
 
         - name: Terraform Drift Detection - Clusters
           id: drift-detect-clusters
-          working-directory: ${{ inputs.tf-modules-path }}/aws/openshift/rosa-hcp-dual-region/terraform/clusters/
+          uses: ./.github/actions/internal-terraform-drift-detect
+          with:
+              working-directory: ${{ inputs.tf-modules-path }}/aws/openshift/rosa-hcp-dual-region/terraform/clusters/
+              plan-extra-args: |
+                  -var='default_tags=${{ steps.sanitize-tags.outputs.sanitized_tags }}' \
+                  -var="cluster_1_region=${{ inputs.aws-region-cluster-1 }}" \
+                  -var="cluster_2_region=${{ inputs.aws-region-cluster-2 }}"
           env:
               RHCS_TOKEN: ${{ inputs.rh-token }}
-          shell: bash
-          run: |
-              set -euo pipefail
-              echo "Running post-apply drift detection..."
-              # Re-run a plan with detailed exit code to see if anything still wants to change.
-              # Exit codes: 0 = no changes, 2 = changes present, 1 = error
-              set +e
-              terraform plan -no-color -detailed-exitcode \
-                -var='default_tags=${{ steps.sanitize-tags.outputs.sanitized_tags }}' \
-                -var="cluster_1_region=${{ inputs.aws-region-cluster-1 }}" \
-                -var="cluster_2_region=${{ inputs.aws-region-cluster-2 }}" > drift.plan.out 2>&1
-              code=$?
-              set -e
-              echo '--- Drift Plan Output Start ---'
-              cat drift.plan.out
-              echo '--- Drift Plan Output End ---'
-              if [ $code -eq 0 ]; then
-                  echo "No drift detected after apply.";
-              elif [ $code -eq 2 ]; then
-                  echo "::error::Drift detected immediately after apply (configuration flapping). Failing the workflow.";
-                  exit 1
-              else
-                  echo "::error::Drift detection plan failed (exit code $code).";
-                  exit $code
-              fi
 
         - name: Login and generate kubeconfig on the clusters
           # we need to retry due as the cluster has just been created and the OIDC provider may not be available yet
@@ -495,34 +476,15 @@ runs:
         - name: Terraform Drift Detection - Peering
           if: inputs.enable-vpc-peering == 'true'
           id: drift-detect-peering
-          working-directory: ${{ inputs.tf-modules-path }}/aws/openshift/rosa-hcp-dual-region/terraform/peering/
-          shell: bash
-          run: |
-              set -euo pipefail
-              echo "Running post-apply drift detection..."
-              # Re-run a plan with detailed exit code to see if anything still wants to change.
-              # Exit codes: 0 = no changes, 2 = changes present, 1 = error
-              set +e
-              terraform init -no-color -detailed-exitcode \
-                -backend-config="bucket=${{ steps.set-terraform-variables.outputs.TFSTATE_BUCKET }}" \
-                -backend-config="region=${{ steps.set-terraform-variables.outputs.TFSTATE_REGION }}" \
-                -backend-config="key=$terraform_state_key"  \
-                -var="cluster_1_region=${{ inputs.aws-region-cluster-1 }}" \
-                -var="cluster_2_region=${{ inputs.aws-region-cluster-2 }}" > drift.plan.out 2>&1
-              code=$?
-              set -e
-              echo '--- Drift Plan Output Start ---'
-              cat drift.plan.out
-              echo '--- Drift Plan Output End ---'
-              if [ $code -eq 0 ]; then
-                  echo "No drift detected after apply.";
-              elif [ $code -eq 2 ]; then
-                  echo "::error::Drift detected immediately after apply (configuration flapping). Failing the workflow.";
-                  exit 1
-              else
-                  echo "::error::Drift detection plan failed (exit code $code).";
-                  exit $code
-              fi
+          uses: ./.github/actions/internal-terraform-drift-detect
+          with:
+              working-directory: ${{ inputs.tf-modules-path }}/aws/openshift/rosa-hcp-dual-region/terraform/peering/
+              plan-extra-args: |
+                  -backend-config="bucket=${{ steps.set-terraform-variables.outputs.TFSTATE_BUCKET }}" \
+                  -backend-config="region=${{ steps.set-terraform-variables.outputs.TFSTATE_REGION }}" \
+                  -backend-config="key=$terraform_state_key"  \
+                  -var="cluster_1_region=${{ inputs.aws-region-cluster-1 }}" \
+                  -var="cluster_2_region=${{ inputs.aws-region-cluster-2 }}"
 
       ### Backup bucket
 
@@ -591,31 +553,12 @@ runs:
         - name: Terraform Drift Detection - Backup Bucket
           if: inputs.enable-backup-bucket == 'true'
           id: drift-detect-backup-bucket
-          working-directory: ${{ inputs.tf-modules-path }}/aws/openshift/rosa-hcp-dual-region/terraform/backup_bucket/
-          shell: bash
-          run: |
-              set -euo pipefail
-              echo "Running post-apply drift detection..."
-              # Re-run a plan with detailed exit code to see if anything still wants to change.
-              # Exit codes: 0 = no changes, 2 = changes present, 1 = error
-              set +e
-              terraform plan -no-color -detailed-exitcode \
-                -var='default_tags=${{ steps.sanitize-tags.outputs.sanitized_tags }}' \
-                -var="bucket_name=cb-${{ steps.plan-backup-bucket.outputs.HASH }}" > drift.plan.out 2>&1
-              code=$?
-              set -e
-              echo '--- Drift Plan Output Start ---'
-              cat drift.plan.out
-              echo '--- Drift Plan Output End ---'
-              if [ $code -eq 0 ]; then
-                  echo "No drift detected after apply.";
-              elif [ $code -eq 2 ]; then
-                  echo "::error::Drift detected immediately after apply (configuration flapping). Failing the workflow.";
-                  exit 1
-              else
-                  echo "::error::Drift detection plan failed (exit code $code).";
-                  exit $code
-              fi
+          uses: ./.github/actions/internal-terraform-drift-detect
+          with:
+              working-directory: ${{ inputs.tf-modules-path }}/aws/openshift/rosa-hcp-dual-region/terraform/backup_bucket/
+              plan-extra-args: |
+                  -var='default_tags=${{ steps.sanitize-tags.outputs.sanitized_tags }}' \
+                  -var="bucket_name=cb-${{ steps.plan-backup-bucket.outputs.HASH }}"
 
         - name: Clean up cloned modules
           if: always() && inputs.cleanup-tf-modules-path == 'true'

--- a/.github/actions/aws-openshift-rosa-hcp-dual-region-create/action.yml
+++ b/.github/actions/aws-openshift-rosa-hcp-dual-region-create/action.yml
@@ -265,6 +265,19 @@ runs:
           with:
               raw-tags: ${{ inputs.tags }}
 
+        - name: Generate tfvars file - Clusters
+          id: generate-tfvars-clusters
+          shell: bash
+          working-directory: ${{ inputs.tf-modules-path }}/aws/openshift/rosa-hcp-dual-region/terraform/clusters/
+          run: |
+              set -euo pipefail
+
+              cat > terraform.tfvars <<EOF
+              default_tags = ${{ steps.sanitize-tags.outputs.sanitized_tags }}
+              cluster_1_region=${{ inputs.aws-region-cluster-1 }}
+              cluster_2_region=${{ inputs.aws-region-cluster-2 }}
+              EOF
+
         - name: Terraform Plan - Clusters
           id: plan-clusters
           working-directory: ${{ inputs.tf-modules-path }}/aws/openshift/rosa-hcp-dual-region/terraform/clusters/
@@ -323,9 +336,7 @@ runs:
               cat cluster_region_2.tf
 
               terraform plan -no-color -out clusters.plan  \
-                -var='default_tags=${{ steps.sanitize-tags.outputs.sanitized_tags }}' \
-                -var="cluster_1_region=${{ inputs.aws-region-cluster-1 }}" \
-                -var="cluster_2_region=${{ inputs.aws-region-cluster-2 }}"
+                -var-file=terraform.tfvars
 
         - name: Terraform Apply - Clusters
           id: apply-clusters
@@ -357,9 +368,7 @@ runs:
           with:
               working-directory: ${{ inputs.tf-modules-path }}/aws/openshift/rosa-hcp-dual-region/terraform/clusters/
               plan-extra-args: |
-                  -var='default_tags=${{ steps.sanitize-tags.outputs.sanitized_tags }}' \
-                  -var='cluster_1_region=${{ inputs.aws-region-cluster-1 }}' \
-                  -var='cluster_2_region=${{ inputs.aws-region-cluster-2 }}' \
+                  -var-file=terraform.tfvars \
               fail-on-drift: 'false' # not failing on drift as there may be an expected drift due to hcp module drifting - cluster_console_url
           env:
               RHCS_TOKEN: ${{ inputs.rh-token }}
@@ -450,6 +459,21 @@ runs:
 
               terraform validate -no-color
 
+        - name: Generate tfvars file - Peering
+          id: generate-tfvars-peering
+          shell: bash
+          working-directory: ${{ inputs.tf-modules-path }}/aws/openshift/rosa-hcp-dual-region/terraform/peering/
+          run: |
+              set -euo pipefail
+
+              cat > terraform.tfvars <<EOF
+              default_tags = ${{ steps.sanitize-tags.outputs.sanitized_tags }}
+              cluster_1_region=${{ inputs.aws-region-cluster-1 }}
+              cluster_2_region=${{ inputs.aws-region-cluster-2 }}
+              cluster_1_vpc_id=${{ steps.apply-clusters.outputs.cluster_1_vpc_id }}
+              cluster_2_vpc_id=${{ steps.apply-clusters.outputs.cluster_2_vpc_id }}
+              EOF
+
         - name: Terraform Plan - Peering
           id: plan-peering
           if: inputs.enable-vpc-peering == 'true'
@@ -459,12 +483,7 @@ runs:
               set -euo pipefail
 
               terraform plan -no-color -out peering.plan \
-                -var='default_tags=${{ steps.sanitize-tags.outputs.sanitized_tags }}' \
-                -var="cluster_1_region=${{ inputs.aws-region-cluster-1 }}" \
-                -var="cluster_2_region=${{ inputs.aws-region-cluster-2 }}" \
-                -var="cluster_1_vpc_id=${{ steps.apply-clusters.outputs.cluster_1_vpc_id }}" \
-                -var="cluster_2_vpc_id=${{ steps.apply-clusters.outputs.cluster_2_vpc_id }}"
-
+                -var-file=terraform.tfvars
 
         - name: Terraform Apply - Peering
           id: apply-peering
@@ -481,11 +500,7 @@ runs:
           with:
               working-directory: ${{ inputs.tf-modules-path }}/aws/openshift/rosa-hcp-dual-region/terraform/peering/
               plan-extra-args: |
-                  -var='default_tags=${{ steps.sanitize-tags.outputs.sanitized_tags }}' \
-                  -var="cluster_1_region=${{ inputs.aws-region-cluster-1 }}" \
-                  -var="cluster_2_region=${{ inputs.aws-region-cluster-2 }}" \
-                  -var="cluster_1_vpc_id=${{ steps.apply-clusters.outputs.cluster_1_vpc_id }}" \
-                  -var="cluster_2_vpc_id=${{ steps.apply-clusters.outputs.cluster_2_vpc_id }}" \
+                  -var-file=terraform.tfvars \
 
       ### Backup bucket
 
@@ -512,6 +527,20 @@ runs:
 
               terraform validate -no-color
 
+        - name: Generate tfvars file - Backup bucket
+          id: generate-tfvars-backup-bucket
+          shell: bash
+          working-directory: ${{ inputs.tf-modules-path }}/aws/openshift/rosa-hcp-dual-region/terraform/backup_bucket/
+          run: |
+              set -euo pipefail
+
+              hash=$(echo -n "${{ inputs.cluster-name-1 }}-oOo-${{ inputs.cluster-name-2 }}" | sha256sum | cut -c1-8)
+
+              cat > terraform.tfvars <<EOF
+              default_tags = ${{ steps.sanitize-tags.outputs.sanitized_tags }}
+              bucket_name=cb-${hash}
+              EOF
+
         - name: Terraform Plan - Backup bucket
           id: plan-backup-bucket
           if: inputs.enable-backup-bucket == 'true'
@@ -522,13 +551,8 @@ runs:
           run: |
               set -euo pipefail
 
-              hash=$(echo -n "${{ inputs.cluster-name-1 }}-oOo-${{ inputs.cluster-name-2 }}" | sha256sum | cut -c1-8)
-
-              echo "HASH=$hash" | tee -a "$GITHUB_OUTPUT"
-
               terraform plan -no-color -out  backup_bucket.plan \
-                -var='default_tags=${{ steps.sanitize-tags.outputs.sanitized_tags }}' \
-                -var="bucket_name=cb-${hash}"
+                -var-file=terraform.tfvars
 
         - name: Terraform Apply - Backup bucket
           id: apply-backup-bucket
@@ -558,8 +582,7 @@ runs:
           with:
               working-directory: ${{ inputs.tf-modules-path }}/aws/openshift/rosa-hcp-dual-region/terraform/backup_bucket/
               plan-extra-args: |
-                  -var='default_tags=${{ steps.sanitize-tags.outputs.sanitized_tags }}' \
-                  -var='bucket_name=cb-${{ steps.plan-backup-bucket.outputs.HASH }}' \
+                  -var-file=terraform.tfvars \
 
         - name: Clean up cloned modules
           if: always() && inputs.cleanup-tf-modules-path == 'true'

--- a/.github/actions/aws-openshift-rosa-hcp-dual-region-create/action.yml
+++ b/.github/actions/aws-openshift-rosa-hcp-dual-region-create/action.yml
@@ -481,11 +481,11 @@ runs:
           with:
               working-directory: ${{ inputs.tf-modules-path }}/aws/openshift/rosa-hcp-dual-region/terraform/peering/
               plan-extra-args: |
-                  -backend-config="bucket=${{ steps.set-terraform-variables.outputs.TFSTATE_BUCKET }}" \
-                  -backend-config="region=${{ steps.set-terraform-variables.outputs.TFSTATE_REGION }}" \
-                  -backend-config="key=$terraform_state_key"  \
-                  -var='cluster_1_region=${{ inputs.aws-region-cluster-1 }}' \
-                  -var='cluster_2_region=${{ inputs.aws-region-cluster-2 }}' \
+                  -var='default_tags=${{ steps.sanitize-tags.outputs.sanitized_tags }}' \
+                  -var="cluster_1_region=${{ inputs.aws-region-cluster-1 }}" \
+                  -var="cluster_2_region=${{ inputs.aws-region-cluster-2 }}" \
+                  -var="cluster_1_vpc_id=${{ steps.apply-clusters.outputs.cluster_1_vpc_id }}" \
+                  -var="cluster_2_vpc_id=${{ steps.apply-clusters.outputs.cluster_2_vpc_id }}" \
 
       ### Backup bucket
 

--- a/.github/actions/aws-openshift-rosa-hcp-dual-region-create/action.yml
+++ b/.github/actions/aws-openshift-rosa-hcp-dual-region-create/action.yml
@@ -359,7 +359,7 @@ runs:
               plan-extra-args: |
                   -var='default_tags=${{ steps.sanitize-tags.outputs.sanitized_tags }}' \
                   -var="cluster_1_region=${{ inputs.aws-region-cluster-1 }}" \
-                  -var="cluster_2_region=${{ inputs.aws-region-cluster-2 }}"
+                  -var="cluster_2_region=${{ inputs.aws-region-cluster-2 }}" \
           env:
               RHCS_TOKEN: ${{ inputs.rh-token }}
 
@@ -484,7 +484,7 @@ runs:
                   -backend-config="region=${{ steps.set-terraform-variables.outputs.TFSTATE_REGION }}" \
                   -backend-config="key=$terraform_state_key"  \
                   -var="cluster_1_region=${{ inputs.aws-region-cluster-1 }}" \
-                  -var="cluster_2_region=${{ inputs.aws-region-cluster-2 }}"
+                  -var="cluster_2_region=${{ inputs.aws-region-cluster-2 }}" \
 
       ### Backup bucket
 
@@ -558,7 +558,7 @@ runs:
               working-directory: ${{ inputs.tf-modules-path }}/aws/openshift/rosa-hcp-dual-region/terraform/backup_bucket/
               plan-extra-args: |
                   -var='default_tags=${{ steps.sanitize-tags.outputs.sanitized_tags }}' \
-                  -var="bucket_name=cb-${{ steps.plan-backup-bucket.outputs.HASH }}"
+                  -var="bucket_name=cb-${{ steps.plan-backup-bucket.outputs.HASH }}" \
 
         - name: Clean up cloned modules
           if: always() && inputs.cleanup-tf-modules-path == 'true'

--- a/.github/actions/aws-openshift-rosa-hcp-dual-region-create/action.yml
+++ b/.github/actions/aws-openshift-rosa-hcp-dual-region-create/action.yml
@@ -360,6 +360,7 @@ runs:
                   -var='default_tags=${{ steps.sanitize-tags.outputs.sanitized_tags }}' \
                   -var='cluster_1_region=${{ inputs.aws-region-cluster-1 }}' \
                   -var='cluster_2_region=${{ inputs.aws-region-cluster-2 }}' \
+              fail-on-drift: 'false' # not failing on drift as there may be an expected drift due to hcp module drifting - cluster_console_url
           env:
               RHCS_TOKEN: ${{ inputs.rh-token }}
 

--- a/.github/actions/aws-openshift-rosa-hcp-dual-region-create/action.yml
+++ b/.github/actions/aws-openshift-rosa-hcp-dual-region-create/action.yml
@@ -274,8 +274,8 @@ runs:
 
               cat > terraform.tfvars <<EOF
               default_tags = ${{ steps.sanitize-tags.outputs.sanitized_tags }}
-              cluster_1_region=${{ inputs.aws-region-cluster-1 }}
-              cluster_2_region=${{ inputs.aws-region-cluster-2 }}
+              cluster_1_region="${{ inputs.aws-region-cluster-1 }}"
+              cluster_2_region="${{ inputs.aws-region-cluster-2 }}"
               EOF
 
         - name: Terraform Plan - Clusters
@@ -468,10 +468,10 @@ runs:
 
               cat > terraform.tfvars <<EOF
               default_tags = ${{ steps.sanitize-tags.outputs.sanitized_tags }}
-              cluster_1_region=${{ inputs.aws-region-cluster-1 }}
-              cluster_2_region=${{ inputs.aws-region-cluster-2 }}
-              cluster_1_vpc_id=${{ steps.apply-clusters.outputs.cluster_1_vpc_id }}
-              cluster_2_vpc_id=${{ steps.apply-clusters.outputs.cluster_2_vpc_id }}
+              cluster_1_region="${{ inputs.aws-region-cluster-1 }}"
+              cluster_2_region="${{ inputs.aws-region-cluster-2 }}"
+              cluster_1_vpc_id="${{ steps.apply-clusters.outputs.cluster_1_vpc_id }}"
+              cluster_2_vpc_id="${{ steps.apply-clusters.outputs.cluster_2_vpc_id }}"
               EOF
 
         - name: Terraform Plan - Peering
@@ -538,7 +538,7 @@ runs:
 
               cat > terraform.tfvars <<EOF
               default_tags = ${{ steps.sanitize-tags.outputs.sanitized_tags }}
-              bucket_name=cb-${hash}
+              bucket_name="cb-${hash}"
               EOF
 
         - name: Terraform Plan - Backup bucket

--- a/.github/actions/aws-openshift-rosa-hcp-dual-region-create/action.yml
+++ b/.github/actions/aws-openshift-rosa-hcp-dual-region-create/action.yml
@@ -351,6 +351,37 @@ runs:
               export cluster_2_vpc_id="$(terraform output -raw cluster_2_vpc_id)"
               echo "cluster_2_vpc_id=$cluster_2_vpc_id" | tee -a "$GITHUB_OUTPUT"
 
+        - name: Terraform Drift Detection - Clusters
+          id: drift-detect-clusters
+          working-directory: ${{ inputs.tf-modules-path }}/aws/openshift/rosa-hcp-dual-region/terraform/clusters/
+          env:
+              RHCS_TOKEN: ${{ inputs.rh-token }}
+          shell: bash
+          run: |
+              set -euo pipefail
+              echo "Running post-apply drift detection..."
+              # Re-run a plan with detailed exit code to see if anything still wants to change.
+              # Exit codes: 0 = no changes, 2 = changes present, 1 = error
+              set +e
+              terraform plan -no-color -detailed-exitcode \
+                -var='default_tags=${{ steps.sanitize-tags.outputs.sanitized_tags }}' \
+                -var="cluster_1_region=${{ inputs.aws-region-cluster-1 }}" \
+                -var="cluster_2_region=${{ inputs.aws-region-cluster-2 }}" > drift.plan.out 2>&1
+              code=$?
+              set -e
+              echo '--- Drift Plan Output Start ---'
+              cat drift.plan.out
+              echo '--- Drift Plan Output End ---'
+              if [ $code -eq 0 ]; then
+                  echo "No drift detected after apply.";
+              elif [ $code -eq 2 ]; then
+                  echo "::error::Drift detected immediately after apply (configuration flapping). Failing the workflow.";
+                  exit 1
+              else
+                  echo "::error::Drift detection plan failed (exit code $code).";
+                  exit $code
+              fi
+
         - name: Login and generate kubeconfig on the clusters
           # we need to retry due as the cluster has just been created and the OIDC provider may not be available yet
           uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
@@ -461,6 +492,37 @@ runs:
           run: |
               terraform apply -no-color peering.plan
 
+        - name: Terraform Drift Detection - Peering
+          if: inputs.enable-vpc-peering == 'true'
+          id: drift-detect-peering
+          working-directory: ${{ inputs.tf-modules-path }}/aws/openshift/rosa-hcp-dual-region/terraform/peering/
+          shell: bash
+          run: |
+              set -euo pipefail
+              echo "Running post-apply drift detection..."
+              # Re-run a plan with detailed exit code to see if anything still wants to change.
+              # Exit codes: 0 = no changes, 2 = changes present, 1 = error
+              set +e
+              terraform init -no-color -detailed-exitcode \
+                -backend-config="bucket=${{ steps.set-terraform-variables.outputs.TFSTATE_BUCKET }}" \
+                -backend-config="region=${{ steps.set-terraform-variables.outputs.TFSTATE_REGION }}" \
+                -backend-config="key=$terraform_state_key"  \
+                -var="cluster_1_region=${{ inputs.aws-region-cluster-1 }}" \
+                -var="cluster_2_region=${{ inputs.aws-region-cluster-2 }}" > drift.plan.out 2>&1
+              code=$?
+              set -e
+              echo '--- Drift Plan Output Start ---'
+              cat drift.plan.out
+              echo '--- Drift Plan Output End ---'
+              if [ $code -eq 0 ]; then
+                  echo "No drift detected after apply.";
+              elif [ $code -eq 2 ]; then
+                  echo "::error::Drift detected immediately after apply (configuration flapping). Failing the workflow.";
+                  exit 1
+              else
+                  echo "::error::Drift detection plan failed (exit code $code).";
+                  exit $code
+              fi
 
       ### Backup bucket
 
@@ -499,6 +561,8 @@ runs:
 
               hash=$(echo -n "${{ inputs.cluster-name-1 }}-oOo-${{ inputs.cluster-name-2 }}" | sha256sum | cut -c1-8)
 
+              echo "HASH=$hash" | tee -a "$GITHUB_OUTPUT"
+
               terraform plan -no-color -out  backup_bucket.plan \
                 -var='default_tags=${{ steps.sanitize-tags.outputs.sanitized_tags }}' \
                 -var="bucket_name=cb-${hash}"
@@ -524,6 +588,34 @@ runs:
               echo "::add-mask::$s3_aws_secret_access_key"
               echo "s3_aws_secret_access_key=$s3_aws_secret_access_key" | tee -a "$GITHUB_OUTPUT"
 
+        - name: Terraform Drift Detection - Backup Bucket
+          if: inputs.enable-backup-bucket == 'true'
+          id: drift-detect-backup-bucket
+          working-directory: ${{ inputs.tf-modules-path }}/aws/openshift/rosa-hcp-dual-region/terraform/backup_bucket/
+          shell: bash
+          run: |
+              set -euo pipefail
+              echo "Running post-apply drift detection..."
+              # Re-run a plan with detailed exit code to see if anything still wants to change.
+              # Exit codes: 0 = no changes, 2 = changes present, 1 = error
+              set +e
+              terraform plan -no-color -detailed-exitcode \
+                -var='default_tags=${{ steps.sanitize-tags.outputs.sanitized_tags }}' \
+                -var="bucket_name=cb-${{ steps.plan-backup-bucket.outputs.HASH }}" > drift.plan.out 2>&1
+              code=$?
+              set -e
+              echo '--- Drift Plan Output Start ---'
+              cat drift.plan.out
+              echo '--- Drift Plan Output End ---'
+              if [ $code -eq 0 ]; then
+                  echo "No drift detected after apply.";
+              elif [ $code -eq 2 ]; then
+                  echo "::error::Drift detected immediately after apply (configuration flapping). Failing the workflow.";
+                  exit 1
+              else
+                  echo "::error::Drift detection plan failed (exit code $code).";
+                  exit $code
+              fi
 
         - name: Clean up cloned modules
           if: always() && inputs.cleanup-tf-modules-path == 'true'

--- a/.github/actions/aws-openshift-rosa-hcp-dual-region-create/action.yml
+++ b/.github/actions/aws-openshift-rosa-hcp-dual-region-create/action.yml
@@ -358,8 +358,8 @@ runs:
               working-directory: ${{ inputs.tf-modules-path }}/aws/openshift/rosa-hcp-dual-region/terraform/clusters/
               plan-extra-args: |
                   -var='default_tags=${{ steps.sanitize-tags.outputs.sanitized_tags }}' \
-                  -var="cluster_1_region=${{ inputs.aws-region-cluster-1 }}" \
-                  -var="cluster_2_region=${{ inputs.aws-region-cluster-2 }}" \
+                  -var='cluster_1_region=${{ inputs.aws-region-cluster-1 }}' \
+                  -var='cluster_2_region=${{ inputs.aws-region-cluster-2 }}' \
           env:
               RHCS_TOKEN: ${{ inputs.rh-token }}
 
@@ -483,8 +483,8 @@ runs:
                   -backend-config="bucket=${{ steps.set-terraform-variables.outputs.TFSTATE_BUCKET }}" \
                   -backend-config="region=${{ steps.set-terraform-variables.outputs.TFSTATE_REGION }}" \
                   -backend-config="key=$terraform_state_key"  \
-                  -var="cluster_1_region=${{ inputs.aws-region-cluster-1 }}" \
-                  -var="cluster_2_region=${{ inputs.aws-region-cluster-2 }}" \
+                  -var='cluster_1_region=${{ inputs.aws-region-cluster-1 }}' \
+                  -var='cluster_2_region=${{ inputs.aws-region-cluster-2 }}' \
 
       ### Backup bucket
 
@@ -558,7 +558,7 @@ runs:
               working-directory: ${{ inputs.tf-modules-path }}/aws/openshift/rosa-hcp-dual-region/terraform/backup_bucket/
               plan-extra-args: |
                   -var='default_tags=${{ steps.sanitize-tags.outputs.sanitized_tags }}' \
-                  -var="bucket_name=cb-${{ steps.plan-backup-bucket.outputs.HASH }}" \
+                  -var='bucket_name=cb-${{ steps.plan-backup-bucket.outputs.HASH }}' \
 
         - name: Clean up cloned modules
           if: always() && inputs.cleanup-tf-modules-path == 'true'

--- a/.github/actions/aws-openshift-rosa-hcp-single-region-create/action.yml
+++ b/.github/actions/aws-openshift-rosa-hcp-single-region-create/action.yml
@@ -350,7 +350,7 @@ runs:
 
               cat > terraform.tfvars <<EOF
               default_tags = ${{ steps.sanitize-tags.outputs.sanitized_tags }}
-              vpc_id=${{ steps.apply-cluster.outputs.vpc_id }}"
+              vpc_id="${{ steps.apply-cluster.outputs.vpc_id }}"
               EOF
 
         - name: Terraform Plan - VPN

--- a/.github/actions/aws-openshift-rosa-hcp-single-region-create/action.yml
+++ b/.github/actions/aws-openshift-rosa-hcp-single-region-create/action.yml
@@ -304,7 +304,7 @@ runs:
           with:
               working-directory: ${{ inputs.tf-modules-path }}/aws/openshift/rosa-hcp-single-region/terraform/cluster/
               plan-extra-args: |
-                  -var='default_tags=${{ steps.sanitize-tags.outputs.sanitized_tags }}'
+                  -var='default_tags=${{ steps.sanitize-tags.outputs.sanitized_tags }}' \
           env:
               RHCS_TOKEN: ${{ inputs.rh-token }}
 
@@ -377,7 +377,7 @@ runs:
               working-directory: ${{ inputs.tf-modules-path }}/aws/openshift/rosa-hcp-single-region/terraform/vpn/
               plan-extra-args: |
                   -var='default_tags=${{ steps.sanitize-tags.outputs.sanitized_tags }}' \
-                  -var="vpc_id=${{ steps.apply-cluster.outputs.vpc_id }}
+                  -var="vpc_id=${{ steps.apply-cluster.outputs.vpc_id }} \
 
         ### End of terraform
 

--- a/.github/actions/aws-openshift-rosa-hcp-single-region-create/action.yml
+++ b/.github/actions/aws-openshift-rosa-hcp-single-region-create/action.yml
@@ -239,6 +239,17 @@ runs:
           with:
               raw-tags: ${{ inputs.tags }}
 
+        - name: Generate tfvars file - Cluster
+          id: generate-tfvars-cluster
+          shell: bash
+          working-directory: ${{ inputs.tf-modules-path }}/aws/openshift/rosa-hcp-single-region/terraform/cluster/
+          run: |
+              set -euo pipefail
+
+              cat > terraform.tfvars <<EOF
+              default_tags = ${{ steps.sanitize-tags.outputs.sanitized_tags }}
+              EOF
+
         - name: Terraform Plan - Cluster
           id: plan-cluster
           working-directory: ${{ inputs.tf-modules-path }}/aws/openshift/rosa-hcp-single-region/terraform/cluster/
@@ -279,7 +290,7 @@ runs:
               echo "Displaying templated cluster.tf file:"
               cat cluster.tf
 
-              terraform plan -no-color -var='default_tags=${{ steps.sanitize-tags.outputs.sanitized_tags }}' -out rosa.plan
+              terraform plan -no-color -var-file=terraform.tfvars -out rosa.plan
 
         - name: Terraform Apply - Cluster
           id: apply-cluster
@@ -304,7 +315,7 @@ runs:
           with:
               working-directory: ${{ inputs.tf-modules-path }}/aws/openshift/rosa-hcp-single-region/terraform/cluster/
               plan-extra-args: |
-                  -var='default_tags=${{ steps.sanitize-tags.outputs.sanitized_tags }}' \
+                  -var-file=terraform.tfvars \
               fail-on-drift: 'false' # not failing on drift as there may be an expected drift due to hcp module drifting - cluster_console_url
           env:
               RHCS_TOKEN: ${{ inputs.rh-token }}
@@ -330,6 +341,18 @@ runs:
 
               terraform validate -no-color
 
+        - name: Generate tfvars file - VPN
+          id: generate-tfvars-vpn
+          shell: bash
+          working-directory: ${{ inputs.tf-modules-path }}/aws/openshift/rosa-hcp-single-region/terraform/vpn/
+          run: |
+              set -euo pipefail
+
+              cat > terraform.tfvars <<EOF
+              default_tags = ${{ steps.sanitize-tags.outputs.sanitized_tags }}
+              vpc_id=${{ steps.apply-cluster.outputs.vpc_id }}"
+              EOF
+
         - name: Terraform Plan - VPN
           id: plan-vpn
           if: inputs.vpn-enabled == 'true'
@@ -350,8 +373,7 @@ runs:
               cat vpn.tf
 
               terraform plan -no-color \
-                -var='default_tags=${{ steps.sanitize-tags.outputs.sanitized_tags }}' \
-                -var="vpc_id=${{ steps.apply-cluster.outputs.vpc_id }}" \
+                -var-file=terraform.tfvars \
                 -out vpn.plan
 
         - name: Terraform Apply - VPN
@@ -377,8 +399,7 @@ runs:
           with:
               working-directory: ${{ inputs.tf-modules-path }}/aws/openshift/rosa-hcp-single-region/terraform/vpn/
               plan-extra-args: |
-                  -var='default_tags=${{ steps.sanitize-tags.outputs.sanitized_tags }}' \
-                  -var='vpc_id=${{ steps.apply-cluster.outputs.vpc_id }}' \
+                  -var-file=terraform.tfvars \
 
         ### End of terraform
 

--- a/.github/actions/aws-openshift-rosa-hcp-single-region-create/action.yml
+++ b/.github/actions/aws-openshift-rosa-hcp-single-region-create/action.yml
@@ -305,6 +305,7 @@ runs:
               working-directory: ${{ inputs.tf-modules-path }}/aws/openshift/rosa-hcp-single-region/terraform/cluster/
               plan-extra-args: |
                   -var='default_tags=${{ steps.sanitize-tags.outputs.sanitized_tags }}' \
+              fail-on-drift: 'false' # not failing on drift as there may be an expected drift due to hcp module drifting - cluster_console_url
           env:
               RHCS_TOKEN: ${{ inputs.rh-token }}
 

--- a/.github/actions/aws-openshift-rosa-hcp-single-region-create/action.yml
+++ b/.github/actions/aws-openshift-rosa-hcp-single-region-create/action.yml
@@ -377,7 +377,7 @@ runs:
               working-directory: ${{ inputs.tf-modules-path }}/aws/openshift/rosa-hcp-single-region/terraform/vpn/
               plan-extra-args: |
                   -var='default_tags=${{ steps.sanitize-tags.outputs.sanitized_tags }}' \
-                  -var="vpc_id=${{ steps.apply-cluster.outputs.vpc_id }} \
+                  -var='vpc_id=${{ steps.apply-cluster.outputs.vpc_id }}' \
 
         ### End of terraform
 

--- a/.github/actions/aws-openshift-rosa-hcp-single-region-create/action.yml
+++ b/.github/actions/aws-openshift-rosa-hcp-single-region-create/action.yml
@@ -298,6 +298,35 @@ runs:
               export vpc_id="$(terraform output -raw vpc_id)"
               echo "vpc_id=$vpc_id" | tee -a "$GITHUB_OUTPUT"
 
+        - name: Terraform Drift Detection - Cluster
+          id: drift-detect-cluster
+          working-directory: ${{ inputs.tf-modules-path }}/aws/openshift/rosa-hcp-single-region/terraform/cluster/
+          env:
+              RHCS_TOKEN: ${{ inputs.rh-token }}
+          shell: bash
+          run: |
+              set -euo pipefail
+              echo "Running post-apply drift detection..."
+              # Re-run a plan with detailed exit code to see if anything still wants to change.
+              # Exit codes: 0 = no changes, 2 = changes present, 1 = error
+              set +e
+              terraform plan -no-color -detailed-exitcode \
+                  -var='default_tags=${{ steps.sanitize-tags.outputs.sanitized_tags }}' > drift.plan.out 2>&1
+              code=$?
+              set -e
+              echo '--- Drift Plan Output Start ---'
+              cat drift.plan.out
+              echo '--- Drift Plan Output End ---'
+              if [ $code -eq 0 ]; then
+                  echo "No drift detected after apply.";
+              elif [ $code -eq 2 ]; then
+                  echo "::error::Drift detected immediately after apply (configuration flapping). Failing the workflow.";
+                  exit 1
+              else
+                  echo "::error::Drift detection plan failed (exit code $code).";
+                  exit $code
+              fi
+
         - name: Terraform Init - VPN
           id: init-vpn
           if: inputs.vpn-enabled == 'true'
@@ -358,6 +387,35 @@ runs:
               echo "::add-mask::$vpn_client_configs"
 
               echo "vpn_endpoint=$(terraform output -json vpn_endpoint)" | tee -a "$GITHUB_OUTPUT"
+
+        - name: Terraform Drift Detection - VPN
+          id: drift-detect-vpn
+          if: inputs.vpn-enabled == 'true'
+          working-directory: ${{ inputs.tf-modules-path }}/aws/openshift/rosa-hcp-single-region/terraform/vpn/
+          shell: bash
+          run: |
+              set -euo pipefail
+              echo "Running post-apply drift detection..."
+              # Re-run a plan with detailed exit code to see if anything still wants to change.
+              # Exit codes: 0 = no changes, 2 = changes present, 1 = error
+              set +e
+              terraform plan -no-color -detailed-exitcode \
+                -var='default_tags=${{ steps.sanitize-tags.outputs.sanitized_tags }}' \
+                -var="vpc_id=${{ steps.apply-cluster.outputs.vpc_id }}" > drift.plan.out 2>&1
+              code=$?
+              set -e
+              echo '--- Drift Plan Output Start ---'
+              cat drift.plan.out
+              echo '--- Drift Plan Output End ---'
+              if [ $code -eq 0 ]; then
+                  echo "No drift detected after apply.";
+              elif [ $code -eq 2 ]; then
+                  echo "::error::Drift detected immediately after apply (configuration flapping). Failing the workflow.";
+                  exit 1
+              else
+                  echo "::error::Drift detection plan failed (exit code $code).";
+                  exit $code
+              fi
 
         ### End of terraform
 

--- a/.github/actions/aws-openshift-rosa-hcp-single-region-create/action.yml
+++ b/.github/actions/aws-openshift-rosa-hcp-single-region-create/action.yml
@@ -299,33 +299,14 @@ runs:
               echo "vpc_id=$vpc_id" | tee -a "$GITHUB_OUTPUT"
 
         - name: Terraform Drift Detection - Cluster
+          uses: ./.github/actions/internal-terraform-drift-detect
           id: drift-detect-cluster
-          working-directory: ${{ inputs.tf-modules-path }}/aws/openshift/rosa-hcp-single-region/terraform/cluster/
+          with:
+              working-directory: ${{ inputs.tf-modules-path }}/aws/openshift/rosa-hcp-single-region/terraform/cluster/
+              plan-extra-args: |
+                  -var='default_tags=${{ steps.sanitize-tags.outputs.sanitized_tags }}'
           env:
               RHCS_TOKEN: ${{ inputs.rh-token }}
-          shell: bash
-          run: |
-              set -euo pipefail
-              echo "Running post-apply drift detection..."
-              # Re-run a plan with detailed exit code to see if anything still wants to change.
-              # Exit codes: 0 = no changes, 2 = changes present, 1 = error
-              set +e
-              terraform plan -no-color -detailed-exitcode \
-                  -var='default_tags=${{ steps.sanitize-tags.outputs.sanitized_tags }}' > drift.plan.out 2>&1
-              code=$?
-              set -e
-              echo '--- Drift Plan Output Start ---'
-              cat drift.plan.out
-              echo '--- Drift Plan Output End ---'
-              if [ $code -eq 0 ]; then
-                  echo "No drift detected after apply.";
-              elif [ $code -eq 2 ]; then
-                  echo "::error::Drift detected immediately after apply (configuration flapping). Failing the workflow.";
-                  exit 1
-              else
-                  echo "::error::Drift detection plan failed (exit code $code).";
-                  exit $code
-              fi
 
         - name: Terraform Init - VPN
           id: init-vpn
@@ -391,31 +372,12 @@ runs:
         - name: Terraform Drift Detection - VPN
           id: drift-detect-vpn
           if: inputs.vpn-enabled == 'true'
-          working-directory: ${{ inputs.tf-modules-path }}/aws/openshift/rosa-hcp-single-region/terraform/vpn/
-          shell: bash
-          run: |
-              set -euo pipefail
-              echo "Running post-apply drift detection..."
-              # Re-run a plan with detailed exit code to see if anything still wants to change.
-              # Exit codes: 0 = no changes, 2 = changes present, 1 = error
-              set +e
-              terraform plan -no-color -detailed-exitcode \
-                -var='default_tags=${{ steps.sanitize-tags.outputs.sanitized_tags }}' \
-                -var="vpc_id=${{ steps.apply-cluster.outputs.vpc_id }}" > drift.plan.out 2>&1
-              code=$?
-              set -e
-              echo '--- Drift Plan Output Start ---'
-              cat drift.plan.out
-              echo '--- Drift Plan Output End ---'
-              if [ $code -eq 0 ]; then
-                  echo "No drift detected after apply.";
-              elif [ $code -eq 2 ]; then
-                  echo "::error::Drift detected immediately after apply (configuration flapping). Failing the workflow.";
-                  exit 1
-              else
-                  echo "::error::Drift detection plan failed (exit code $code).";
-                  exit $code
-              fi
+          uses: ./.github/actions/internal-terraform-drift-detect
+          with:
+              working-directory: ${{ inputs.tf-modules-path }}/aws/openshift/rosa-hcp-single-region/terraform/vpn/
+              plan-extra-args: |
+                  -var='default_tags=${{ steps.sanitize-tags.outputs.sanitized_tags }}' \
+                  -var="vpc_id=${{ steps.apply-cluster.outputs.vpc_id }}
 
         ### End of terraform
 

--- a/.github/actions/azure-kubernetes-aks-single-region-create/action.yml
+++ b/.github/actions/azure-kubernetes-aks-single-region-create/action.yml
@@ -167,6 +167,18 @@ runs:
           with:
               raw-tags: ${{ steps.prepare.outputs.COMBINED_TAGS }}
 
+        - name: Generate tfvars file
+          id: generate-tfvars
+          shell: bash
+          working-directory: ${{ inputs.tf-modules-path }}/azure/kubernetes/${{ inputs.ref-arch }}/
+          run: |
+              set -euo pipefail
+
+              cat > terraform.tfvars <<EOF
+              tags = ${{ steps.sanitize-tags.outputs.sanitized_tags }}
+              resource_prefix_placeholder = "${{ steps.prepare.outputs.RESOURCE_PREFIX_PLACEHOLDER }}"
+              EOF
+
         - name: Terraform Plan
           id: plan
           working-directory: ${{ inputs.tf-modules-path }}/azure/kubernetes/${{ inputs.ref-arch }}/
@@ -177,8 +189,7 @@ runs:
               terraform plan \
                   -no-color \
                   -out tf.plan \
-                  -var 'resource_prefix_placeholder=${{ steps.prepare.outputs.RESOURCE_PREFIX_PLACEHOLDER }}' \
-                  -var 'tags=${{ steps.sanitize-tags.outputs.sanitized_tags }}' \
+                  -var-file=terraform.tfvars \
                   -var-file="${{ inputs.tfvars }}"
 
         - name: Terraform Apply
@@ -195,8 +206,7 @@ runs:
           with:
               working-directory: ${{ inputs.tf-modules-path }}/azure/kubernetes/${{ inputs.ref-arch }}/
               plan-extra-args: |
-                  -var 'resource_prefix_placeholder=${{ steps.prepare.outputs.RESOURCE_PREFIX_PLACEHOLDER }}' \
-                  -var 'tags=${{ steps.sanitize-tags.outputs.sanitized_tags }}' \
+                  -var-file=terraform.tfvars \
                   -var-file="${{ inputs.tfvars }}" \
 
         - name: Login and generate kubeconfig

--- a/.github/actions/azure-kubernetes-aks-single-region-create/action.yml
+++ b/.github/actions/azure-kubernetes-aks-single-region-create/action.yml
@@ -189,6 +189,35 @@ runs:
               set -euo pipefail
               terraform apply -no-color tf.plan
 
+        - name: Terraform Drift Detection
+          id: drift-detect
+          working-directory: ${{ inputs.tf-modules-path }}/azure/kubernetes/${{ inputs.ref-arch }}/
+          shell: bash
+          run: |
+              set -euo pipefail
+              echo "Running post-apply drift detection..."
+              # Re-run a plan with detailed exit code to see if anything still wants to change.
+              # Exit codes: 0 = no changes, 2 = changes present, 1 = error
+              set +e
+              terraform plan -no-color -detailed-exitcode \
+                  -var 'resource_prefix_placeholder=${{ steps.prepare.outputs.RESOURCE_PREFIX_PLACEHOLDER }}' \
+                  -var 'tags=${{ steps.sanitize-tags.outputs.sanitized_tags }}' \
+                  -var-file="${{ inputs.tfvars }}" > drift.plan.out 2>&1
+              code=$?
+              set -e
+              echo '--- Drift Plan Output Start ---'
+              cat drift.plan.out
+              echo '--- Drift Plan Output End ---'
+              if [ $code -eq 0 ]; then
+                  echo "No drift detected after apply.";
+              elif [ $code -eq 2 ]; then
+                  echo "::error::Drift detected immediately after apply (configuration flapping). Failing the workflow.";
+                  exit 1
+              else
+                  echo "::error::Drift detection plan failed (exit code $code).";
+                  exit $code
+              fi
+
         - name: Login and generate kubeconfig
           if: inputs.login == 'true'
           shell: bash

--- a/.github/actions/azure-kubernetes-aks-single-region-create/action.yml
+++ b/.github/actions/azure-kubernetes-aks-single-region-create/action.yml
@@ -190,33 +190,14 @@ runs:
               terraform apply -no-color tf.plan
 
         - name: Terraform Drift Detection
+          uses: ./.github/actions/internal-terraform-drift-detect
           id: drift-detect
-          working-directory: ${{ inputs.tf-modules-path }}/azure/kubernetes/${{ inputs.ref-arch }}/
-          shell: bash
-          run: |
-              set -euo pipefail
-              echo "Running post-apply drift detection..."
-              # Re-run a plan with detailed exit code to see if anything still wants to change.
-              # Exit codes: 0 = no changes, 2 = changes present, 1 = error
-              set +e
-              terraform plan -no-color -detailed-exitcode \
+          with:
+              working-directory: ${{ inputs.tf-modules-path }}/azure/kubernetes/${{ inputs.ref-arch }}/
+              plan-extra-args: |
                   -var 'resource_prefix_placeholder=${{ steps.prepare.outputs.RESOURCE_PREFIX_PLACEHOLDER }}' \
                   -var 'tags=${{ steps.sanitize-tags.outputs.sanitized_tags }}' \
-                  -var-file="${{ inputs.tfvars }}" > drift.plan.out 2>&1
-              code=$?
-              set -e
-              echo '--- Drift Plan Output Start ---'
-              cat drift.plan.out
-              echo '--- Drift Plan Output End ---'
-              if [ $code -eq 0 ]; then
-                  echo "No drift detected after apply.";
-              elif [ $code -eq 2 ]; then
-                  echo "::error::Drift detected immediately after apply (configuration flapping). Failing the workflow.";
-                  exit 1
-              else
-                  echo "::error::Drift detection plan failed (exit code $code).";
-                  exit $code
-              fi
+                  -var-file="${{ inputs.tfvars }}"
 
         - name: Login and generate kubeconfig
           if: inputs.login == 'true'

--- a/.github/actions/azure-kubernetes-aks-single-region-create/action.yml
+++ b/.github/actions/azure-kubernetes-aks-single-region-create/action.yml
@@ -197,7 +197,7 @@ runs:
               plan-extra-args: |
                   -var 'resource_prefix_placeholder=${{ steps.prepare.outputs.RESOURCE_PREFIX_PLACEHOLDER }}' \
                   -var 'tags=${{ steps.sanitize-tags.outputs.sanitized_tags }}' \
-                  -var-file="${{ inputs.tfvars }}"
+                  -var-file="${{ inputs.tfvars }}" \
 
         - name: Login and generate kubeconfig
           if: inputs.login == 'true'

--- a/.github/actions/internal-terraform-drift-detect/README.md
+++ b/.github/actions/internal-terraform-drift-detect/README.md
@@ -11,7 +11,7 @@ Fails when drift is detected (config flapping) unless disabled via input.
 | name | description | required | default |
 | --- | --- | --- | --- |
 | `working-directory` | <p>Directory where Terraform has been initialized for this stack</p> | `true` | `""` |
-| `plan-extra-args` | <p>Extra arguments to append to <code>terraform plan</code> (e.g. -var, -var-file)</p> | `false` | `""` |
+| `plan-extra-args` | <p>Extra arguments to append to <code>terraform plan</code> (e.g. -var, -var-file). If using multiline input add a \ for the last line as well.</p> | `false` | `""` |
 | `fail-on-drift` | <p>Fail the job when drift is detected (exit code 2)</p> | `false` | `true` |
 
 
@@ -38,7 +38,7 @@ This action is a `composite` action.
     # Default: ""
 
     plan-extra-args:
-    # Extra arguments to append to `terraform plan` (e.g. -var, -var-file)
+    # Extra arguments to append to `terraform plan` (e.g. -var, -var-file). If using multiline input add a \ for the last line as well.
     #
     # Required: false
     # Default: ""

--- a/.github/actions/internal-terraform-drift-detect/README.md
+++ b/.github/actions/internal-terraform-drift-detect/README.md
@@ -38,7 +38,8 @@ This action is a `composite` action.
     # Default: ""
 
     plan-extra-args:
-    # Extra arguments to append to `terraform plan` (e.g. -var, -var-file). If using multiline input add a \ for the last line as well.
+    # Extra arguments to append to `terraform plan` (e.g. -var, -var-file).
+    # If using multiline input add a \ for the last line as well.
     #
     # Required: false
     # Default: ""

--- a/.github/actions/internal-terraform-drift-detect/README.md
+++ b/.github/actions/internal-terraform-drift-detect/README.md
@@ -1,0 +1,51 @@
+# Terraform Drift Detection
+
+## Description
+
+Runs `terraform plan -detailed-exitcode` after an apply to detect immediate drift/flapping.
+Fails when drift is detected (config flapping) unless disabled via input.
+
+
+## Inputs
+
+| name | description | required | default |
+| --- | --- | --- | --- |
+| `working-directory` | <p>Directory where Terraform has been initialized for this stack</p> | `true` | `""` |
+| `plan-extra-args` | <p>Extra arguments to append to <code>terraform plan</code> (e.g. -var, -var-file)</p> | `false` | `""` |
+| `fail-on-drift` | <p>Fail the job when drift is detected (exit code 2)</p> | `false` | `true` |
+
+
+## Outputs
+
+| name | description |
+| --- | --- |
+| `drift-detected` | <p>Whether drift was detected by the plan (true/false)</p> |
+
+
+## Runs
+
+This action is a `composite` action.
+
+## Usage
+
+```yaml
+- uses: camunda/camunda-deployment-references/.github/actions/internal-terraform-drift-detect@main
+  with:
+    working-directory:
+    # Directory where Terraform has been initialized for this stack
+    #
+    # Required: true
+    # Default: ""
+
+    plan-extra-args:
+    # Extra arguments to append to `terraform plan` (e.g. -var, -var-file)
+    #
+    # Required: false
+    # Default: ""
+
+    fail-on-drift:
+    # Fail the job when drift is detected (exit code 2)
+    #
+    # Required: false
+    # Default: true
+```

--- a/.github/actions/internal-terraform-drift-detect/action.yml
+++ b/.github/actions/internal-terraform-drift-detect/action.yml
@@ -9,7 +9,9 @@ inputs:
         description: Directory where Terraform has been initialized for this stack
         required: true
     plan-extra-args:
-        description: Extra arguments to append to `terraform plan` (e.g. -var, -var-file). If using multiline input add a \ for the last line as well.
+        description: |
+            Extra arguments to append to `terraform plan` (e.g. -var, -var-file).
+            If using multiline input add a \ for the last line as well.
         required: false
         default: ''
     fail-on-drift:
@@ -48,17 +50,12 @@ runs:
               if [ $code -eq 0 ]; then
                 echo "No drift detected after apply."
                 echo "drift_detected=false" >> "$GITHUB_OUTPUT"
-              elif [ $code -eq 2 ]; then
-                echo "drift_detected=true" >> "$GITHUB_OUTPUT"
-                if [[ "${{ inputs.fail-on-drift }}" == "true" ]]; then
-                  echo "::error::Drift detected immediately after apply (configuration flapping)."
-                  exit 1
-                else
-                  echo "drift_detected=true" >> "$GITHUB_OUTPUT"
-                  echo "::warning::Drift detected but not failing as per configuration."
-                fi
               else
                 echo "drift_detected=true" >> "$GITHUB_OUTPUT"
-                echo "::error::Drift detection plan failed (exit code $code)."
-                exit $code
+                if [[ "${{ inputs.fail-on-drift }}" == "true" ]]; then
+                  echo "::error::Drift detected immediately after apply (configuration flapping - exit code $code)."
+                  exit 1
+                else
+                  echo "::warning::Drift detected but not failing as per configuration."
+                fi
               fi

--- a/.github/actions/internal-terraform-drift-detect/action.yml
+++ b/.github/actions/internal-terraform-drift-detect/action.yml
@@ -34,13 +34,10 @@ runs:
               echo "Running post-apply drift detection in $(pwd)..."
 
               PLAN_OUT="drift.plan.out"
-              EXTRA_ARGS="${{ inputs.plan-extra-args }}"
-
-              echo "[debug] extra args: '${EXTRA_ARGS}'"
 
               # Run plan with detailed exit code. 0 = no changes, 2 = changes, 1 = error
               set +e
-              terraform plan -no-color -detailed-exitcode ${EXTRA_ARGS} > "$PLAN_OUT" 2>&1
+              terraform plan -no-color -detailed-exitcode ${{ inputs.plan-extra-args }} > "$PLAN_OUT" 2>&1
               code=$?
               set -e
 

--- a/.github/actions/internal-terraform-drift-detect/action.yml
+++ b/.github/actions/internal-terraform-drift-detect/action.yml
@@ -1,0 +1,67 @@
+---
+name: Terraform Drift Detection
+description: |
+    Runs `terraform plan -detailed-exitcode` after an apply to detect immediate drift/flapping.
+    Fails when drift is detected (config flapping) unless disabled via input.
+
+inputs:
+    working-directory:
+        description: Directory where Terraform has been initialized for this stack
+        required: true
+    plan-extra-args:
+        description: Extra arguments to append to `terraform plan` (e.g. -var, -var-file)
+        required: false
+        default: ''
+    fail-on-drift:
+        description: Fail the job when drift is detected (exit code 2)
+        required: false
+        default: 'true'
+
+outputs:
+    drift-detected:
+        description: Whether drift was detected by the plan (true/false)
+        value: ${{ steps.detect.outputs.drift_detected }}
+
+runs:
+    using: composite
+    steps:
+        - name: Terraform Drift Detection
+          id: detect
+          shell: bash
+          working-directory: ${{ inputs.working-directory }}
+          run: |
+              set -euo pipefail
+              echo "Running post-apply drift detection in $(pwd)..."
+
+              PLAN_OUT="drift.plan.out"
+              EXTRA_ARGS="${{ inputs.plan-extra-args }}"
+
+              echo "[debug] extra args: '${EXTRA_ARGS}'"
+
+              # Run plan with detailed exit code. 0 = no changes, 2 = changes, 1 = error
+              set +e
+              terraform plan -no-color -detailed-exitcode ${EXTRA_ARGS} > "$PLAN_OUT" 2>&1
+              code=$?
+              set -e
+
+              echo '--- Drift Plan Output Start ---'
+              cat "$PLAN_OUT"
+              echo '--- Drift Plan Output End ---'
+
+              if [ $code -eq 0 ]; then
+                echo "No drift detected after apply."
+                echo "drift_detected=false" >> "$GITHUB_OUTPUT"
+              elif [ $code -eq 2 ]; then
+                echo "drift_detected=true" >> "$GITHUB_OUTPUT"
+                if [[ "${{ inputs.fail-on-drift }}" == "true" ]]; then
+                  echo "::error::Drift detected immediately after apply (configuration flapping)."
+                  exit 1
+                else
+                  echo "drift_detected=true" >> "$GITHUB_OUTPUT"
+                  echo "::warning::Drift detected but not failing as per configuration."
+                fi
+              else
+                echo "drift_detected=true" >> "$GITHUB_OUTPUT"
+                echo "::error::Drift detection plan failed (exit code $code)."
+                exit $code
+              fi

--- a/.github/actions/internal-terraform-drift-detect/action.yml
+++ b/.github/actions/internal-terraform-drift-detect/action.yml
@@ -9,7 +9,7 @@ inputs:
         description: Directory where Terraform has been initialized for this stack
         required: true
     plan-extra-args:
-        description: Extra arguments to append to `terraform plan` (e.g. -var, -var-file)
+        description: Extra arguments to append to `terraform plan` (e.g. -var, -var-file). If using multiline input add a \ for the last line as well.
         required: false
         default: ''
     fail-on-drift:

--- a/azure/kubernetes/aks-single-region/test/golden/tfplan-golden.json
+++ b/azure/kubernetes/aks-single-region/test/golden/tfplan-golden.json
@@ -228,7 +228,9 @@
             "node_labels": {},
             "node_network_profile": [],
             "tags": {},
-            "upgrade_settings": [],
+            "upgrade_settings": [
+              {}
+            ],
             "windows_profile": [],
             "zones": [
               false,
@@ -279,7 +281,13 @@
             "temporary_name_for_rotation": null,
             "timeouts": null,
             "ultra_ssd_enabled": false,
-            "upgrade_settings": [],
+            "upgrade_settings": [
+              {
+                "drain_timeout_in_minutes": 0,
+                "max_surge": "10",
+                "node_soak_duration_in_minutes": 0
+              }
+            ],
             "vm_size": "Standard_D4s_v3",
             "windows_profile": [],
             "workload_runtime": null,

--- a/azure/modules/aks/README.md
+++ b/azure/modules/aks/README.md
@@ -37,6 +37,9 @@ No modules.
 | <a name="input_uami_object_id"></a> [uami\_object\_id](#input\_uami\_object\_id) | User-assigned identity object ID to use for KMS | `string` | n/a | yes |
 | <a name="input_user_node_disk_size_gb"></a> [user\_node\_disk\_size\_gb](#input\_user\_node\_disk\_size\_gb) | OS disk size in GB for user nodes | `number` | `30` | no |
 | <a name="input_user_node_pool_count"></a> [user\_node\_pool\_count](#input\_user\_node\_pool\_count) | Number of nodes in the user node pool | `number` | `2` | no |
+| <a name="input_user_node_pool_drain_timeout_in_minutes"></a> [user\_node\_pool\_drain\_timeout\_in\_minutes](#input\_user\_node\_pool\_drain\_timeout\_in\_minutes) | The amount of time in minutes to wait on eviction of pods and graceful termination per node | `number` | `0` | no |
+| <a name="input_user_node_pool_max_surge"></a> [user\_node\_pool\_max\_surge](#input\_user\_node\_pool\_max\_surge) | The maximum number or percentage of nodes which will be added to the Node Pool size during an upgrade | `number` | `10` | no |
+| <a name="input_user_node_pool_node_soak_duration_in_minutes"></a> [user\_node\_pool\_node\_soak\_duration\_in\_minutes](#input\_user\_node\_pool\_node\_soak\_duration\_in\_minutes) | The amount of time in minutes to wait after draining a node and before reimaging and moving on to next node | `number` | `0` | no |
 | <a name="input_user_node_pool_vm_size"></a> [user\_node\_pool\_vm\_size](#input\_user\_node\_pool\_vm\_size) | VM size for the user node pool | `string` | `"Standard_D4s_v3"` | no |
 | <a name="input_user_node_pool_zones"></a> [user\_node\_pool\_zones](#input\_user\_node\_pool\_zones) | AZs for user node pool | `list(string)` | <pre>[<br/>  "1",<br/>  "2",<br/>  "3"<br/>]</pre> | no |
 ## Outputs

--- a/azure/modules/aks/node_pools.tf
+++ b/azure/modules/aks/node_pools.tf
@@ -16,6 +16,12 @@ resource "azurerm_kubernetes_cluster_node_pool" "user" {
     "app"           = "camunda"
   }
 
+  upgrade_settings {
+    drain_timeout_in_minutes      = var.user_node_pool_drain_timeout_in_minutes
+    max_surge                     = var.user_node_pool_max_surge
+    node_soak_duration_in_minutes = var.user_node_pool_node_soak_duration_in_minutes
+  }
+
   # Keep things simple
   max_pods = 30
   tags     = var.tags

--- a/azure/modules/aks/variables.tf
+++ b/azure/modules/aks/variables.tf
@@ -69,6 +69,24 @@ variable "user_node_pool_count" {
   default     = 2
 }
 
+variable "user_node_pool_drain_timeout_in_minutes" {
+  description = "The amount of time in minutes to wait on eviction of pods and graceful termination per node"
+  type        = number
+  default     = 0
+}
+
+variable "user_node_pool_max_surge" {
+  description = "The maximum number or percentage of nodes which will be added to the Node Pool size during an upgrade"
+  type        = number
+  default     = 10
+}
+
+variable "user_node_pool_node_soak_duration_in_minutes" {
+  description = "The amount of time in minutes to wait after draining a node and before reimaging and moving on to next node"
+  type        = number
+  default     = 0
+}
+
 # Network configuration
 variable "network_plugin" {
   description = "Network plugin to use for Kubernetes networking"


### PR DESCRIPTION
the idea here is that since we dont run them atm longterm to at least check after the immediate apply whether there's still a drift or not

Meaning something would need to be fixed in the config, otherwise not good ux

Following workflow run shows a drift detected:

https://github.com/camunda/camunda-deployment-references/actions/runs/17120867185/job/48561204864?pr=854

Consider backporting to 8.7.