### PR TITLE
fix: disable c8-sm-checks for dual region

### DIFF
--- a/.github/workflows/aws_openshift_rosa_hcp_dual_region_tests.yml
+++ b/.github/workflows/aws_openshift_rosa_hcp_dual_region_tests.yml
@@ -25,6 +25,7 @@ on:
             - .github/actions/internal-generic-decrypt-import/**
             - .github/actions/internal-tests-matrix/**
             - .github/actions/internal-terraform-drift-detect/**
+            - .github/actions/internal-camunda-chart-tests/**
 
     workflow_dispatch:
         inputs:
@@ -1021,6 +1022,12 @@ jobs:
                   test-release-name: ${{ env.CAMUNDA_RELEASE_NAME }}
                   test-client-id: ${{ steps.secrets.outputs.CI_CAMUNDA_USER_TEST_CLIENT_ID }}
                   test-client-secret: ${{ steps.secrets.outputs.CI_CAMUNDA_USER_TEST_CLIENT_SECRET }}
+                  # Disable C8-SM-CHECKS for dual region
+                  enable-c8sm-deployment-check: 'false'
+                  enable-c8sm-connectivity-check: 'false'
+                  enable-c8sm-irsa-check: 'false'
+                  enable-c8sm-zeebe-token-check: 'false'
+                  enable-c8sm-zeebe-connectivity-check: 'false'
 
             - name: 🔬🚨 Get failed Pods info - Cluster 1
               if: failure()


### PR DESCRIPTION
This pull request updates the `.github/workflows/aws_openshift_rosa_hcp_dual_region_tests.yml` workflow to improve test configuration and coverage. The main changes include adding a new action path to the workflow trigger and disabling several C8-SM checks for dual region testing.

Workflow configuration improvements:

* Added `.github/actions/internal-camunda-chart-tests/**` to the workflow trigger paths, ensuring that changes to Camunda chart tests will trigger this workflow.

Test parameter adjustments for dual region:

* Disabled multiple C8-SM deployment and connectivity checks (`enable-c8sm-deployment-check`, `enable-c8sm-connectivity-check`, `enable-c8sm-irsa-check`, `enable-c8sm-zeebe-token-check`, `enable-c8sm-zeebe-connectivity-check`) by setting them to `'false'` in the test job configuration, as these are not needed for dual region scenarios.