### PR TITLE
chore: bump renovate annotations

### DIFF
--- a/.github/actions/aws-opensearch-manage-cluster/action.yml
+++ b/.github/actions/aws-opensearch-manage-cluster/action.yml
@@ -16,7 +16,7 @@ inputs:
 
     engine-version:
         description: Version of the OpenSearch engine to deploy
-        # renovate: datasource=custom.opensearch-camunda depName=opensearch versioning=semver
+        # renovate: datasource=custom.opensearch-camunda depName=opensearch versioning=loose
         default: '2.19'
 
     vpc-id:

--- a/aws/compute/ec2-single-region/terraform/cluster/opensearch.tf
+++ b/aws/compute/ec2-single-region/terraform/cluster/opensearch.tf
@@ -25,7 +25,7 @@ module "opensearch_domain" {
   count = local.opensearch_enable ? 1 : 0
 
   domain_name = local.opensearch_domain_name
-  # renovate: datasource=custom.opensearch-camunda depName=opensearch versioning=semver
+  # renovate: datasource=custom.opensearch-camunda depName=opensearch versioning=loose
   engine_version = "2.19"
   subnet_ids     = module.vpc.private_subnets
   vpc_id         = module.vpc.vpc_id

--- a/aws/kubernetes/eks-single-region-irsa/terraform/cluster/db.tf
+++ b/aws/kubernetes/eks-single-region-irsa/terraform/cluster/db.tf
@@ -25,7 +25,8 @@ locals {
 }
 
 module "postgresql" {
-  source                     = "../../../../modules/aurora"
+  source = "../../../../modules/aurora"
+  # renovate: datasource=custom.aurora-pg-camunda depName=aurora-postgresql versioning=loose
   engine_version             = "17.5"
   auto_minor_version_upgrade = false
   cluster_name               = local.aurora_cluster_name

--- a/aws/kubernetes/eks-single-region-irsa/terraform/cluster/opensearch.tf
+++ b/aws/kubernetes/eks-single-region-irsa/terraform/cluster/opensearch.tf
@@ -18,7 +18,7 @@ locals {
 module "opensearch_domain" {
   source      = "../../../../modules/opensearch"
   domain_name = local.opensearch_domain_name
-  # renovate: datasource=custom.opensearch-camunda depName=opensearch versioning=semver
+  # renovate: datasource=custom.opensearch-camunda depName=opensearch versioning=loose
   engine_version = "2.19"
 
   instance_type   = "m7i.large.search"

--- a/aws/kubernetes/eks-single-region/terraform/cluster/db.tf
+++ b/aws/kubernetes/eks-single-region/terraform/cluster/db.tf
@@ -21,7 +21,8 @@ locals {
 }
 
 module "postgresql" {
-  source                     = "../../../../modules/aurora"
+  source = "../../../../modules/aurora"
+  # renovate: datasource=custom.aurora-pg-camunda depName=aurora-postgresql versioning=loose
   engine_version             = "17.5"
   auto_minor_version_upgrade = false
   cluster_name               = local.aurora_cluster_name

--- a/aws/kubernetes/eks-single-region/terraform/cluster/opensearch.tf
+++ b/aws/kubernetes/eks-single-region/terraform/cluster/opensearch.tf
@@ -6,7 +6,7 @@ locals {
 module "opensearch_domain" {
   source      = "../../../../modules/opensearch"
   domain_name = local.opensearch_domain_name
-  # renovate: datasource=custom.opensearch-camunda depName=opensearch versioning=semver
+  # renovate: datasource=custom.opensearch-camunda depName=opensearch versioning=loose
   engine_version = "2.19"
 
   instance_type = "m7i.large.search"


### PR DESCRIPTION
This pull request updates the versioning strategy for OpenSearch and Aurora PostgreSQL dependencies managed by Renovate across several Terraform and GitHub Action configuration files. The main change is switching from strict semantic versioning (`semver`) to a looser versioning scheme (`loose`), which allows for more flexible upgrades.

Dependency management updates:

* Changed the Renovate versioning for OpenSearch from `semver` to `loose` in `.github/actions/aws-opensearch-manage-cluster/action.yml`, `aws/compute/ec2-single-region/terraform/cluster/opensearch.tf`, `aws/kubernetes/eks-single-region-irsa/terraform/cluster/opensearch.tf`, and `aws/kubernetes/eks-single-region/terraform/cluster/opensearch.tf` to enable less restrictive updates. [[1]](diffhunk://#diff-b723335f58fab7c2c37eb91330deb2cdb3df9f62ff9a629692f8d3a162065ca8L19-R19) [[2]](diffhunk://#diff-0fd1d0d2a3572b337e0e0e2cb00373a4cbf5071f358cd2845531b77368edd59bL28-R28) [[3]](diffhunk://#diff-aaf596dafb632f4dfcb928f28dc219f92f6bc54e0e095577ac1aa1d7fc6e4d3dL21-R21) [[4]](diffhunk://#diff-4c63524b6e378bc06111b481af4e9352c660963a6c7557032f7f52c59e0b9b08L9-R9)

* Added Renovate configuration for Aurora PostgreSQL with `loose` versioning in `aws/kubernetes/eks-single-region-irsa/terraform/cluster/db.tf` and `aws/kubernetes/eks-single-region/terraform/cluster/db.tf` to allow more flexible dependency updates. [[1]](diffhunk://#diff-a964d5f3007d528a211e676c0bab44a3dc4d5b4a11a7e7f3a83a55733e84f50aR29) [[2]](diffhunk://#diff-d34e6013ea49dea25c53916c981c4fc5f6f1a72950a377a36bf5bc12fdba2b36R25)