### PR TITLE
chore: add certificate debug output for aks and eks [ci skip]

### DIFF
--- a/.github/workflows/aws_kubernetes_eks_single_region_tests.yml
+++ b/.github/workflows/aws_kubernetes_eks_single_region_tests.yml
@@ -711,6 +711,14 @@ jobs:
                   test-cluster-type: ${{ env.TEST_CLUSTER_TYPE }}
                   test-release-name: ${{ env.CAMUNDA_RELEASE_NAME }}
 
+            - name: 🔬🚨 Get failed certificate info
+              if: failure() && matrix.declination.name == 'domain'
+              run: |
+                  set -euo pipefail
+
+                  kubectl -n "$CAMUNDA_NAMESPACE" get certificates
+                  kubectl -n "$CAMUNDA_NAMESPACE" describe certificates
+
             - name: 🔬🚨 Get failed Pods info
               timeout-minutes: 10
               if: failure()

--- a/.github/workflows/azure_kubernetes_aks_single_region_tests.yml
+++ b/.github/workflows/azure_kubernetes_aks_single_region_tests.yml
@@ -646,6 +646,14 @@ jobs:
                   test-cluster-type: ${{ env.TEST_CLUSTER_TYPE }}
                   test-release-name: ${{ env.CAMUNDA_RELEASE_NAME }}
 
+            - name: 🔬🚨 Get failed certificate info
+              if: failure() && matrix.declination.name == 'domain'
+              run: |
+                  set -euo pipefail
+
+                  kubectl -n "$CAMUNDA_NAMESPACE" get certificates
+                  kubectl -n "$CAMUNDA_NAMESPACE" describe certificates
+
             - name: 🔬🚨 Get failed Pods info
               if: failure()
               run: |


### PR DESCRIPTION
related to https://camunda.slack.com/archives/C076N4G1162/p1759896822221909

in case of failure and domain print the certificates and describe them.
So we know whether they succeeded or timeout or similar.