### PR TITLE
fix: disable c8-sm-checks for dual region (#1265)

### DIFF
--- a/.github/workflows/aws_openshift_rosa_hcp_dual_region_tests.yml
+++ b/.github/workflows/aws_openshift_rosa_hcp_dual_region_tests.yml
@@ -25,6 +25,7 @@ on:
             - .github/actions/internal-generic-decrypt-import/**
             - .github/actions/internal-tests-matrix/**
             - .github/actions/internal-terraform-drift-detect/**
+            - .github/actions/internal-camunda-chart-tests/**
 
     workflow_dispatch:
         inputs:
@@ -1021,6 +1022,12 @@ jobs:
                   test-release-name: ${{ env.CAMUNDA_RELEASE_NAME }}
                   test-client-id: ${{ steps.secrets.outputs.CI_CAMUNDA_USER_TEST_CLIENT_ID }}
                   test-client-secret: ${{ steps.secrets.outputs.CI_CAMUNDA_USER_TEST_CLIENT_SECRET }}
+                  # Disable C8-SM-CHECKS for dual region
+                  enable-c8sm-deployment-check: 'false'
+                  enable-c8sm-connectivity-check: 'false'
+                  enable-c8sm-irsa-check: 'false'
+                  enable-c8sm-zeebe-token-check: 'false'
+                  enable-c8sm-zeebe-connectivity-check: 'false'
 
             - name: 🔬🚨 Get failed Pods info - Cluster 1
               if: failure()


### PR DESCRIPTION
backport of https://github.com/camunda/camunda-deployment-references/pull/1265