### PR TITLE
fix: renovate annotation ordering to properly update helm chart

### DIFF
--- a/generic/kubernetes/single-region/procedure/chart-env.sh
+++ b/generic/kubernetes/single-region/procedure/chart-env.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 # The Camunda 8 Helm Chart version
-# renovate: datasource=helm depName=camunda-platform versioning=regex:^12(\.(?<minor>\d+))?(\.(?<patch>\d+))?$ registryUrl=https://helm.camunda.io
-export CAMUNDA_HELM_CHART_VERSION="12.0.2"
+# renovate: datasource=helm depName=camunda-platform registryUrl=https://helm.camunda.io versioning=regex:^12(\.(?<minor>\d+))?(\.(?<patch>\d+))?$
+export CAMUNDA_HELM_CHART_VERSION="12.4.0"
 
 export CAMUNDA_NAMESPACE="camunda"
 export CAMUNDA_RELEASE_NAME="camunda"

--- a/generic/openshift/dual-region/procedure/chart-env.sh
+++ b/generic/openshift/dual-region/procedure/chart-env.sh
@@ -29,5 +29,5 @@ export AWS_ES_BUCKET_REGION=""
 
 # The Helm release name used for installing Camunda 8 in both Kubernetes clusters
 export CAMUNDA_RELEASE_NAME=camunda
-# renovate: datasource=helm depName=camunda-platform registryUrl=https://helm.camunda.io
+# renovate: datasource=helm depName=camunda-platform registryUrl=https://helm.camunda.io versioning=regex:^12(\.(?<minor>\d+))?(\.(?<patch>\d+))?$
 export HELM_CHART_VERSION=12.4.0

--- a/generic/openshift/single-region/procedure/chart-env.sh
+++ b/generic/openshift/single-region/procedure/chart-env.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 # The Camunda 8 Helm Chart version
-# renovate: datasource=helm depName=camunda-platform versioning=regex:^12(\.(?<minor>\d+))?(\.(?<patch>\d+))?$ registryUrl=https://helm.camunda.io
-export CAMUNDA_HELM_CHART_VERSION="12.0.2"
+# renovate: datasource=helm depName=camunda-platform registryUrl=https://helm.camunda.io versioning=regex:^12(\.(?<minor>\d+))?(\.(?<patch>\d+))?$
+export CAMUNDA_HELM_CHART_VERSION="12.4.0"
 
 export CAMUNDA_NAMESPACE="camunda"
 export CAMUNDA_RELEASE_NAME="camunda"


### PR DESCRIPTION
```
# renovate: datasource=helm depName=camunda-platform registryUrl=https://helm.camunda.io versioning=regex:^11(\.(?<minor>\d+))?(\.(?<patch>\d+))?$
```

The order is important, if registryUrl comes after the version it will be interpreted as part of the version.

As well as fixes future issues when a new major is released by searching explicitly for version 12 in one case was missing.

Makes sense it's failing in Azure since the fix is depending on the changes in here.