### PR TITLE
fix: Azure switch registry 8.7

### DIFF
--- a/.github/workflows/azure_kubernetes_aks_single_region_tests.yml
+++ b/.github/workflows/azure_kubernetes_aks_single_region_tests.yml
@@ -337,6 +337,9 @@ jobs:
                       secret/data/products/infrastructure-experience/ci/common AZURE_TENANT_ID;
                       secret/data/products/infrastructure-experience/ci/common AZURE_SUBSCRIPTION_ID;
                       secret/data/products/infrastructure-experience/ci/common CI_ENCRYPTION_KEY;
+                      secret/data/products/infrastructure-experience/ci/common MACHINE_USR;
+                      secret/data/products/infrastructure-experience/ci/common MACHINE_PWD;
+
 
             - name: 🚢 Retrieve environment variables from outputs
               uses: ./.github/actions/internal-generic-decrypt-import
@@ -509,7 +512,7 @@ jobs:
 
                   # Add integration tests values
                   if [ "$TESTS_ENABLED" == "true" ]; then
-                    for file in registry.yml identity.yml; do
+                    for file in registry-harbor.yml identity.yml; do
                       yq ". *+ load(\"generic/kubernetes/single-region/tests/helm-values/$file\")" values.yml > values-result.yml
                       cat values-result.yml && mv values-result.yml values.yml
                     done
@@ -568,6 +571,12 @@ jobs:
                         --docker-server=index.docker.io \
                         --docker-username="${{ steps.secrets.outputs.DOCKERHUB_USER }}" \
                         --docker-password="${{ steps.secrets.outputs.DOCKERHUB_PASSWORD }}" \
+                        --namespace="$CAMUNDA_NAMESPACE"
+
+                    kubectl create secret docker-registry registry-camunda-cloud \
+                        --docker-server=registry.camunda.cloud \
+                        --docker-username="${{ steps.secrets.outputs.MACHINE_USR }}" \
+                        --docker-password="${{ steps.secrets.outputs.MACHINE_PWD }}" \
                         --namespace="$CAMUNDA_NAMESPACE"
 
                     kubectl create secret generic identity-secret-for-components-integration \

--- a/azure/kubernetes/aks-single-region/manifests/setup-postgres-create-db.yml
+++ b/azure/kubernetes/aks-single-region/manifests/setup-postgres-create-db.yml
@@ -12,12 +12,12 @@ spec:
             restartPolicy: Never
             containers:
                 - name: create-setup-user-db
-                  image: postgres:15
+                  image: alpine/psql:15.5
                   command:
                       - sh
                       - -c
                       - |
-                        /bin/bash <<'EOF'
+                        /bin/sh <<'EOF'
                         set -o pipefail
                         set -e  # Exit on error
 

--- a/generic/kubernetes/single-region/tests/helm-values/registry-harbor.yml
+++ b/generic/kubernetes/single-region/tests/helm-values/registry-harbor.yml
@@ -1,0 +1,68 @@
+---
+# This file contains specific values used during the integration tests
+# Using the Camunda harbor registry as Docker Hub is too slow on Azure
+identityKeycloak:
+    image:
+        registry: registry.camunda.cloud
+        repository: dockerhub-camunda/camunda/keycloak
+        pullSecrets:
+            - name: registry-camunda-cloud
+
+global:
+    image:
+        pullSecrets:
+            - name: registry-camunda-cloud
+
+elasticsearch:
+    image:
+        registry: registry.camunda.cloud
+        repository: dockerhub-camunda/bitnami/elasticsearch
+    sysctlImage:
+        registry: registry.camunda.cloud
+        repository: dockerhub-camunda/bitnami/os-shell
+    global:
+        imagePullSecrets:
+            - name: registry-camunda-cloud
+
+zeebe:
+    image:
+        repository: registry.camunda.cloud/dockerhub-camunda/camunda/zeebe
+
+zeebeGateway:
+    image:
+        repository: registry.camunda.cloud/dockerhub-camunda/camunda/zeebe
+
+operate:
+    image:
+        repository: registry.camunda.cloud/dockerhub-camunda/camunda/operate
+
+tasklist:
+    image:
+        repository: registry.camunda.cloud/dockerhub-camunda/camunda/tasklist
+
+identity:
+    image:
+        repository: registry.camunda.cloud/dockerhub-camunda/camunda/identity
+
+optimize:
+    image:
+        repository: registry.camunda.cloud/dockerhub-camunda/camunda/optimize
+
+webModeler:
+    restapi:
+        image:
+            repository: registry.camunda.cloud/dockerhub-camunda/camunda/web-modeler-restapi
+    webapp:
+        image:
+            repository: registry.camunda.cloud/dockerhub-camunda/camunda/web-modeler-webapp
+    websockets:
+        image:
+            repository: registry.camunda.cloud/dockerhub-camunda/camunda/web-modeler-websockets
+
+connectors:
+    image:
+        repository: registry.camunda.cloud/dockerhub-camunda/camunda/connectors-bundle
+
+console:
+    image:
+        repository: registry.camunda.cloud/dockerhub-camunda/camunda/console


### PR DESCRIPTION
backport of the azure fix: https://github.com/camunda/camunda-deployment-references/pull/916

will merge after successful run.

depends on https://github.com/camunda/camunda-deployment-references/pull/921

the helm chart reference is lagging too much behind as `allowInsecure` was only introduced in 12.3 or so.