### PR TITLE
fix: azure wildcard

### DIFF
--- a/.github/actions/azure-kubernetes-ingress-setup/action.yml
+++ b/.github/actions/azure-kubernetes-ingress-setup/action.yml
@@ -118,24 +118,11 @@ runs:
 
               echo "✅ Ingress setup completed successfully for AKS cluster."
 
-        - name: Prepare TLD for wildcard certificate
-          if: ${{ inputs.use-wildcard-cert == 'true' }}
-          id: prepare-tld
-          shell: bash
-          run: |
-              TLD="${{ inputs.tld }}"
-              # Remove azure. prefix if present (e.g., azure.camunda.ie -> camunda.ie)
-              if [[ "$TLD" == azure.* ]]; then
-                TLD="${TLD#azure.}"
-              fi
-              echo "tld=$TLD" >> $GITHUB_OUTPUT
-              echo "Prepared TLD for wildcard certificate: $TLD"
-
         - name: Setup wildcard TLS certificate from Vault
           if: ${{ inputs.use-wildcard-cert == 'true' }}
           uses: ./.github/actions/kubernetes-wildcard-certificate
           with:
-              tld: ${{ steps.prepare-tld.outputs.tld }}
+              tld: ${{ inputs.tld }}
               namespace: ${{ inputs.wildcard-cert-namespace }}
               secret-name: ${{ inputs.wildcard-cert-secret-name }}
               vault-addr: ${{ inputs.vault-addr }}


### PR DESCRIPTION
This pull request simplifies the process of setting up wildcard TLS certificates in the Azure Kubernetes ingress setup workflow by removing the step that modifies the top-level domain (TLD) input. Instead, the workflow now passes the original TLD value directly to the certificate setup action.

Certificate setup workflow simplification:

* Removed the `Prepare TLD for wildcard certificate` step, which previously stripped the `azure.` prefix from the TLD input before passing it to subsequent steps. (`.github/actions/azure-kubernetes-ingress-setup/action.yml`)
* Updated the `Setup wildcard TLS certificate from Vault` step to use the original `inputs.tld` value directly, rather than a modified output from the removed preparation step. (`.github/actions/azure-kubernetes-ingress-setup/action.yml`)

TODO: backport to 8.8, 8.7