### PR TITLE
fix: Azure switch registry mostly to Harbor

### DIFF
--- a/.github/workflows/azure_kubernetes_aks_single_region_tests.yml
+++ b/.github/workflows/azure_kubernetes_aks_single_region_tests.yml
@@ -338,6 +338,9 @@ jobs:
                       secret/data/products/infrastructure-experience/ci/common AZURE_TENANT_ID;
                       secret/data/products/infrastructure-experience/ci/common AZURE_SUBSCRIPTION_ID;
                       secret/data/products/infrastructure-experience/ci/common CI_ENCRYPTION_KEY;
+                      secret/data/products/infrastructure-experience/ci/common MACHINE_USR;
+                      secret/data/products/infrastructure-experience/ci/common MACHINE_PWD;
+
 
             - name: 🚢 Retrieve environment variables from outputs
               uses: ./.github/actions/internal-generic-decrypt-import
@@ -510,7 +513,7 @@ jobs:
 
                   # Add integration tests values
                   if [ "$TESTS_ENABLED" == "true" ]; then
-                    for file in registry.yml identity.yml; do
+                    for file in registry-harbor.yml identity.yml; do
                       yq ". *+ load(\"generic/kubernetes/single-region/tests/helm-values/$file\")" values.yml > values-result.yml
                       cat values-result.yml && mv values-result.yml values.yml
                     done
@@ -569,6 +572,12 @@ jobs:
                         --docker-server=index.docker.io \
                         --docker-username="${{ steps.secrets.outputs.DOCKERHUB_USER }}" \
                         --docker-password="${{ steps.secrets.outputs.DOCKERHUB_PASSWORD }}" \
+                        --namespace="$CAMUNDA_NAMESPACE"
+
+                    kubectl create secret docker-registry registry-camunda-cloud \
+                        --docker-server=registry.camunda.cloud \
+                        --docker-username="${{ steps.secrets.outputs.MACHINE_USR }}" \
+                        --docker-password="${{ steps.secrets.outputs.MACHINE_PWD }}" \
                         --namespace="$CAMUNDA_NAMESPACE"
 
                     kubectl create secret generic identity-secret-for-components-integration \

--- a/azure/kubernetes/aks-single-region/manifests/setup-postgres-create-db.yml
+++ b/azure/kubernetes/aks-single-region/manifests/setup-postgres-create-db.yml
@@ -12,7 +12,7 @@ spec:
             restartPolicy: Never
             containers:
                 - name: create-setup-user-db
-                  image: alpine/psql:15
+                  image: alpine/psql:15.5
                   command:
                       - sh
                       - -c

--- a/azure/kubernetes/aks-single-region/manifests/setup-postgres-create-db.yml
+++ b/azure/kubernetes/aks-single-region/manifests/setup-postgres-create-db.yml
@@ -12,12 +12,12 @@ spec:
             restartPolicy: Never
             containers:
                 - name: create-setup-user-db
-                  image: postgres:15
+                  image: alpine/psql:15
                   command:
                       - sh
                       - -c
                       - |
-                        /bin/bash <<'EOF'
+                        /bin/sh <<'EOF'
                         set -o pipefail
                         set -e  # Exit on error
 

--- a/generic/kubernetes/single-region/tests/helm-values/registry-harbor.yml
+++ b/generic/kubernetes/single-region/tests/helm-values/registry-harbor.yml
@@ -62,3 +62,7 @@ webModeler:
 connectors:
     image:
         repository: registry.camunda.cloud/dockerhub-camunda/camunda/connectors-bundle
+
+console:
+    image:
+        repository: registry.camunda.cloud/dockerhub-camunda/camunda/console

--- a/generic/kubernetes/single-region/tests/helm-values/registry-harbor.yml
+++ b/generic/kubernetes/single-region/tests/helm-values/registry-harbor.yml
@@ -1,0 +1,58 @@
+---
+# This file contains specific values used during the integration tests
+# Using the Camunda harbor registry as Docker Hub is too slow on Azure
+identityKeycloak:
+    image:
+        repository: registry.camunda.cloud/dockerhub-camunda/camunda/keycloak
+        pullSecrets:
+            - name: registry-camunda-cloud
+
+global:
+    image:
+        pullSecrets:
+            - name: registry-camunda-cloud
+
+elasticsearch:
+    image: registry.camunda.cloud/dockerhub-camunda/bitnami/elasticsearch
+    global:
+        imagePullSecrets:
+            - name: registry-camunda-cloud
+
+zeebe:
+    image:
+        repository: registry.camunda.cloud/dockerhub-camunda/camunda/zeebe
+
+zeebeGateway:
+    image:
+        repository: registry.camunda.cloud/dockerhub-camunda/camunda/zeebe
+
+operate:
+    image:
+        repository: registry.camunda.cloud/dockerhub-camunda/camunda/operate
+
+tasklist:
+    image:
+        repository: registry.camunda.cloud/dockerhub-camunda/camunda/tasklist
+
+identity:
+    image:
+        repository: registry.camunda.cloud/dockerhub-camunda/camunda/identity
+
+optimize:
+    image:
+        repository: registry.camunda.cloud/dockerhub-camunda/camunda/optimize
+
+webModeler:
+    restapi:
+        image:
+            repository: registry.camunda.cloud/dockerhub-camunda/camunda/web-modeler-restapi
+    webapp:
+        image:
+            repository: registry.camunda.cloud/dockerhub-camunda/camunda/web-modeler-webapp
+    websockets:
+        image:
+            repository: registry.camunda.cloud/dockerhub-camunda/camunda/web-modeler-websockets
+
+connectors:
+    image:
+        repository: registry.camunda.cloud/dockerhub-camunda/camunda/connectors-bundle

--- a/generic/kubernetes/single-region/tests/helm-values/registry-harbor.yml
+++ b/generic/kubernetes/single-region/tests/helm-values/registry-harbor.yml
@@ -3,7 +3,8 @@
 # Using the Camunda harbor registry as Docker Hub is too slow on Azure
 identityKeycloak:
     image:
-        repository: registry.camunda.cloud/dockerhub-camunda/camunda/keycloak
+        registry: registry.camunda.cloud
+        repository: dockerhub-camunda/camunda/keycloak
         pullSecrets:
             - name: registry-camunda-cloud
 
@@ -13,7 +14,12 @@ global:
             - name: registry-camunda-cloud
 
 elasticsearch:
-    image: registry.camunda.cloud/dockerhub-camunda/bitnami/elasticsearch
+    image:
+        registry: registry.camunda.cloud
+        repository: dockerhub-camunda/bitnami/elasticsearch
+    sysctlImage:
+        registry: registry.camunda.cloud
+        repository: dockerhub-camunda/bitnami/os-shell
     global:
         imagePullSecrets:
             - name: registry-camunda-cloud


### PR DESCRIPTION
We have problems with the network between swedencentral and Docker Hub resulting in very slow download speeds causing test failures.

One of the approach ideas was to switch temporarily to the Camunda Harbor registry.

An another alternative is to explore switching regions but that requires IT involvement again as we don't have the permissions. If Infra complains, definitely a thing to explore.

Changes:
- Switch Postgres image to psql
- Add registry test overlay + secret creation for Azure tests to consume Harbor

Example execution:
https://github.com/camunda/camunda-deployment-references/actions/runs/17259728723