### PR TITLE
chore: remove groupName from Renovate configuration

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,5 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: ["github>camunda/infraex-common-config:default.json5"],
-  groupName: "mono-update-renovate", // we keep all updates in a single renovate branch in order to save CI tests
   packageRules: []
 }


### PR DESCRIPTION
Removed groupName to allow separate renovate branches.

Was already wondering where it was coming from since we manage the grouping via the default global renovate config.

While minor / patch were properly grouped due to the default config, this part grouped anything else together that wasn't explicitly set.