### PR TITLE
fix: cleanup script loose matching

### DIFF
--- a/.github/actions/aws-generic-terraform-cleanup/scripts/destroy-resources.sh
+++ b/.github/actions/aws-generic-terraform-cleanup/scripts/destroy-resources.sh
@@ -183,7 +183,7 @@ fi
 if [ "$ID_OR_ALL" == "all" ]; then
   groups=$(echo "$all_objects" | awk '{print $NF}' | sed -n 's#.*/tfstate-\([^/]*\)/.*#\1#p' | sort -u)
 else
-  groups=$(echo "$all_objects" | awk '{print $NF}' | grep "tfstate-$ID_OR_ALL/" | sed -n 's#.*/tfstate-\([^/]*\)/.*#\1#p' | sort -u)
+  groups=$(echo "$all_objects" | awk '{print $NF}' | grep "$ID_OR_ALL" | sed -n 's#.*/tfstate-\([^/]*\)/.*#\1#p' | sort -u)
   if [ -z "$groups" ] && [ "$FAIL_ON_NOT_FOUND" = true ]; then
     echo "Error: No object found for ID '$ID_OR_ALL'"
     exit 1


### PR DESCRIPTION
related to [slack](https://camunda.slack.com/archives/C076N4G1162/p1756791199838569?thread_ts=1756791167.199409&cid=C076N4G1162)

in case of dual-region it's not able to find it since the `tfstate` is something like `tfstate-cluster-1-cluster-2` so one approach is to just generally look for the `id` or if that's not wanted, removing the trailing `/` would also be sufficient.

It would then able to parse the group `hci-2b597-559de-1-oOo-hci-2b597-559de-2` and execute the follow up items.