### PR TITLE
fix: bump azure nodes to newer tier with higher network througput

### DIFF
--- a/azure/kubernetes/aks-single-region/README.md
+++ b/azure/kubernetes/aks-single-region/README.md
@@ -38,12 +38,12 @@
 | <a name="input_resource_prefix_placeholder"></a> [resource\_prefix\_placeholder](#input\_resource\_prefix\_placeholder) | Placeholder for the resource prefix | `string` | `""` | no |
 | <a name="input_subscription_id"></a> [subscription\_id](#input\_subscription\_id) | The Azure Subscription ID to deploy into | `string` | n/a | yes |
 | <a name="input_system_node_pool_count"></a> [system\_node\_pool\_count](#input\_system\_node\_pool\_count) | Number of nodes in the system node pool | `number` | `1` | no |
-| <a name="input_system_node_pool_vm_size"></a> [system\_node\_pool\_vm\_size](#input\_system\_node\_pool\_vm\_size) | VM size for the system node pool | `string` | `"Standard_D2s_v3"` | no |
+| <a name="input_system_node_pool_vm_size"></a> [system\_node\_pool\_vm\_size](#input\_system\_node\_pool\_vm\_size) | VM size for the system node pool | `string` | `"Standard_D2s_v6"` | no |
 | <a name="input_system_node_pool_zones"></a> [system\_node\_pool\_zones](#input\_system\_node\_pool\_zones) | List of AZs for the system node pool | `list(string)` | <pre>[<br/>  "1",<br/>  "2",<br/>  "3"<br/>]</pre> | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | <pre>{<br/>  "Environment": "Testing",<br/>  "Purpose": "Reference Implementation"<br/>}</pre> | no |
 | <a name="input_terraform_sp_app_id"></a> [terraform\_sp\_app\_id](#input\_terraform\_sp\_app\_id) | The Service Principals Application (client) ID that Terraform is using | `string` | n/a | yes |
 | <a name="input_user_node_pool_count"></a> [user\_node\_pool\_count](#input\_user\_node\_pool\_count) | Number of nodes in the user node pool | `number` | `5` | no |
-| <a name="input_user_node_pool_vm_size"></a> [user\_node\_pool\_vm\_size](#input\_user\_node\_pool\_vm\_size) | VM size for the user node pool | `string` | `"Standard_D4s_v3"` | no |
+| <a name="input_user_node_pool_vm_size"></a> [user\_node\_pool\_vm\_size](#input\_user\_node\_pool\_vm\_size) | VM size for the user node pool | `string` | `"Standard_D4s_v6"` | no |
 | <a name="input_user_node_pool_zones"></a> [user\_node\_pool\_zones](#input\_user\_node\_pool\_zones) | List of AZs for the user node pool | `list(string)` | <pre>[<br/>  "1",<br/>  "2",<br/>  "3"<br/>]</pre> | no |
 | <a name="input_vnet_address_space"></a> [vnet\_address\_space](#input\_vnet\_address\_space) | Address space for the virtual network | `list(string)` | <pre>[<br/>  "10.1.0.0/16"<br/>]</pre> | no |
 ## Outputs

--- a/azure/kubernetes/aks-single-region/README.md
+++ b/azure/kubernetes/aks-single-region/README.md
@@ -38,12 +38,12 @@
 | <a name="input_resource_prefix_placeholder"></a> [resource\_prefix\_placeholder](#input\_resource\_prefix\_placeholder) | Placeholder for the resource prefix | `string` | `""` | no |
 | <a name="input_subscription_id"></a> [subscription\_id](#input\_subscription\_id) | The Azure Subscription ID to deploy into | `string` | n/a | yes |
 | <a name="input_system_node_pool_count"></a> [system\_node\_pool\_count](#input\_system\_node\_pool\_count) | Number of nodes in the system node pool | `number` | `1` | no |
-| <a name="input_system_node_pool_vm_size"></a> [system\_node\_pool\_vm\_size](#input\_system\_node\_pool\_vm\_size) | VM size for the system node pool | `string` | `"Standard_D2s_v6"` | no |
+| <a name="input_system_node_pool_vm_size"></a> [system\_node\_pool\_vm\_size](#input\_system\_node\_pool\_vm\_size) | VM size for the system node pool | `string` | `"Standard_D2as_v6"` | no |
 | <a name="input_system_node_pool_zones"></a> [system\_node\_pool\_zones](#input\_system\_node\_pool\_zones) | List of AZs for the system node pool | `list(string)` | <pre>[<br/>  "1",<br/>  "2",<br/>  "3"<br/>]</pre> | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | <pre>{<br/>  "Environment": "Testing",<br/>  "Purpose": "Reference Implementation"<br/>}</pre> | no |
 | <a name="input_terraform_sp_app_id"></a> [terraform\_sp\_app\_id](#input\_terraform\_sp\_app\_id) | The Service Principals Application (client) ID that Terraform is using | `string` | n/a | yes |
 | <a name="input_user_node_pool_count"></a> [user\_node\_pool\_count](#input\_user\_node\_pool\_count) | Number of nodes in the user node pool | `number` | `5` | no |
-| <a name="input_user_node_pool_vm_size"></a> [user\_node\_pool\_vm\_size](#input\_user\_node\_pool\_vm\_size) | VM size for the user node pool | `string` | `"Standard_D4s_v6"` | no |
+| <a name="input_user_node_pool_vm_size"></a> [user\_node\_pool\_vm\_size](#input\_user\_node\_pool\_vm\_size) | VM size for the user node pool | `string` | `"Standard_D4as_v6"` | no |
 | <a name="input_user_node_pool_zones"></a> [user\_node\_pool\_zones](#input\_user\_node\_pool\_zones) | List of AZs for the user node pool | `list(string)` | <pre>[<br/>  "1",<br/>  "2",<br/>  "3"<br/>]</pre> | no |
 | <a name="input_vnet_address_space"></a> [vnet\_address\_space](#input\_vnet\_address\_space) | Address space for the virtual network | `list(string)` | <pre>[<br/>  "10.1.0.0/16"<br/>]</pre> | no |
 ## Outputs

--- a/azure/kubernetes/aks-single-region/README.md
+++ b/azure/kubernetes/aks-single-region/README.md
@@ -38,12 +38,12 @@
 | <a name="input_resource_prefix_placeholder"></a> [resource\_prefix\_placeholder](#input\_resource\_prefix\_placeholder) | Placeholder for the resource prefix | `string` | `""` | no |
 | <a name="input_subscription_id"></a> [subscription\_id](#input\_subscription\_id) | The Azure Subscription ID to deploy into | `string` | n/a | yes |
 | <a name="input_system_node_pool_count"></a> [system\_node\_pool\_count](#input\_system\_node\_pool\_count) | Number of nodes in the system node pool | `number` | `1` | no |
-| <a name="input_system_node_pool_vm_size"></a> [system\_node\_pool\_vm\_size](#input\_system\_node\_pool\_vm\_size) | VM size for the system node pool | `string` | `"Standard_D2as_v6"` | no |
+| <a name="input_system_node_pool_vm_size"></a> [system\_node\_pool\_vm\_size](#input\_system\_node\_pool\_vm\_size) | VM size for the system node pool | `string` | `"Standard_D2s_v5"` | no |
 | <a name="input_system_node_pool_zones"></a> [system\_node\_pool\_zones](#input\_system\_node\_pool\_zones) | List of AZs for the system node pool | `list(string)` | <pre>[<br/>  "1",<br/>  "2",<br/>  "3"<br/>]</pre> | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | <pre>{<br/>  "Environment": "Testing",<br/>  "Purpose": "Reference Implementation"<br/>}</pre> | no |
 | <a name="input_terraform_sp_app_id"></a> [terraform\_sp\_app\_id](#input\_terraform\_sp\_app\_id) | The Service Principals Application (client) ID that Terraform is using | `string` | n/a | yes |
 | <a name="input_user_node_pool_count"></a> [user\_node\_pool\_count](#input\_user\_node\_pool\_count) | Number of nodes in the user node pool | `number` | `5` | no |
-| <a name="input_user_node_pool_vm_size"></a> [user\_node\_pool\_vm\_size](#input\_user\_node\_pool\_vm\_size) | VM size for the user node pool | `string` | `"Standard_D4as_v6"` | no |
+| <a name="input_user_node_pool_vm_size"></a> [user\_node\_pool\_vm\_size](#input\_user\_node\_pool\_vm\_size) | VM size for the user node pool | `string` | `"Standard_D4s_v5"` | no |
 | <a name="input_user_node_pool_zones"></a> [user\_node\_pool\_zones](#input\_user\_node\_pool\_zones) | List of AZs for the user node pool | `list(string)` | <pre>[<br/>  "1",<br/>  "2",<br/>  "3"<br/>]</pre> | no |
 | <a name="input_vnet_address_space"></a> [vnet\_address\_space](#input\_vnet\_address\_space) | Address space for the virtual network | `list(string)` | <pre>[<br/>  "10.1.0.0/16"<br/>]</pre> | no |
 ## Outputs

--- a/azure/kubernetes/aks-single-region/test/golden/tfplan-golden.json
+++ b/azure/kubernetes/aks-single-region/test/golden/tfplan-golden.json
@@ -142,7 +142,7 @@
                     "node_soak_duration_in_minutes": 0
                   }
                 ],
-                "vm_size": "Standard_D2s_v6",
+                "vm_size": "Standard_D2as_v6",
                 "zones": [
                   "1",
                   "2",
@@ -280,7 +280,7 @@
             "timeouts": null,
             "ultra_ssd_enabled": false,
             "upgrade_settings": [],
-            "vm_size": "Standard_D4s_v6",
+            "vm_size": "Standard_D4as_v6",
             "windows_profile": [],
             "workload_runtime": null,
             "zones": [

--- a/azure/kubernetes/aks-single-region/test/golden/tfplan-golden.json
+++ b/azure/kubernetes/aks-single-region/test/golden/tfplan-golden.json
@@ -142,7 +142,7 @@
                     "node_soak_duration_in_minutes": 0
                   }
                 ],
-                "vm_size": "Standard_D2s_v3",
+                "vm_size": "Standard_D2s_v6",
                 "zones": [
                   "1",
                   "2",
@@ -280,7 +280,7 @@
             "timeouts": null,
             "ultra_ssd_enabled": false,
             "upgrade_settings": [],
-            "vm_size": "Standard_D4s_v3",
+            "vm_size": "Standard_D4s_v6",
             "windows_profile": [],
             "workload_runtime": null,
             "zones": [

--- a/azure/kubernetes/aks-single-region/test/golden/tfplan-golden.json
+++ b/azure/kubernetes/aks-single-region/test/golden/tfplan-golden.json
@@ -142,7 +142,7 @@
                     "node_soak_duration_in_minutes": 0
                   }
                 ],
-                "vm_size": "Standard_D2as_v6",
+                "vm_size": "Standard_D2s_v5",
                 "zones": [
                   "1",
                   "2",
@@ -280,7 +280,7 @@
             "timeouts": null,
             "ultra_ssd_enabled": false,
             "upgrade_settings": [],
-            "vm_size": "Standard_D4as_v6",
+            "vm_size": "Standard_D4s_v5",
             "windows_profile": [],
             "workload_runtime": null,
             "zones": [

--- a/azure/kubernetes/aks-single-region/variables.tf
+++ b/azure/kubernetes/aks-single-region/variables.tf
@@ -79,7 +79,7 @@ variable "system_node_pool_count" {
 variable "system_node_pool_vm_size" {
   description = "VM size for the system node pool"
   type        = string
-  default     = "Standard_D2s_v6"
+  default     = "Standard_D2as_v6"
 }
 
 variable "user_node_pool_count" {
@@ -91,7 +91,7 @@ variable "user_node_pool_count" {
 variable "user_node_pool_vm_size" {
   description = "VM size for the user node pool"
   type        = string
-  default     = "Standard_D4s_v6"
+  default     = "Standard_D4as_v6"
 }
 
 variable "system_node_pool_zones" {

--- a/azure/kubernetes/aks-single-region/variables.tf
+++ b/azure/kubernetes/aks-single-region/variables.tf
@@ -79,7 +79,7 @@ variable "system_node_pool_count" {
 variable "system_node_pool_vm_size" {
   description = "VM size for the system node pool"
   type        = string
-  default     = "Standard_D2s_v3"
+  default     = "Standard_D2s_v6"
 }
 
 variable "user_node_pool_count" {
@@ -91,7 +91,7 @@ variable "user_node_pool_count" {
 variable "user_node_pool_vm_size" {
   description = "VM size for the user node pool"
   type        = string
-  default     = "Standard_D4s_v3"
+  default     = "Standard_D4s_v6"
 }
 
 variable "system_node_pool_zones" {

--- a/azure/kubernetes/aks-single-region/variables.tf
+++ b/azure/kubernetes/aks-single-region/variables.tf
@@ -79,7 +79,7 @@ variable "system_node_pool_count" {
 variable "system_node_pool_vm_size" {
   description = "VM size for the system node pool"
   type        = string
-  default     = "Standard_D2as_v6"
+  default     = "Standard_D2s_v5"
 }
 
 variable "user_node_pool_count" {
@@ -91,7 +91,7 @@ variable "user_node_pool_count" {
 variable "user_node_pool_vm_size" {
   description = "VM size for the user node pool"
   type        = string
-  default     = "Standard_D4as_v6"
+  default     = "Standard_D4s_v5"
 }
 
 variable "system_node_pool_zones" {

--- a/azure/modules/aks/README.md
+++ b/azure/modules/aks/README.md
@@ -30,14 +30,14 @@ No modules.
 | <a name="input_subnet_id"></a> [subnet\_id](#input\_subnet\_id) | ID of the subnet where the AKS cluster will be deployed | `string` | n/a | yes |
 | <a name="input_system_node_disk_size_gb"></a> [system\_node\_disk\_size\_gb](#input\_system\_node\_disk\_size\_gb) | OS disk size in GB for system nodes | `number` | `30` | no |
 | <a name="input_system_node_pool_count"></a> [system\_node\_pool\_count](#input\_system\_node\_pool\_count) | Number of nodes in the system node pool | `number` | `3` | no |
-| <a name="input_system_node_pool_vm_size"></a> [system\_node\_pool\_vm\_size](#input\_system\_node\_pool\_vm\_size) | VM size for the system node pool | `string` | `"Standard_D2s_v3"` | no |
+| <a name="input_system_node_pool_vm_size"></a> [system\_node\_pool\_vm\_size](#input\_system\_node\_pool\_vm\_size) | VM size for the system node pool | `string` | `"Standard_D2s_v6"` | no |
 | <a name="input_system_node_pool_zones"></a> [system\_node\_pool\_zones](#input\_system\_node\_pool\_zones) | AZs for system node pool, e.g. ["1","2","3"] | `list(string)` | <pre>[<br/>  "1",<br/>  "2",<br/>  "3"<br/>]</pre> | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to apply to all resources | `map(string)` | `{}` | no |
 | <a name="input_uami_id"></a> [uami\_id](#input\_uami\_id) | User-assigned identity ID to use for KMS | `string` | n/a | yes |
 | <a name="input_uami_object_id"></a> [uami\_object\_id](#input\_uami\_object\_id) | User-assigned identity object ID to use for KMS | `string` | n/a | yes |
 | <a name="input_user_node_disk_size_gb"></a> [user\_node\_disk\_size\_gb](#input\_user\_node\_disk\_size\_gb) | OS disk size in GB for user nodes | `number` | `30` | no |
 | <a name="input_user_node_pool_count"></a> [user\_node\_pool\_count](#input\_user\_node\_pool\_count) | Number of nodes in the user node pool | `number` | `2` | no |
-| <a name="input_user_node_pool_vm_size"></a> [user\_node\_pool\_vm\_size](#input\_user\_node\_pool\_vm\_size) | VM size for the user node pool | `string` | `"Standard_D4s_v3"` | no |
+| <a name="input_user_node_pool_vm_size"></a> [user\_node\_pool\_vm\_size](#input\_user\_node\_pool\_vm\_size) | VM size for the user node pool | `string` | `"Standard_D4s_v6"` | no |
 | <a name="input_user_node_pool_zones"></a> [user\_node\_pool\_zones](#input\_user\_node\_pool\_zones) | AZs for user node pool | `list(string)` | <pre>[<br/>  "1",<br/>  "2",<br/>  "3"<br/>]</pre> | no |
 ## Outputs
 

--- a/azure/modules/aks/README.md
+++ b/azure/modules/aks/README.md
@@ -30,14 +30,14 @@ No modules.
 | <a name="input_subnet_id"></a> [subnet\_id](#input\_subnet\_id) | ID of the subnet where the AKS cluster will be deployed | `string` | n/a | yes |
 | <a name="input_system_node_disk_size_gb"></a> [system\_node\_disk\_size\_gb](#input\_system\_node\_disk\_size\_gb) | OS disk size in GB for system nodes | `number` | `30` | no |
 | <a name="input_system_node_pool_count"></a> [system\_node\_pool\_count](#input\_system\_node\_pool\_count) | Number of nodes in the system node pool | `number` | `3` | no |
-| <a name="input_system_node_pool_vm_size"></a> [system\_node\_pool\_vm\_size](#input\_system\_node\_pool\_vm\_size) | VM size for the system node pool | `string` | `"Standard_D2as_v6"` | no |
+| <a name="input_system_node_pool_vm_size"></a> [system\_node\_pool\_vm\_size](#input\_system\_node\_pool\_vm\_size) | VM size for the system node pool | `string` | `"Standard_D2s_v5"` | no |
 | <a name="input_system_node_pool_zones"></a> [system\_node\_pool\_zones](#input\_system\_node\_pool\_zones) | AZs for system node pool, e.g. ["1","2","3"] | `list(string)` | <pre>[<br/>  "1",<br/>  "2",<br/>  "3"<br/>]</pre> | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to apply to all resources | `map(string)` | `{}` | no |
 | <a name="input_uami_id"></a> [uami\_id](#input\_uami\_id) | User-assigned identity ID to use for KMS | `string` | n/a | yes |
 | <a name="input_uami_object_id"></a> [uami\_object\_id](#input\_uami\_object\_id) | User-assigned identity object ID to use for KMS | `string` | n/a | yes |
 | <a name="input_user_node_disk_size_gb"></a> [user\_node\_disk\_size\_gb](#input\_user\_node\_disk\_size\_gb) | OS disk size in GB for user nodes | `number` | `30` | no |
 | <a name="input_user_node_pool_count"></a> [user\_node\_pool\_count](#input\_user\_node\_pool\_count) | Number of nodes in the user node pool | `number` | `2` | no |
-| <a name="input_user_node_pool_vm_size"></a> [user\_node\_pool\_vm\_size](#input\_user\_node\_pool\_vm\_size) | VM size for the user node pool | `string` | `"Standard_D4as_v6"` | no |
+| <a name="input_user_node_pool_vm_size"></a> [user\_node\_pool\_vm\_size](#input\_user\_node\_pool\_vm\_size) | VM size for the user node pool | `string` | `"Standard_D4s_v5"` | no |
 | <a name="input_user_node_pool_zones"></a> [user\_node\_pool\_zones](#input\_user\_node\_pool\_zones) | AZs for user node pool | `list(string)` | <pre>[<br/>  "1",<br/>  "2",<br/>  "3"<br/>]</pre> | no |
 ## Outputs
 

--- a/azure/modules/aks/README.md
+++ b/azure/modules/aks/README.md
@@ -30,14 +30,14 @@ No modules.
 | <a name="input_subnet_id"></a> [subnet\_id](#input\_subnet\_id) | ID of the subnet where the AKS cluster will be deployed | `string` | n/a | yes |
 | <a name="input_system_node_disk_size_gb"></a> [system\_node\_disk\_size\_gb](#input\_system\_node\_disk\_size\_gb) | OS disk size in GB for system nodes | `number` | `30` | no |
 | <a name="input_system_node_pool_count"></a> [system\_node\_pool\_count](#input\_system\_node\_pool\_count) | Number of nodes in the system node pool | `number` | `3` | no |
-| <a name="input_system_node_pool_vm_size"></a> [system\_node\_pool\_vm\_size](#input\_system\_node\_pool\_vm\_size) | VM size for the system node pool | `string` | `"Standard_D2s_v6"` | no |
+| <a name="input_system_node_pool_vm_size"></a> [system\_node\_pool\_vm\_size](#input\_system\_node\_pool\_vm\_size) | VM size for the system node pool | `string` | `"Standard_D2as_v6"` | no |
 | <a name="input_system_node_pool_zones"></a> [system\_node\_pool\_zones](#input\_system\_node\_pool\_zones) | AZs for system node pool, e.g. ["1","2","3"] | `list(string)` | <pre>[<br/>  "1",<br/>  "2",<br/>  "3"<br/>]</pre> | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to apply to all resources | `map(string)` | `{}` | no |
 | <a name="input_uami_id"></a> [uami\_id](#input\_uami\_id) | User-assigned identity ID to use for KMS | `string` | n/a | yes |
 | <a name="input_uami_object_id"></a> [uami\_object\_id](#input\_uami\_object\_id) | User-assigned identity object ID to use for KMS | `string` | n/a | yes |
 | <a name="input_user_node_disk_size_gb"></a> [user\_node\_disk\_size\_gb](#input\_user\_node\_disk\_size\_gb) | OS disk size in GB for user nodes | `number` | `30` | no |
 | <a name="input_user_node_pool_count"></a> [user\_node\_pool\_count](#input\_user\_node\_pool\_count) | Number of nodes in the user node pool | `number` | `2` | no |
-| <a name="input_user_node_pool_vm_size"></a> [user\_node\_pool\_vm\_size](#input\_user\_node\_pool\_vm\_size) | VM size for the user node pool | `string` | `"Standard_D4s_v6"` | no |
+| <a name="input_user_node_pool_vm_size"></a> [user\_node\_pool\_vm\_size](#input\_user\_node\_pool\_vm\_size) | VM size for the user node pool | `string` | `"Standard_D4as_v6"` | no |
 | <a name="input_user_node_pool_zones"></a> [user\_node\_pool\_zones](#input\_user\_node\_pool\_zones) | AZs for user node pool | `list(string)` | <pre>[<br/>  "1",<br/>  "2",<br/>  "3"<br/>]</pre> | no |
 ## Outputs
 

--- a/azure/modules/aks/variables.tf
+++ b/azure/modules/aks/variables.tf
@@ -35,7 +35,7 @@ variable "tags" {
 variable "system_node_pool_vm_size" {
   description = "VM size for the system node pool"
   type        = string
-  default     = "Standard_D2s_v6"
+  default     = "Standard_D2as_v6"
 }
 
 variable "system_node_disk_size_gb" {
@@ -54,7 +54,7 @@ variable "system_node_pool_count" {
 variable "user_node_pool_vm_size" {
   description = "VM size for the user node pool"
   type        = string
-  default     = "Standard_D4s_v6"
+  default     = "Standard_D4as_v6"
 }
 
 variable "user_node_disk_size_gb" {

--- a/azure/modules/aks/variables.tf
+++ b/azure/modules/aks/variables.tf
@@ -35,7 +35,7 @@ variable "tags" {
 variable "system_node_pool_vm_size" {
   description = "VM size for the system node pool"
   type        = string
-  default     = "Standard_D2as_v6"
+  default     = "Standard_D2s_v5"
 }
 
 variable "system_node_disk_size_gb" {
@@ -54,7 +54,7 @@ variable "system_node_pool_count" {
 variable "user_node_pool_vm_size" {
   description = "VM size for the user node pool"
   type        = string
-  default     = "Standard_D4as_v6"
+  default     = "Standard_D4s_v5"
 }
 
 variable "user_node_disk_size_gb" {

--- a/azure/modules/aks/variables.tf
+++ b/azure/modules/aks/variables.tf
@@ -35,7 +35,7 @@ variable "tags" {
 variable "system_node_pool_vm_size" {
   description = "VM size for the system node pool"
   type        = string
-  default     = "Standard_D2s_v3"
+  default     = "Standard_D2s_v6"
 }
 
 variable "system_node_disk_size_gb" {
@@ -54,7 +54,7 @@ variable "system_node_pool_count" {
 variable "user_node_pool_vm_size" {
   description = "VM size for the user node pool"
   type        = string
-  default     = "Standard_D4s_v3"
+  default     = "Standard_D4s_v6"
 }
 
 variable "user_node_disk_size_gb" {


### PR DESCRIPTION
The current Azure nodes example needs too long to pull the Camunda images.
Easily up to 20 minutes for a 500 mb image, with the default baseline being round about a minute.

Could also be local disk throughput issue, difficult to pinpoint.

The following proposal is switching to a newer tier. It has a higher network throughput and higher disk throughput, which hopefully helps with the image pull issues.

- [ ] backport 8.7

tried out instance types:
- Standard_D4s_v6 (latest) - not supported in all zones of a region
- Standard_D4as_v6 (latest, different type) - not enough quota, would need IT
- Standard_D4s_v5 (previous gen) - supported, should fit the quota, let's see how it perfoms ... 

Same problem for now, maybe not even a node related issue on their sizing but something wrong within AKS specific K8s version.
Or something from docker hub that they throttle to Microsoft but also strange considering that for some it works instant.