### PR TITLE
fix: retry destroy on second time for aws

### DIFF
--- a/.github/actions/aws-generic-terraform-cleanup/action.yml
+++ b/.github/actions/aws-generic-terraform-cleanup/action.yml
@@ -95,8 +95,6 @@ runs:
         - name: Delete Resources
           id: delete_resources
           shell: bash
-          env:
-              RETRY_DESTROY: 'true' # trigger cloud nuke by default as we may have to deal with remaining LB etc
           run: |
               set -euo pipefail
 
@@ -107,9 +105,21 @@ runs:
               # Use repo .tool-version as global version
               cp .tool-versions ~/.tool-versions
 
-              ${{ github.action_path }}/scripts/destroy-resources.sh "${{ inputs.tf-bucket }}" \
+              # First attempt without RETRY_DESTROY
+              echo "🚀 First attempt: Running destroy without cloud-nuke retry..."
+              if ${{ github.action_path }}/scripts/destroy-resources.sh "${{ inputs.tf-bucket }}" \
                 ${{ inputs.max-age-hours }} ${{ inputs.target }} ${{ inputs.modules-order }} ${{ inputs.tf-bucket-key-prefix }} \
-                $([[ "${{ inputs.fail-on-not-found }}" == "true" ]] && echo "--fail-on-not-found")
+                $([[ "${{ inputs.fail-on-not-found }}" == "true" ]] && echo "--fail-on-not-found"); then
+                  echo "✅ Destroy succeeded without retry"
+              else
+                  echo "⚠️  First attempt failed, retrying with cloud-nuke..."
+                  # RETRY_DESTROY enables cloud-nuke to clean up resources created outside of Terraform
+                  # such as Load Balancers created by ingress-nginx, EBS volumes, etc.
+                  export RETRY_DESTROY='true'
+                  ${{ github.action_path }}/scripts/destroy-resources.sh "${{ inputs.tf-bucket }}" \
+                    ${{ inputs.max-age-hours }} ${{ inputs.target }} ${{ inputs.modules-order }} ${{ inputs.tf-bucket-key-prefix }} \
+                    $([[ "${{ inputs.fail-on-not-found }}" == "true" ]] && echo "--fail-on-not-found")
+              fi
 
               if [ "${{ inputs.delete-ghost-rosa-clusters }}" == "true" ]; then
                 ${{ github.action_path }}/scripts/cleanup-ghost-rosa-clusters.sh ${{ inputs.max-age-hours }}


### PR DESCRIPTION
This pull request updates the AWS Terraform cleanup GitHub Action to improve resource deletion reliability and clarity. The main change is restructuring the destroy process to first attempt deletion without cloud-nuke, and only retry with cloud-nuke if the initial attempt fails. This helps avoid unnecessary retries and makes the workflow more robust.

Improvements to resource deletion process:

* The destroy step now first runs without the `RETRY_DESTROY` environment variable, attempting a clean deletion of resources using Terraform. If this fails, it retries with `RETRY_DESTROY='true'`, enabling cloud-nuke to clean up resources not managed by Terraform (e.g., orphaned load balancers, EBS volumes).
* Removed the unconditional setting of `RETRY_DESTROY: 'true'` from the environment, so cloud-nuke is only triggered when necessary, reducing potential side effects and unnecessary cleanup operations.