### PR TITLE
chore(stable-8.6): backport wildcard certificate actions for EKS and …

### DIFF
--- a/.github/actions/aws-kubernetes-ingress-setup/README.md
+++ b/.github/actions/aws-kubernetes-ingress-setup/README.md
@@ -1,0 +1,106 @@
+# AWS Kubernetes Ingress Setup
+
+## Description
+
+Install and configure ingress-nginx, external-dns, and cert-manager for AWS EKS clusters
+
+## Inputs
+
+| name | description | required | default |
+| --- | --- | --- | --- |
+| `cluster-name` | <p>Name of the cluster (used for external-dns owner ID)</p> | `true` | `""` |
+| `scenario-short-name` | <p>Short name of the scenario (used for external-dns owner ID)</p> | `true` | `""` |
+| `aws-region` | <p>AWS region where the cluster is deployed</p> | `true` | `eu-west-2` |
+| `mail` | <p>Email address for Let's Encrypt certificates</p> | `false` | `admin@camunda.ie` |
+| `tld` | <p>Top-level domain for the cluster</p> | `false` | `camunda.ie` |
+| `ref-arch` | <p>Reference architecture name (eks-single-region, eks-single-region-irsa)</p> | `false` | `eks-single-region` |
+| `use-wildcard-cert` | <p>Use wildcard certificate from Vault instead of ACME/Let's Encrypt. When true, ACME issuer is not installed and wildcard certificate is created from Vault.</p> | `false` | `false` |
+| `wildcard-cert-namespace` | <p>Namespace where the wildcard TLS certificate will be created (when use-wildcard-cert is true)</p> | `false` | `camunda` |
+| `wildcard-cert-secret-name` | <p>Name of the wildcard TLS secret to create (when use-wildcard-cert is true)</p> | `false` | `camunda-tls` |
+| `vault-addr` | <p>Vault server address (required when use-wildcard-cert is true)</p> | `false` | `""` |
+| `vault-role-id` | <p>Vault AppRole role ID (required when use-wildcard-cert is true)</p> | `false` | `""` |
+| `vault-secret-id` | <p>Vault AppRole secret ID (required when use-wildcard-cert is true)</p> | `false` | `""` |
+
+
+## Runs
+
+This action is a `composite` action.
+
+## Usage
+
+```yaml
+- uses: camunda/camunda-deployment-references/.github/actions/aws-kubernetes-ingress-setup@main
+  with:
+    cluster-name:
+    # Name of the cluster (used for external-dns owner ID)
+    #
+    # Required: true
+    # Default: ""
+
+    scenario-short-name:
+    # Short name of the scenario (used for external-dns owner ID)
+    #
+    # Required: true
+    # Default: ""
+
+    aws-region:
+    # AWS region where the cluster is deployed
+    #
+    # Required: true
+    # Default: eu-west-2
+
+    mail:
+    # Email address for Let's Encrypt certificates
+    #
+    # Required: false
+    # Default: admin@camunda.ie
+
+    tld:
+    # Top-level domain for the cluster
+    #
+    # Required: false
+    # Default: camunda.ie
+
+    ref-arch:
+    # Reference architecture name (eks-single-region, eks-single-region-irsa)
+    #
+    # Required: false
+    # Default: eks-single-region
+
+    use-wildcard-cert:
+    # Use wildcard certificate from Vault instead of ACME/Let's Encrypt.
+    # When true, ACME issuer is not installed and wildcard certificate is created from Vault.
+    #
+    # Required: false
+    # Default: false
+
+    wildcard-cert-namespace:
+    # Namespace where the wildcard TLS certificate will be created (when use-wildcard-cert is true)
+    #
+    # Required: false
+    # Default: camunda
+
+    wildcard-cert-secret-name:
+    # Name of the wildcard TLS secret to create (when use-wildcard-cert is true)
+    #
+    # Required: false
+    # Default: camunda-tls
+
+    vault-addr:
+    # Vault server address (required when use-wildcard-cert is true)
+    #
+    # Required: false
+    # Default: ""
+
+    vault-role-id:
+    # Vault AppRole role ID (required when use-wildcard-cert is true)
+    #
+    # Required: false
+    # Default: ""
+
+    vault-secret-id:
+    # Vault AppRole secret ID (required when use-wildcard-cert is true)
+    #
+    # Required: false
+    # Default: ""
+```

--- a/.github/actions/aws-kubernetes-ingress-setup/action.yml
+++ b/.github/actions/aws-kubernetes-ingress-setup/action.yml
@@ -1,0 +1,139 @@
+---
+name: AWS Kubernetes Ingress Setup
+description: Install and configure ingress-nginx, external-dns, and cert-manager for AWS EKS clusters
+
+inputs:
+    cluster-name:
+        description: Name of the cluster (used for external-dns owner ID)
+        required: true
+    scenario-short-name:
+        description: Short name of the scenario (used for external-dns owner ID)
+        required: true
+    aws-region:
+        description: AWS region where the cluster is deployed
+        required: true
+        default: eu-west-2
+    mail:
+        description: Email address for Let's Encrypt certificates
+        required: false
+        default: admin@camunda.ie
+    tld:
+        description: Top-level domain for the cluster
+        required: false
+        default: camunda.ie
+    ref-arch:
+        description: Reference architecture name (eks-single-region, eks-single-region-irsa)
+        required: false
+        default: eks-single-region
+    use-wildcard-cert:
+        description: |
+            Use wildcard certificate from Vault instead of ACME/Let's Encrypt.
+            When true, ACME issuer is not installed and wildcard certificate is created from Vault.
+        required: false
+        default: 'false'
+    wildcard-cert-namespace:
+        description: Namespace where the wildcard TLS certificate will be created (when use-wildcard-cert is true)
+        required: false
+        default: camunda
+    wildcard-cert-secret-name:
+        description: Name of the wildcard TLS secret to create (when use-wildcard-cert is true)
+        required: false
+        default: camunda-tls
+    vault-addr:
+        description: Vault server address (required when use-wildcard-cert is true)
+        required: false
+    vault-role-id:
+        description: Vault AppRole role ID (required when use-wildcard-cert is true)
+        required: false
+    vault-secret-id:
+        description: Vault AppRole secret ID (required when use-wildcard-cert is true)
+        required: false
+
+runs:
+    using: composite
+    steps:
+
+        - name: 🏗️ Clean cert-manager operator namespace
+          uses: ./.github/actions/internal-clean-namespace
+          with:
+              namespace: cert-manager
+
+        - name: 🏗️ Clean external-dns operator namespace
+          uses: ./.github/actions/internal-clean-namespace
+          with:
+              namespace: external-dns
+
+        - name: 🏗️ Clean ingress-nginx operator namespace
+          uses: ./.github/actions/internal-clean-namespace
+          with:
+              namespace: ingress-nginx
+
+        - name: Setup ingress components for EKS cluster
+          shell: bash
+          run: |
+              set -euo pipefail
+
+              echo "Setting up ingress components for EKS cluster..."
+              echo "Cluster: ${{ inputs.cluster-name }}-${{ inputs.scenario-short-name }}"
+              echo "Region: ${{ inputs.aws-region }}"
+              echo "Mail: ${{ inputs.mail }}"
+              echo "TLD: ${{ inputs.tld }}"
+              echo "Ref-arch: ${{ inputs.ref-arch }}"
+              echo "Use wildcard cert: ${{ inputs.use-wildcard-cert }}"
+
+              # Set required environment variables for ingress setup
+              export REGION="${{ inputs.aws-region }}"
+              export MAIL_OVERWRITE="${{ inputs.mail }}"
+              export TLD="${{ inputs.tld }}"
+
+              # Source ingress setup variables
+              source generic/kubernetes/single-region/procedure/export-ingress-setup-vars.sh
+
+              # Validate that IRSA ARNs are available
+              if [[ -z "$EXTERNAL_DNS_IRSA_ARN" ]]; then
+                  echo "❌ ERROR: Could not retrieve external_dns_arn from Terraform outputs"
+                  echo "This ARN is required for external-dns to manage Route53 DNS records."
+                  echo "Ensure that the EKS cluster has been created with IRSA support."
+                  exit 1
+              fi
+              echo "✅ Found external-dns IRSA ARN: $EXTERNAL_DNS_IRSA_ARN"
+
+              if [[ -z "$CERT_MANAGER_IRSA_ARN" ]]; then
+                  echo "❌ ERROR: Could not retrieve cert_manager_arn from Terraform outputs"
+                  echo "This ARN is required for cert-manager to perform DNS-01 ACME challenges."
+                  echo "Ensure that the EKS cluster has been created with IRSA support."
+                  exit 1
+              fi
+              echo "✅ Found cert-manager IRSA ARN: $CERT_MANAGER_IRSA_ARN"
+
+              # Install ingress-nginx
+              echo "Installing ingress-nginx..."
+              ./aws/kubernetes/${{ inputs.ref-arch }}/procedure/install-ingress-nginx.sh
+
+              # Install external-dns
+              echo "Installing external-dns..."
+              export EXTERNAL_DNS_OWNER_ID="external-dns-${{ inputs.cluster-name }}-${{ inputs.scenario-short-name }}"
+              ./aws/kubernetes/${{ inputs.ref-arch }}/procedure/install-external-dns.sh
+
+              # Install cert-manager CRDs
+              echo "Installing cert-manager CRDs..."
+              ./generic/kubernetes/single-region/procedure/install-cert-manager-crds.sh
+
+              echo "Installing cert-manager..."
+              ./aws/kubernetes/${{ inputs.ref-arch }}/procedure/install-cert-manager.sh
+
+              echo "Installing ACME/Let's Encrypt issuer..."
+              ./aws/kubernetes/${{ inputs.ref-arch }}/procedure/install-cert-manager-issuer.sh
+
+              echo "✅ Ingress setup completed successfully for EKS cluster."
+
+        - name: 🔐 Setup wildcard TLS certificate from Vault
+          if: ${{ inputs.use-wildcard-cert == 'true' }}
+          uses: ./.github/actions/kubernetes-wildcard-certificate
+          with:
+              tld: ${{ inputs.tld }}
+              namespace: ${{ inputs.wildcard-cert-namespace }}
+              secret-name: ${{ inputs.wildcard-cert-secret-name }}
+              vault-addr: ${{ inputs.vault-addr }}
+              vault-role-id: ${{ inputs.vault-role-id }}
+              vault-secret-id: ${{ inputs.vault-secret-id }}

--- a/.github/actions/azure-kubernetes-ingress-setup/README.md
+++ b/.github/actions/azure-kubernetes-ingress-setup/README.md
@@ -1,0 +1,113 @@
+# Azure Kubernetes Ingress Setup
+
+## Description
+
+Install and configure ingress-nginx, external-dns, and cert-manager for Azure AKS clusters
+
+## Inputs
+
+| name | description | required | default |
+| --- | --- | --- | --- |
+| `cluster-name` | <p>Name of the cluster (used for external-dns owner ID)</p> | `true` | `""` |
+| `scenario-short-name` | <p>Short name of the scenario (used for external-dns owner ID)</p> | `true` | `""` |
+| `scenario-name` | <p>Full name of the scenario (e.g., aks-single-region)</p> | `true` | `""` |
+| `mail` | <p>Email address for Let's Encrypt certificates</p> | `false` | `admin@camunda.ie` |
+| `tld` | <p>Top-level domain for the cluster</p> | `false` | `azure.camunda.ie` |
+| `azure-dns-resource-group` | <p>Azure resource group containing the DNS zone</p> | `true` | `""` |
+| `azure-subscription-id` | <p>Azure subscription ID where the DNS zone is located</p> | `true` | `""` |
+| `use-wildcard-cert` | <p>Use wildcard certificate from Vault instead of ACME/Let's Encrypt. When true, ACME issuer is not installed and wildcard certificate is created from Vault.</p> | `false` | `false` |
+| `wildcard-cert-namespace` | <p>Namespace where the wildcard TLS certificate will be created (when use-wildcard-cert is true)</p> | `false` | `camunda` |
+| `wildcard-cert-secret-name` | <p>Name of the wildcard TLS secret to create (when use-wildcard-cert is true)</p> | `false` | `camunda-tls` |
+| `vault-addr` | <p>Vault server address (required when use-wildcard-cert is true)</p> | `false` | `""` |
+| `vault-role-id` | <p>Vault AppRole role ID (required when use-wildcard-cert is true)</p> | `false` | `""` |
+| `vault-secret-id` | <p>Vault AppRole secret ID (required when use-wildcard-cert is true)</p> | `false` | `""` |
+
+
+## Runs
+
+This action is a `composite` action.
+
+## Usage
+
+```yaml
+- uses: camunda/camunda-deployment-references/.github/actions/azure-kubernetes-ingress-setup@main
+  with:
+    cluster-name:
+    # Name of the cluster (used for external-dns owner ID)
+    #
+    # Required: true
+    # Default: ""
+
+    scenario-short-name:
+    # Short name of the scenario (used for external-dns owner ID)
+    #
+    # Required: true
+    # Default: ""
+
+    scenario-name:
+    # Full name of the scenario (e.g., aks-single-region)
+    #
+    # Required: true
+    # Default: ""
+
+    mail:
+    # Email address for Let's Encrypt certificates
+    #
+    # Required: false
+    # Default: admin@camunda.ie
+
+    tld:
+    # Top-level domain for the cluster
+    #
+    # Required: false
+    # Default: azure.camunda.ie
+
+    azure-dns-resource-group:
+    # Azure resource group containing the DNS zone
+    #
+    # Required: true
+    # Default: ""
+
+    azure-subscription-id:
+    # Azure subscription ID where the DNS zone is located
+    #
+    # Required: true
+    # Default: ""
+
+    use-wildcard-cert:
+    # Use wildcard certificate from Vault instead of ACME/Let's Encrypt.
+    # When true, ACME issuer is not installed and wildcard certificate is created from Vault.
+    #
+    # Required: false
+    # Default: false
+
+    wildcard-cert-namespace:
+    # Namespace where the wildcard TLS certificate will be created (when use-wildcard-cert is true)
+    #
+    # Required: false
+    # Default: camunda
+
+    wildcard-cert-secret-name:
+    # Name of the wildcard TLS secret to create (when use-wildcard-cert is true)
+    #
+    # Required: false
+    # Default: camunda-tls
+
+    vault-addr:
+    # Vault server address (required when use-wildcard-cert is true)
+    #
+    # Required: false
+    # Default: ""
+
+    vault-role-id:
+    # Vault AppRole role ID (required when use-wildcard-cert is true)
+    #
+    # Required: false
+    # Default: ""
+
+    vault-secret-id:
+    # Vault AppRole secret ID (required when use-wildcard-cert is true)
+    #
+    # Required: false
+    # Default: ""
+```

--- a/.github/actions/azure-kubernetes-ingress-setup/action.yml
+++ b/.github/actions/azure-kubernetes-ingress-setup/action.yml
@@ -1,0 +1,143 @@
+---
+name: Azure Kubernetes Ingress Setup
+description: Install and configure ingress-nginx, external-dns, and cert-manager for Azure AKS clusters
+
+inputs:
+    cluster-name:
+        description: Name of the cluster (used for external-dns owner ID)
+        required: true
+    scenario-short-name:
+        description: Short name of the scenario (used for external-dns owner ID)
+        required: true
+    scenario-name:
+        description: Full name of the scenario (e.g., aks-single-region)
+        required: true
+    mail:
+        description: Email address for Let's Encrypt certificates
+        required: false
+        default: admin@camunda.ie
+    tld:
+        description: Top-level domain for the cluster
+        required: false
+        default: azure.camunda.ie
+    azure-dns-resource-group:
+        description: Azure resource group containing the DNS zone
+        required: true
+    azure-subscription-id:
+        description: Azure subscription ID where the DNS zone is located
+        required: true
+    use-wildcard-cert:
+        description: |
+            Use wildcard certificate from Vault instead of ACME/Let's Encrypt.
+            When true, ACME issuer is not installed and wildcard certificate is created from Vault.
+        required: false
+        default: 'false'
+    wildcard-cert-namespace:
+        description: Namespace where the wildcard TLS certificate will be created (when use-wildcard-cert is true)
+        required: false
+        default: camunda
+    wildcard-cert-secret-name:
+        description: Name of the wildcard TLS secret to create (when use-wildcard-cert is true)
+        required: false
+        default: camunda-tls
+    vault-addr:
+        description: Vault server address (required when use-wildcard-cert is true)
+        required: false
+    vault-role-id:
+        description: Vault AppRole role ID (required when use-wildcard-cert is true)
+        required: false
+    vault-secret-id:
+        description: Vault AppRole secret ID (required when use-wildcard-cert is true)
+        required: false
+
+runs:
+    using: composite
+    steps:
+        - name: 🏗️ Clean cert-manager operator namespace
+          uses: ./.github/actions/internal-clean-namespace
+          with:
+              namespace: cert-manager
+
+        - name: 🏗️ Clean external-dns operator namespace
+          uses: ./.github/actions/internal-clean-namespace
+          with:
+              namespace: external-dns
+
+        - name: 🏗️ Clean ingress-nginx operator namespace
+          uses: ./.github/actions/internal-clean-namespace
+          with:
+              namespace: ingress-nginx
+
+        - name: Setup ingress components for AKS cluster
+          shell: bash
+          run: |
+              set -euo pipefail
+
+              echo "Setting up ingress components for AKS cluster..."
+              echo "Cluster: ${{ inputs.cluster-name }}-${{ inputs.scenario-short-name }}"
+              echo "Mail: ${{ inputs.mail }}"
+              echo "TLD: ${{ inputs.tld }}"
+              echo "Scenario: ${{ inputs.scenario-name }}"
+              echo "Use wildcard cert: ${{ inputs.use-wildcard-cert }}"
+
+              # Set required environment variables for ingress setup
+              export MAIL="${{ inputs.mail }}"
+              export MAIL_OVERWRITE="${{ inputs.mail }}"
+              export TLD="${{ inputs.tld }}"
+
+              # Source ingress setup variables
+              source generic/kubernetes/single-region/procedure/export-ingress-setup-vars.sh
+
+              # Install ingress-nginx
+              echo "Installing ingress-nginx..."
+              ./azure/kubernetes/${{ inputs.scenario-name }}/procedure/install-ingress-nginx.sh
+
+              # Install external-dns
+              echo "Installing external-dns..."
+              export EXTERNAL_DNS_OWNER_ID="external-dns-${{ inputs.cluster-name }}-${{ inputs.scenario-short-name }}"
+              ./azure/kubernetes/${{ inputs.scenario-name }}/procedure/install-external-dns.sh
+
+              source azure/kubernetes/${{ matrix.scenario.name }}/procedure/export-domain-setup-vars.sh
+
+              # Configure external-dns with Azure credentials
+              echo "Configuring external-dns with Azure credentials..."
+              export AZURE_DNS_RESOURCE_GROUP="${{ inputs.azure-dns-resource-group }}"
+              export AZURE_SUBSCRIPTION_ID="${{ inputs.azure-subscription-id }}"
+              ./azure/kubernetes/${{ inputs.scenario-name }}/procedure/external-dns-azure-config.sh
+
+
+              echo "Installing cert-manager CRDs..."
+              ./generic/kubernetes/single-region/procedure/install-cert-manager-crds.sh
+
+              echo "Installing cert-manager with ACME issuer as default..."
+              ./azure/kubernetes/${{ inputs.scenario-name }}/procedure/install-cert-manager.sh
+
+              echo "Installing ACME/Let's Encrypt issuer..."
+              export AZURE_DNS_ZONE="${{ inputs.tld }}"
+              ./azure/kubernetes/${{ inputs.scenario-name }}/procedure/install-cert-manager-issuer.sh
+
+              echo "✅ Ingress setup completed successfully for AKS cluster."
+
+        - name: Prepare TLD for wildcard certificate
+          if: ${{ inputs.use-wildcard-cert == 'true' }}
+          id: prepare-tld
+          shell: bash
+          run: |
+              TLD="${{ inputs.tld }}"
+              # Remove azure. prefix if present (e.g., azure.camunda.ie -> camunda.ie)
+              if [[ "$TLD" == azure.* ]]; then
+                TLD="${TLD#azure.}"
+              fi
+              echo "tld=$TLD" >> $GITHUB_OUTPUT
+              echo "Prepared TLD for wildcard certificate: $TLD"
+
+        - name: Setup wildcard TLS certificate from Vault
+          if: ${{ inputs.use-wildcard-cert == 'true' }}
+          uses: ./.github/actions/kubernetes-wildcard-certificate
+          with:
+              tld: ${{ steps.prepare-tld.outputs.tld }}
+              namespace: ${{ inputs.wildcard-cert-namespace }}
+              secret-name: ${{ inputs.wildcard-cert-secret-name }}
+              vault-addr: ${{ inputs.vault-addr }}
+              vault-role-id: ${{ inputs.vault-role-id }}
+              vault-secret-id: ${{ inputs.vault-secret-id }}

--- a/.github/actions/internal-clean-namespace/README.md
+++ b/.github/actions/internal-clean-namespace/README.md
@@ -1,0 +1,42 @@
+# Clean namespace
+
+## Description
+
+Clean a single namespace for a fresh test environment
+
+## Inputs
+
+| name | description | required | default |
+| --- | --- | --- | --- |
+| `namespace` | <p>The namespace to clean</p> | `true` | `""` |
+| `recreate` | <p>Whether to recreate the namespace after deletion</p> | `false` | `false` |
+| `openshift-project` | <p>Use oc new-project for OpenShift with metadata</p> | `false` | `false` |
+
+
+## Runs
+
+This action is a `composite` action.
+
+## Usage
+
+```yaml
+- uses: camunda/camunda-deployment-references/.github/actions/internal-clean-namespace@main
+  with:
+    namespace:
+    # The namespace to clean
+    #
+    # Required: true
+    # Default: ""
+
+    recreate:
+    # Whether to recreate the namespace after deletion
+    #
+    # Required: false
+    # Default: false
+
+    openshift-project:
+    # Use oc new-project for OpenShift with metadata
+    #
+    # Required: false
+    # Default: false
+```

--- a/.github/actions/internal-clean-namespace/action.yml
+++ b/.github/actions/internal-clean-namespace/action.yml
@@ -1,0 +1,48 @@
+---
+name: Clean namespace
+description: Clean a single namespace for a fresh test environment
+inputs:
+    namespace:
+        description: The namespace to clean
+        required: true
+    recreate:
+        description: Whether to recreate the namespace after deletion
+        required: false
+        default: 'false'
+    openshift-project:
+        description: Use oc new-project for OpenShift with metadata
+        required: false
+        default: 'false'
+runs:
+    using: composite
+    steps:
+        - name: Clean namespace
+          shell: bash
+          run: |
+              set -euo pipefail
+
+              NAMESPACE="${{ inputs.namespace }}"
+              RECREATE="${{ inputs.recreate }}"
+              OPENSHIFT_PROJECT="${{ inputs.openshift-project }}"
+
+              if kubectl get namespace "$NAMESPACE" &>/dev/null; then
+                  echo "Deleting namespace: $NAMESPACE"
+                  kubectl delete namespace "$NAMESPACE" --wait
+                  echo "✓ Namespace $NAMESPACE deleted"
+              else
+                  echo "✓ Namespace $NAMESPACE does not exist"
+              fi
+
+              if [[ "$RECREATE" == "true" ]]; then
+                  if [[ "$OPENSHIFT_PROJECT" == "true" ]]; then
+                      # Use oc new-project for OpenShift with metadata
+                      oc new-project "$NAMESPACE" \
+                        --description="Integration project of $NAMESPACE" \
+                        --display-name="$NAMESPACE"
+                      echo "✓ Created fresh OpenShift project: $NAMESPACE"
+                  else
+                      # Use kubectl for standard Kubernetes
+                      kubectl create namespace "$NAMESPACE"
+                      echo "✓ Created fresh namespace: $NAMESPACE"
+                  fi
+              fi

--- a/.github/actions/internal-configure-wildcard-cert/README.md
+++ b/.github/actions/internal-configure-wildcard-cert/README.md
@@ -1,0 +1,59 @@
+# Configure Wildcard Certificate Usage
+
+## Description
+
+Determines whether to use wildcard certificates or Let's Encrypt based on PR context.
+For Renovate PRs, automatically detects if cert-manager is modified.
+
+
+## Inputs
+
+| name | description | required | default |
+| --- | --- | --- | --- |
+| `manual-wildcard-cert` | <p>Manual override to use wildcard certificate (takes precedence)</p> | `false` | `false` |
+| `is-renovate-pr` | <p>Whether this is a Renovate bot PR</p> | `true` | `""` |
+| `is-schedule` | <p>Whether this is a scheduled run</p> | `true` | `""` |
+| `base-ref` | <p>Base branch reference for diff comparison</p> | `false` | `main` |
+
+
+## Outputs
+
+| name | description |
+| --- | --- |
+| `use-wildcard-cert` | <p>Whether to use wildcard certificate (true/false)</p> |
+| `has-cert-manager-changes` | <p>Whether the PR contains cert-manager changes (only set for Renovate PRs)</p> |
+
+
+## Runs
+
+This action is a `composite` action.
+
+## Usage
+
+```yaml
+- uses: camunda/camunda-deployment-references/.github/actions/internal-configure-wildcard-cert@main
+  with:
+    manual-wildcard-cert:
+    # Manual override to use wildcard certificate (takes precedence)
+    #
+    # Required: false
+    # Default: false
+
+    is-renovate-pr:
+    # Whether this is a Renovate bot PR
+    #
+    # Required: true
+    # Default: ""
+
+    is-schedule:
+    # Whether this is a scheduled run
+    #
+    # Required: true
+    # Default: ""
+
+    base-ref:
+    # Base branch reference for diff comparison
+    #
+    # Required: false
+    # Default: main
+```

--- a/.github/actions/internal-configure-wildcard-cert/action.yml
+++ b/.github/actions/internal-configure-wildcard-cert/action.yml
@@ -1,0 +1,101 @@
+---
+name: Configure Wildcard Certificate Usage
+description: |
+    Determines whether to use wildcard certificates or Let's Encrypt based on PR context.
+    For Renovate PRs, automatically detects if cert-manager is modified.
+
+inputs:
+    manual-wildcard-cert:
+        description: Manual override to use wildcard certificate (takes precedence)
+        required: false
+        default: 'false'
+    is-renovate-pr:
+        description: Whether this is a Renovate bot PR
+        required: true
+    is-schedule:
+        description: Whether this is a scheduled run
+        required: true
+    base-ref:
+        description: Base branch reference for diff comparison
+        required: false
+        default: main
+
+outputs:
+    use-wildcard-cert:
+        description: Whether to use wildcard certificate (true/false)
+        value: ${{ steps.configure.outputs.USE_WILDCARD_CERT }}
+    has-cert-manager-changes:
+        description: Whether the PR contains cert-manager changes (only set for Renovate PRs)
+        value: ${{ steps.check_cert_manager_changes.outputs.HAS_CERT_MANAGER_CHANGES }}
+
+runs:
+    using: composite
+    steps:
+        - name: Check if PR contains cert-manager changes (Renovate only)
+          if: github.event_name == 'pull_request' && inputs.is-renovate-pr == 'true'
+          id: check_cert_manager_changes
+          shell: bash
+          run: |
+              set -euo pipefail
+
+              echo "🔍 Checking for cert-manager changes in Renovate PR..."
+
+              # Check if PR contains changes to cert-manager
+              CHANGED_FILES=$(git diff --name-only origin/${{ inputs.base-ref }}...HEAD || echo "")
+
+              if echo "$CHANGED_FILES" | grep -qE "cert-manager"; then
+                  echo "HAS_CERT_MANAGER_CHANGES=true" | tee -a "$GITHUB_OUTPUT"
+                  echo "✅ Detected cert-manager changes in PR, will use Let's Encrypt certificates"
+              else
+                  echo "HAS_CERT_MANAGER_CHANGES=false" | tee -a "$GITHUB_OUTPUT"
+                  echo "ℹ️  No cert-manager changes detected, will use wildcard certificate"
+              fi
+
+        - name: Configure wildcard certificate usage
+          id: configure
+          shell: bash
+          run: |
+              set -euo pipefail
+
+              echo "🔧 Determining certificate configuration strategy..."
+
+              # Logic for wildcard cert usage:
+              # 1. Manual input: use the specified value (highest priority)
+              # 2. Renovate PR targeting main with cert-manager changes: use Let's Encrypt (false)
+              # 3. Renovate PR targeting main without cert-manager changes: use wildcard (true)
+              # 4. Renovate PR targeting non-main branches: use wildcard (true) - legacy branches don't have cert-manager
+              # 5. Regular PR: use Let's Encrypt (false)
+              # 6. Schedule: use Let's Encrypt (false)
+
+              if [[ "${{ inputs.manual-wildcard-cert }}" == "true" ]]; then
+                  USE_WILDCARD="true"
+                  echo "📋 Manual override: Using wildcard certificate"
+              elif [[ "${{ github.event_name }}" == "pull_request" && "${{ inputs.is-renovate-pr }}" == "true" ]]; then
+                  # For Renovate PRs, check target branch first
+                  if [[ "${{ inputs.base-ref }}" != "main" ]]; then
+                      USE_WILDCARD="true"
+                      echo "🔖 Renovate PR targeting non-main branch (${{ inputs.base-ref }}): Using wildcard certificate (legacy branch without cert-manager)"
+                  elif [[ "${{ steps.check_cert_manager_changes.outputs.HAS_CERT_MANAGER_CHANGES }}" == "true" ]]; then
+                      USE_WILDCARD="false"
+                      echo "🔐 Renovate PR targeting main with cert-manager changes: Using Let's Encrypt"
+                  else
+                      USE_WILDCARD="true"
+                      echo "🎫 Renovate PR targeting main without cert-manager changes: Using wildcard certificate"
+                  fi
+              elif [[ "${{ github.event_name }}" == "pull_request" && "${{ inputs.is-schedule }}" != "true" ]]; then
+                  USE_WILDCARD="false"
+                  echo "🔐 Regular PR: Using Let's Encrypt"
+              else
+                  USE_WILDCARD="false"
+                  echo "🔐 Default behavior: Using Let's Encrypt"
+              fi
+
+              echo "USE_WILDCARD_CERT=$USE_WILDCARD" | tee -a "$GITHUB_OUTPUT"
+              echo ""
+              echo "📊 Summary:"
+              echo "  - Manual override: ${{ inputs.manual-wildcard-cert }}"
+              echo "  - Is Renovate PR: ${{ inputs.is-renovate-pr }}"
+              echo "  - Target branch: ${{ inputs.base-ref }}"
+              echo "  - Is Schedule: ${{ inputs.is-schedule }}"
+              echo "  - Has cert-manager Changes: ${{ steps.check_cert_manager_changes.outputs.HAS_CERT_MANAGER_CHANGES || 'N/A' }}"
+              echo "  - Final Decision: USE_WILDCARD_CERT=$USE_WILDCARD"

--- a/.github/actions/kubernetes-wildcard-certificate/README.md
+++ b/.github/actions/kubernetes-wildcard-certificate/README.md
@@ -1,0 +1,63 @@
+# Kubernetes Wildcard Certificate Setup
+
+## Description
+
+Setup wildcard TLS certificate from Vault for Kubernetes clusters
+
+## Inputs
+
+| name | description | required | default |
+| --- | --- | --- | --- |
+| `tld` | <p>Top-level domain for the wildcard certificate</p> | `false` | `camunda.ie` |
+| `namespace` | <p>Kubernetes namespace where the TLS secret will be created</p> | `false` | `camunda` |
+| `secret-name` | <p>Name of the TLS secret to create</p> | `false` | `camunda-tls` |
+| `vault-addr` | <p>Vault server address</p> | `true` | `""` |
+| `vault-role-id` | <p>Vault AppRole role ID</p> | `true` | `""` |
+| `vault-secret-id` | <p>Vault AppRole secret ID</p> | `true` | `""` |
+
+
+## Runs
+
+This action is a `composite` action.
+
+## Usage
+
+```yaml
+- uses: camunda/camunda-deployment-references/.github/actions/kubernetes-wildcard-certificate@main
+  with:
+    tld:
+    # Top-level domain for the wildcard certificate
+    #
+    # Required: false
+    # Default: camunda.ie
+
+    namespace:
+    # Kubernetes namespace where the TLS secret will be created
+    #
+    # Required: false
+    # Default: camunda
+
+    secret-name:
+    # Name of the TLS secret to create
+    #
+    # Required: false
+    # Default: camunda-tls
+
+    vault-addr:
+    # Vault server address
+    #
+    # Required: true
+    # Default: ""
+
+    vault-role-id:
+    # Vault AppRole role ID
+    #
+    # Required: true
+    # Default: ""
+
+    vault-secret-id:
+    # Vault AppRole secret ID
+    #
+    # Required: true
+    # Default: ""
+```

--- a/.github/actions/kubernetes-wildcard-certificate/action.yml
+++ b/.github/actions/kubernetes-wildcard-certificate/action.yml
@@ -1,0 +1,103 @@
+---
+name: Kubernetes Wildcard Certificate Setup
+description: Setup wildcard TLS certificate from Vault for Kubernetes clusters
+
+inputs:
+    tld:
+        description: Top-level domain for the wildcard certificate
+        required: false
+        default: camunda.ie
+    namespace:
+        description: Kubernetes namespace where the TLS secret will be created
+        required: false
+        default: camunda
+    secret-name:
+        description: Name of the TLS secret to create
+        required: false
+        default: camunda-tls
+    vault-addr:
+        description: Vault server address
+        required: true
+    vault-role-id:
+        description: Vault AppRole role ID
+        required: true
+    vault-secret-id:
+        description: Vault AppRole secret ID
+        required: true
+
+runs:
+    using: composite
+    steps:
+        - name: 🔐 Import wildcard certificate from Vault
+          uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3
+          with:
+              url: ${{ inputs.vault-addr }}
+              method: approle
+              roleId: ${{ inputs.vault-role-id }}
+              secretId: ${{ inputs.vault-secret-id }}
+              secrets: |
+                  secret/data/products/infrastructure-experience/certificates/${{ inputs.tld }}/wildcard full_chain | WILDCARD_CERT ;
+                  secret/data/products/infrastructure-experience/certificates/${{ inputs.tld }}/wildcard private_key | WILDCARD_KEY
+
+        - name: 📜 Create TLS secret from Vault certificate
+          shell: bash
+          run: |
+              set -euo pipefail
+
+              echo "🌐 Creating TLS secret for wildcard certificate *.${{ inputs.tld }}"
+              echo "📍 Target namespace: ${{ inputs.namespace }}"
+              echo "🔑 Secret name: ${{ inputs.secret-name }}"
+
+              # Mask sensitive certificate data in logs
+              echo "::add-mask::$WILDCARD_CERT"
+              echo "::add-mask::$WILDCARD_KEY"
+
+              # Validate that certificates were retrieved
+              if [[ -z "${WILDCARD_CERT:-}" ]]; then
+                  echo "❌ ERROR: Failed to retrieve certificate from Vault"
+                  exit 1
+              fi
+
+              if [[ -z "${WILDCARD_KEY:-}" ]]; then
+                  echo "❌ ERROR: Failed to retrieve private key from Vault"
+                  exit 1
+              fi
+
+              echo "✅ Successfully retrieved certificates from Vault"
+              echo "🔒 Certificate data is masked in logs for security"
+
+
+              # Create temporary files for certificate data
+              TEMP_DIR=$(mktemp -d)
+              CERT_FILE="$TEMP_DIR/tls.crt"
+              KEY_FILE="$TEMP_DIR/tls.key"
+
+              # Cleanup function
+              cleanup() {
+                  echo "🧹 Cleaning up temporary files..."
+                  rm -rf "$TEMP_DIR"
+              }
+              trap cleanup EXIT
+
+              # Write certificate data to files
+              echo "📝 Writing certificate data to temporary files..."
+              echo "$WILDCARD_CERT" > "$CERT_FILE"
+              echo "$WILDCARD_KEY" > "$KEY_FILE"
+
+
+              # Create or update the TLS secret
+              echo "🔐 Creating TLS secret '${{ inputs.secret-name }}'..."
+              kubectl create secret tls "${{ inputs.secret-name }}" \
+                  --cert="$CERT_FILE" \
+                  --key="$KEY_FILE" \
+                  --namespace="${{ inputs.namespace }}" \
+                  --dry-run=client -o yaml | \
+              kubectl apply -f -
+
+              echo "✅ Wildcard certificate setup completed successfully"
+              echo ""
+              echo "📋 Created resources:"
+              echo "  - Secret: ${{ inputs.secret-name }} (namespace: ${{ inputs.namespace }})"
+              echo "  - Type: kubernetes.io/tls"
+              echo "  - Certificate: *.${{ inputs.tld }}"
+              echo ""


### PR DESCRIPTION
…AKS ingress

- Add internal-configure-wildcard-cert action to determine certificate strategy
- Add kubernetes-wildcard-certificate action for Vault certificate retrieval
- Add aws-kubernetes-ingress-setup action with wildcard cert support
- Add azure-kubernetes-ingress-setup action with wildcard cert support
- Add internal-clean-namespace helper action

The workflows were already configured to use these actions (from previous backport). This commit adds the missing action files that the workflows reference.

This backport enables using wildcard certificates from Vault instead of Let's Encrypt for testing, avoiding rate limits. The configuration automatically uses wildcard certs for Renovate PRs targeting non-main branches (legacy branches without cert-manager support).