### PR TITLE
feat: Add workflow to save Aurora PostgreSQL versions as artifact

### DIFF
--- a/.github/workflows/internal_aws_artifact_aurora_versions.yml
+++ b/.github/workflows/internal_aws_artifact_aurora_versions.yml
@@ -13,7 +13,7 @@ on:
 
 env:
     AWS_REGION: eu-west-2
-    AWS_PROFILE: infreaex
+    AWS_PROFILE: infraex
 
 jobs:
     save-aurora-versions:

--- a/.github/workflows/internal_aws_artifact_opensearch_versions.yml
+++ b/.github/workflows/internal_aws_artifact_opensearch_versions.yml
@@ -13,7 +13,7 @@ on:
 
 env:
     AWS_REGION: eu-west-2
-    AWS_PROFILE: infreaex
+    AWS_PROFILE: infraex
 
 jobs:
     save-opensearch-versions:


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for managing Aurora PostgreSQL version artifacts and includes a minor fix to an existing workflow. The main focus is on automating the retrieval and publishing of Aurora PostgreSQL versions for use by other tools, with added reliability and notification features.

New Aurora PostgreSQL artifact workflow:

* Added `.github/workflows/internal_aws_artifact_aurora_versions.yml` to automate fetching Aurora PostgreSQL versions from AWS, saving them to `docs/aurora_postgres_versions.txt`, and committing updates to the `gh-pages` branch. This workflow runs nightly, on demand, and on pull requests affecting itself.
* Configured Slack notifications for workflow failures when triggered by the scheduled event, improving visibility of operational issues.

Bug fix in existing workflow:

* Corrected a typo in the environment variable `AWS_PROFILE` from `infreaex` to `infraex` in `.github/workflows/internal_aws_artifact_opensearch_versions.yml` to ensure proper AWS profile usage.