### PR TITLE
fix: use correct custom source for aurora rds module

### DIFF
--- a/aws/modules/aurora/variables.tf
+++ b/aws/modules/aurora/variables.tf
@@ -10,7 +10,7 @@ variable "engine" {
 
 variable "engine_version" {
   type = string
-  # renovate: datasource=endoflife-date depName=amazon-rds-postgresql versioning=loose
+  # renovate: datasource=custom.aurora-pg-camunda depName=aurora-postgresql versioning=loose
   default     = "17.5"
   description = "The DB engine version for Postgres to use."
 }


### PR DESCRIPTION
related to [slack alert thread](https://camunda.slack.com/archives/C076N4G1162/p1762221836672779)

All other aurora references are already using the custom source, just this one was missing.
EOL is for AWS PostgreSQL and not AWS Aurora PostgreSQL causing the diff in availability.