### PR TITLE
chore: backport link-checker ignore

### DIFF
--- a/lychee-links.toml
+++ b/lychee-links.toml
@@ -16,4 +16,5 @@ exclude_path = [
 # Explicitly exclude some URLs
 exclude = [
   "^file:",
+  "https://developer.hashicorp.com/*", # vercel security check causing issues
 ]


### PR DESCRIPTION
backports link checker fix that is already on stable/8.7 and main.