### PR TITLE
fix: renovate annotation ordering to properly update helm chart

### DIFF
--- a/aws/openshift/rosa-hcp-dual-region/procedure/export_environment_prerequisites.sh
+++ b/aws/openshift/rosa-hcp-dual-region/procedure/export_environment_prerequisites.sh
@@ -29,5 +29,5 @@ export AWS_ES_BUCKET_REGION=""
 
 # The Helm release name used for installing Camunda 8 in both Kubernetes clusters
 export HELM_RELEASE_NAME=camunda
-# renovate: datasource=helm depName=camunda-platform registryUrl=https://helm.camunda.io
-export HELM_CHART_VERSION=11.3.2
+# renovate: datasource=helm depName=camunda-platform registryUrl=https://helm.camunda.io versioning=regex:^11(\.(?<minor>\d+))?(\.(?<patch>\d+))?$
+export HELM_CHART_VERSION=11.8.0

--- a/generic/openshift/single-region/procedure/chart-env.sh
+++ b/generic/openshift/single-region/procedure/chart-env.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 # The Camunda 8 Helm Chart version
-# renovate: datasource=helm depName=camunda-platform versioning=regex:^11(\.(?<minor>\d+))?(\.(?<patch>\d+))?$ registryUrl=https://helm.camunda.io
-export CAMUNDA_HELM_CHART_VERSION="11.3.2"
+# renovate: datasource=helm depName=camunda-platform registryUrl=https://helm.camunda.io versioning=regex:^11(\.(?<minor>\d+))?(\.(?<patch>\d+))?$
+export CAMUNDA_HELM_CHART_VERSION="11.8.0"


### PR DESCRIPTION
Two issues in here:

1.

```
# renovate: datasource=helm depName=camunda-platform registryUrl=https://helm.camunda.io
export HELM_CHART_VERSION=11.8.0
```

Will not search for version 11 but only version 12, so latest published stable version.
Adding the regex will fix it and search only for major 11 versions.

<img width="1116" height="71" alt="image" src="https://github.com/user-attachments/assets/5bfd8306-f301-4934-9061-de39a06b98e2" />

2.

```
# renovate: datasource=helm depName=camunda-platform registryUrl=https://helm.camunda.io versioning=regex:^11(\.(?<minor>\d+))?(\.(?<patch>\d+))?$
```

The order is important, if registryUrl comes after the version it will be interpreted as part of the version.