### PR TITLE
fix: openshift dual import (#1264)

### DIFF
--- a/.github/workflows/aws_openshift_rosa_hcp_dual_region_tests.yml
+++ b/.github/workflows/aws_openshift_rosa_hcp_dual_region_tests.yml
@@ -382,365 +382,8 @@ jobs:
                   ./aws/openshift/${{ matrix.scenario.name }}/procedure/get-your-copy.sh
                   tree
 
-            # It's expected to always run in case an existing cluster is present.
-            # E.g. manual development deployment or retry after failure.
-            # This ensures a completely clean state before installing ACM.
-            - name: Ensure ACM and associated MultiCluster are not installed
-              timeout-minutes: 30
-              run: |
-                  set -euo pipefail
-
-                  echo "🧹 Starting comprehensive ACM cleanup for fresh installation..."
-                  echo "================================================================"
-                  echo ""
-
-                  MANAGEDCLUSTER_TIMEOUT=60  # Reduced timeout for ManagedCluster deletion
-                  CLUSTERS=("local-cluster" "$CLUSTER_2_NAME")
-
-                  # Step 1: Delete all ManagedClusters (aggressive mode)
-                  echo "Step 1: Deleting all ManagedClusters..."
-                  echo "----------------------------------------"
-                  for cluster_name in "${CLUSTERS[@]}"; do
-                    echo "🗑️  Deleting ManagedCluster: $cluster_name"
-
-                    if oc --context "$CLUSTER_1_NAME" get managedcluster "$cluster_name" >/dev/null 2>&1; then
-
-                      # Immediately remove finalizers (don't wait for graceful deletion in cleanup scenario)
-                      echo "  Removing finalizers immediately..."
-                      oc --context "$CLUSTER_1_NAME" patch managedcluster "$cluster_name" \
-                        --type='merge' -p '{"metadata":{"finalizers":[]}}' || true
-
-                      # Now delete with short timeout
-                      echo "  Deleting resource..."
-                      oc --context "$CLUSTER_1_NAME" delete managedcluster "$cluster_name" \
-                        --timeout=30s --grace-period=0 2>/dev/null || true
-
-                      # Verify deletion (short wait)
-                      echo "⏳ Verifying deletion of '$cluster_name'..."
-                      SECONDS=0
-                      while oc --context "$CLUSTER_1_NAME" get managedcluster "$cluster_name" >/dev/null 2>&1; do
-                        if [ $((SECONDS % 10)) -eq 0 ]; then
-                          echo "  Still waiting... (${SECONDS}s elapsed)"
-                        fi
-                        sleep 2
-
-                        if [ "$SECONDS" -ge "$MANAGEDCLUSTER_TIMEOUT" ]; then
-                          echo "  ⚠️  ManagedCluster still present after $MANAGEDCLUSTER_TIMEOUT seconds"
-                          echo "  Forcing final removal..."
-                          oc --context "$CLUSTER_1_NAME" patch managedcluster "$cluster_name" \
-                            --type='json' -p='[{"op": "remove", "path": "/metadata/finalizers"}]' 2>/dev/null || true
-                          oc --context "$CLUSTER_1_NAME" delete managedcluster "$cluster_name" \
-                            --grace-period=0 --force 2>/dev/null || true
-                          sleep 5
-                          break
-                        fi
-                      done
-
-                      if ! oc --context "$CLUSTER_1_NAME" get managedcluster "$cluster_name" >/dev/null 2>&1; then
-                        echo "  ✅ ManagedCluster '$cluster_name' deleted"
-                      else
-                        echo "  ⚠️  ManagedCluster '$cluster_name' still exists - continuing anyway"
-                      fi
-                    else
-                      echo "  ℹ️  ManagedCluster '$cluster_name' not found - skipping"
-                    fi
-                    echo ""
-                  done
-
-                  # Step 2: Clean up cluster-specific namespaces on hub
-                  echo "Step 2: Cleaning up cluster namespaces on hub..."
-                  echo "-------------------------------------------------"
-                  for cluster_name in "${CLUSTERS[@]}"; do
-                    if oc --context "$CLUSTER_1_NAME" get namespace "$cluster_name" >/dev/null 2>&1; then
-                      echo "🗑️  Deleting namespace: $cluster_name"
-                      oc --context "$CLUSTER_1_NAME" delete namespace "$cluster_name" --timeout=60s || {
-                        echo "  ⚠️  Normal deletion failed, forcing..."
-                        # Remove finalizers from all resources in the namespace
-                        oc --context "$CLUSTER_1_NAME" patch namespace "$cluster_name" --type='merge' -p '{"metadata":{"finalizers":[]}}' || true
-                      }
-                    fi
-                  done
-                  echo ""
-
-                  # Step 3: Clean up klusterlet resources on managed clusters
-                  echo "Step 3: Cleaning up klusterlet resources on managed clusters..."
-                  echo "----------------------------------------------------------------"
-
-                  # Clean cluster 1 (hub, also a managed cluster as local-cluster)
-                  if oc --context "$CLUSTER_1_NAME" get namespace open-cluster-management-agent >/dev/null 2>&1; then
-                    echo "🗑️  Cleaning klusterlet on cluster 1 (hub/local-cluster)"
-                    oc --context "$CLUSTER_1_NAME" -n open-cluster-management-agent delete all --all --timeout=30s || true
-                    oc --context "$CLUSTER_1_NAME" delete namespace open-cluster-management-agent --timeout=60s || {
-                      oc --context "$CLUSTER_1_NAME" patch namespace open-cluster-management-agent --type='merge' -p '{"metadata":{"finalizers":[]}}' || true
-                    }
-                  fi
-
-                  if oc --context "$CLUSTER_1_NAME" get namespace open-cluster-management-agent-addon >/dev/null 2>&1; then
-                    echo "🗑️  Cleaning klusterlet addon namespace on cluster 1"
-                    oc --context "$CLUSTER_1_NAME" delete namespace open-cluster-management-agent-addon --timeout=60s || {
-                      oc --context "$CLUSTER_1_NAME" patch namespace open-cluster-management-agent-addon --type='merge' -p '{"metadata":{"finalizers":[]}}' || true
-                    }
-                  fi
-
-                  # Clean cluster 2
-                  if oc --context "$CLUSTER_2_NAME" get namespace open-cluster-management-agent >/dev/null 2>&1; then
-                    echo "🗑️  Cleaning klusterlet on cluster 2"
-                    oc --context "$CLUSTER_2_NAME" -n open-cluster-management-agent delete all --all --timeout=30s || true
-                    oc --context "$CLUSTER_2_NAME" delete namespace open-cluster-management-agent --timeout=60s || {
-                      oc --context "$CLUSTER_2_NAME" patch namespace open-cluster-management-agent --type='merge' -p '{"metadata":{"finalizers":[]}}' || true
-                    }
-                  fi
-
-                  if oc --context "$CLUSTER_2_NAME" get namespace open-cluster-management-agent-addon >/dev/null 2>&1; then
-                    echo "🗑️  Cleaning klusterlet addon namespace on cluster 2"
-                    oc --context "$CLUSTER_2_NAME" delete namespace open-cluster-management-agent-addon --timeout=60s || {
-                      oc --context "$CLUSTER_2_NAME" patch namespace open-cluster-management-agent-addon --type='merge' -p '{"metadata":{"finalizers":[]}}' || true
-                    }
-                  fi
-
-                  # Delete klusterlet CRs if they exist
-                  if oc --context "$CLUSTER_1_NAME" get klusterlet >/dev/null 2>&1; then
-                    echo "🗑️  Deleting klusterlet CRs on cluster 1"
-                    oc --context "$CLUSTER_1_NAME" delete klusterlet --all --timeout=30s || {
-                      for kl in $(oc --context "$CLUSTER_1_NAME" get klusterlet -o name); do
-                        oc --context "$CLUSTER_1_NAME" patch "$kl" --type='merge' -p '{"metadata":{"finalizers":[]}}' || true
-                      done
-                    }
-                  fi
-
-                  if oc --context "$CLUSTER_2_NAME" get klusterlet >/dev/null 2>&1; then
-                    echo "🗑️  Deleting klusterlet CRs on cluster 2"
-                    oc --context "$CLUSTER_2_NAME" delete klusterlet --all --timeout=30s || {
-                      for kl in $(oc --context "$CLUSTER_2_NAME" get klusterlet -o name); do
-                        oc --context "$CLUSTER_2_NAME" patch "$kl" --type='merge' -p '{"metadata":{"finalizers":[]}}' || true
-                      done
-                    }
-                  fi
-                  echo ""
-
-                  # Step 4: Delete ManagedClusterSet and related resources
-                  echo "Step 4: Deleting ManagedClusterSet..."
-                  echo "-------------------------------------"
-                  if oc --context="$CLUSTER_1_NAME" get managedclusterset camunda-zeebe >/dev/null 2>&1; then
-                    echo "🗑️  Deleting ManagedClusterSet: camunda-zeebe"
-                    oc --context="$CLUSTER_1_NAME" delete -f ./generic/openshift/dual-region/procedure/acm/managed-cluster-set.yml --timeout=60s || {
-                      oc --context="$CLUSTER_1_NAME" patch managedclusterset camunda-zeebe --type='merge' -p '{"metadata":{"finalizers":[]}}' || true
-                    }
-                  fi
-
-                  if oc --context="$CLUSTER_1_NAME" get managedclustersetbinding camunda-zeebe \
-                      -n open-cluster-management >/dev/null 2>&1; then
-                    echo "🗑️  Deleting ManagedClusterSetBinding: camunda-zeebe"
-                    oc --context="$CLUSTER_1_NAME" delete managedclustersetbinding camunda-zeebe \
-                      -n open-cluster-management --timeout=60s || {
-                      oc --context="$CLUSTER_1_NAME" patch managedclustersetbinding camunda-zeebe \
-                        -n open-cluster-management --type='merge' -p '{"metadata":{"finalizers":[]}}' || true
-                    }
-                  fi
-                  echo ""
-
-                  # Step 5: Delete MultiClusterHub (aggressive cleanup)
-                  echo "Step 5: Deleting MultiClusterHub..."
-                  echo "------------------------------------"
-                  if oc --context="$CLUSTER_1_NAME" get clusterrole open-cluster-management:cluster-manager-admin >/dev/null 2>&1; then
-                    echo "🗑️  Deleting cluster role: open-cluster-management:cluster-manager-admin"
-                    oc --context="$CLUSTER_1_NAME" delete clusterrole open-cluster-management:cluster-manager-admin || true
-                  fi
-
-                  if oc --context="$CLUSTER_1_NAME" get crd multiclusterhubs.operator.open-cluster-management.io >/dev/null 2>&1; then
-                    # Check if MultiClusterHub exists
-                    if oc --context="$CLUSTER_1_NAME" get multiclusterhub -n open-cluster-management >/dev/null 2>&1; then
-                      echo "🗑️  MultiClusterHub found - forcing immediate deletion"
-
-                      # Immediate finalizer removal (don't wait for graceful deletion)
-                      echo "  Removing finalizers immediately..."
-                      for mch in $(oc --context="$CLUSTER_1_NAME" get multiclusterhub -n open-cluster-management -o name 2>/dev/null); do
-                        oc --context="$CLUSTER_1_NAME" patch "$mch" -n open-cluster-management --type='merge' -p '{"metadata":{"finalizers":[]}}' || true
-                      done
-
-                      # Force delete with zero grace period
-                      echo "  Force deleting resource..."
-                      oc --context="$CLUSTER_1_NAME" delete multiclusterhub --all -n open-cluster-management --grace-period=0 --force 2>/dev/null || true
-
-                      # Verify deletion (short timeout since we forced it)
-                      echo "⏳ Verifying deletion..."
-                      SECONDS=0
-                      while oc --context="$CLUSTER_1_NAME" get multiclusterhub -n open-cluster-management >/dev/null 2>&1; do
-                        if [ $((SECONDS % 10)) -eq 0 ]; then
-                          echo "  Still waiting for deletion... (${SECONDS}s elapsed)"
-                        fi
-                        sleep 2
-
-                        if [ $SECONDS -ge 60 ]; then
-                          echo "  ⚠️  MultiClusterHub still present after force delete - will clean namespace"
-                          break
-                        fi
-                      done
-                      echo "  ✅ MultiClusterHub deletion complete"
-                    else
-                      echo "  ℹ️  MultiClusterHub not found - already deleted"
-                    fi
-                  else
-                    echo "  ℹ️  MultiClusterHub CRD not found - skipping"
-                  fi
-                  echo ""
-
-                  # Step 6: Delete ACM Operator Subscription and CSV
-                  echo "Step 6: Deleting ACM Operator..."
-                  echo "---------------------------------"
-                  if oc --context="$CLUSTER_1_NAME" get subscription advanced-cluster-management -n open-cluster-management >/dev/null 2>&1; then
-                    echo "🗑️  Deleting ACM subscription"
-                    oc --context="$CLUSTER_1_NAME" delete subscription advanced-cluster-management -n open-cluster-management --timeout=30s || true
-                  fi
-
-                  # Delete ClusterServiceVersion (CSV) for ACM
-                  if oc --context="$CLUSTER_1_NAME" get csv -n open-cluster-management \
-                      | grep -q advanced-cluster-management; then
-                    echo "🗑️  Deleting ACM ClusterServiceVersion"
-                    oc --context="$CLUSTER_1_NAME" delete csv -n open-cluster-management \
-                      -l operators.coreos.com/advanced-cluster-management.open-cluster-management= \
-                      --timeout=30s || true
-                  fi
-                  echo ""
-
-                  # Step 7: Delete MultiClusterEngine (aggressive cleanup)
-                  echo "Step 7: Deleting MultiClusterEngine..."
-                  echo "---------------------------------------"
-                  if oc --context="$CLUSTER_1_NAME" get crd multiclusterengines.multicluster.openshift.io >/dev/null 2>&1; then
-                    # Check if MultiClusterEngine exists
-                    if oc --context="$CLUSTER_1_NAME" get multiclusterengine -n open-cluster-management >/dev/null 2>&1; then
-                      echo "🗑️  MultiClusterEngine found - forcing immediate deletion"
-
-                      # Immediate finalizer removal
-                      echo "  Removing finalizers immediately..."
-                      for mce in $(oc --context="$CLUSTER_1_NAME" get multiclusterengine -n open-cluster-management -o name 2>/dev/null); do
-                        oc --context="$CLUSTER_1_NAME" patch "$mce" -n open-cluster-management --type='merge' -p '{"metadata":{"finalizers":[]}}' || true
-                      done
-
-                      # Force delete with zero grace period
-                      echo "  Force deleting resource..."
-                      oc --context="$CLUSTER_1_NAME" delete multiclusterengine --all -n open-cluster-management --grace-period=0 --force 2>/dev/null || true
-
-                      # Verify deletion (short timeout)
-                      echo "⏳ Verifying deletion..."
-                      SECONDS=0
-                      while oc --context="$CLUSTER_1_NAME" get multiclusterengine -n open-cluster-management >/dev/null 2>&1; do
-                        if [ $((SECONDS % 10)) -eq 0 ]; then
-                          echo "  Still waiting for deletion... (${SECONDS}s elapsed)"
-                        fi
-                        sleep 2
-
-                        if [ "$SECONDS" -ge 60 ]; then
-                          echo "  ⚠️  MultiClusterEngine still present after force delete - will clean namespace"
-                          break
-                        fi
-                      done
-                      echo "  ✅ MultiClusterEngine deletion complete"
-                    else
-                      echo "  ℹ️  MultiClusterEngine not found - already deleted"
-                    fi
-                  else
-                    echo "  ℹ️  MultiClusterEngine CRD not found - skipping"
-                  fi
-                  echo ""
-
-                  # Step 8: Delete open-cluster-management namespace (with thorough verification)
-                  echo "Step 8: Deleting open-cluster-management namespace..."
-                  echo "------------------------------------------------------"
-                  if oc --context="$CLUSTER_1_NAME" get namespace open-cluster-management >/dev/null 2>&1; then
-                    echo "🗑️  Initiating deletion of namespace: open-cluster-management"
-
-                    # First, try graceful deletion
-                    oc --context="$CLUSTER_1_NAME" delete namespace open-cluster-management --timeout=120s || {
-                      echo "  ⚠️  Graceful deletion timed out, investigating..."
-
-                      # Check namespace status
-                      ns_status=$(oc --context="$CLUSTER_1_NAME" get namespace open-cluster-management -o jsonpath='{.status.phase}' 2>/dev/null || echo "NotFound")
-                      echo "  Namespace status: $ns_status"
-
-                      if [ "$ns_status" = "Terminating" ]; then
-                        echo "  Namespace stuck in Terminating state, removing finalizers..."
-
-                        # Remove finalizers from all resources in the namespace
-                        echo "  Removing finalizers from all pods..."
-                        for pod in $(oc --context="$CLUSTER_1_NAME" get pods -n open-cluster-management -o name 2>/dev/null); do
-                          oc --context="$CLUSTER_1_NAME" patch "$pod" -n open-cluster-management --type='merge' -p '{"metadata":{"finalizers":[]}}' 2>/dev/null || true
-                        done
-
-                        echo "  Removing finalizers from all deployments..."
-                        for deploy in $(oc --context="$CLUSTER_1_NAME" get deployments -n open-cluster-management -o name 2>/dev/null); do
-                          oc --context="$CLUSTER_1_NAME" patch "$deploy" -n open-cluster-management --type='merge' -p '{"metadata":{"finalizers":[]}}' 2>/dev/null || true
-                        done
-
-                        # Finally remove namespace finalizers
-                        echo "  Removing namespace finalizers..."
-                        oc --context="$CLUSTER_1_NAME" patch namespace open-cluster-management --type='merge' -p '{"metadata":{"finalizers":[]}}' || true
-
-                        sleep 5
-                      fi
-                    }
-
-                    # Wait for namespace to be completely gone
-                    echo "⏳ Waiting for namespace to be completely deleted..."
-                    SECONDS=0
-                    while oc --context="$CLUSTER_1_NAME" get namespace open-cluster-management >/dev/null 2>&1; do
-                      if [ $((SECONDS % 15)) -eq 0 ]; then
-                        ns_phase=$(oc --context="$CLUSTER_1_NAME" get namespace open-cluster-management -o jsonpath='{.status.phase}' 2>/dev/null || echo "Deleted")
-                        echo "  Still waiting... namespace phase: $ns_phase (${SECONDS}s elapsed)"
-
-                        # Show what's preventing deletion
-                        if [ $((SECONDS % 30)) -eq 0 ]; then
-                          echo "  Resources still in namespace:"
-                          oc --context="$CLUSTER_1_NAME" api-resources --verbs=list --namespaced -o name 2>/dev/null | \
-                            xargs -n 1 oc --context="$CLUSTER_1_NAME" get -n open-cluster-management --ignore-not-found --show-kind 2>/dev/null | \
-                            head -20 || true
-                        fi
-                      fi
-                      sleep 3
-
-                      if [ $SECONDS -ge 180 ]; then
-                        echo "  ⛔ Timeout after 3 minutes - forcing final removal"
-                        # Last resort: remove all finalizers from namespace
-                        oc --context="$CLUSTER_1_NAME" get namespace open-cluster-management -o json 2>/dev/null | \
-                          jq '.metadata.finalizers = []' | \
-                          oc --context="$CLUSTER_1_NAME" replace --raw "/api/v1/namespaces/open-cluster-management/finalize" -f - || true
-                        sleep 10
-                        break
-                      fi
-                    done
-
-                    # Final verification
-                    if ! oc --context="$CLUSTER_1_NAME" get namespace open-cluster-management >/dev/null 2>&1; then
-                      echo "  ✅ Namespace completely deleted"
-                    else
-                      echo "  ⚠️  WARNING: Namespace still exists after cleanup attempts!"
-                      echo "  This may cause ACM installation to fail. Manual intervention may be required."
-                      oc --context="$CLUSTER_1_NAME" get namespace open-cluster-management -o yaml || true
-                    fi
-                  else
-                    echo "  ℹ️  Namespace not found - already deleted"
-                  fi
-                  echo ""
-
-                  # Step 9: Clean up remaining ACM CRDs and cluster-scoped resources
-                  echo "Step 9: Cleaning up ACM CRDs and cluster resources..."
-                  echo "------------------------------------------------------"
-                  echo "🗑️  Removing ACM-related ClusterRoles and ClusterRoleBindings"
-                  oc --context="$CLUSTER_1_NAME" delete clusterrole -l open-cluster-management.io/aggregate-to-work= --timeout=30s 2>/dev/null || true
-                  oc --context="$CLUSTER_1_NAME" delete clusterrolebinding -l open-cluster-management.io/aggregate-to-work= --timeout=30s 2>/dev/null || true
-
-                  echo "🗑️  Removing webhook configurations"
-                  oc --context="$CLUSTER_1_NAME" delete validatingwebhookconfiguration -l app=multicluster-operators-subscription --timeout=30s 2>/dev/null || true
-                  oc --context="$CLUSTER_1_NAME" delete mutatingwebhookconfiguration -l app=multicluster-operators-subscription --timeout=30s 2>/dev/null || true
-                  echo ""
-
-                  echo "================================================================"
-                  echo "✅ ACM cleanup completed - system ready for fresh installation"
-                  echo "================================================================"
-
-
             - name: 🚢 Configure ACM
-              timeout-minutes: 30
+              timeout-minutes: 15
               env:
                   RHCS_TOKEN: ${{ steps.secrets.outputs.RH_OPENSHIFT_TOKEN }}
               run: |
@@ -787,7 +430,7 @@ jobs:
                   ./verify-managed-cluster-set.sh
 
             - name: 🐠 Configure Submariner
-              timeout-minutes: 30
+              timeout-minutes: 10
               run: |
                   set -euo pipefail
 
@@ -1057,16 +700,31 @@ jobs:
                     kubectl --context="$CLUSTER_2_NAME" -n "$CAMUNDA_NAMESPACE_2" logs "$pod_name"
                   done
 
+    integration-tests-retry:
+        name: Retry Tests in case of failure
+        if: failure() && fromJSON(github.run_attempt) < 3
+        runs-on: ubuntu-latest
+        needs:
+            - integration-tests
+        steps:
+            - name: Retrigger job
+              uses: camunda/infra-global-github-actions/rerun-failed-run@98d1314ca835f199797565423661bc1a66acc802 # main
+              with:
+                  error-messages: '' # retry no matter the error as we want to ensure that the last retries will trigger the cleanup
+                  run-id: ${{ github.run_id }}
+                  repository: ${{ github.repository }}
+                  vault-addr: ${{ secrets.VAULT_ADDR }}
+                  vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+                  vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
 
     cleanup-clusters:
         name: Cleanup ROSA clusters
-        # in case of a failure that is retried, we will spawn a new cluster
-        # as ACM is bugged
-        if: always()
+        if: always() && (needs.integration-tests.result == 'success' || fromJson(github.run_attempt) >= 3)
         runs-on: ubuntu-latest
         needs:
             - clusters-info
             - integration-tests
+            - integration-tests-retry
         strategy:
             fail-fast: false
             matrix:
@@ -1129,25 +787,6 @@ jobs:
                   openshift: 'true'
                   delete-ghost-rosa-clusters: 'true'
                   modules-order: backup_bucket,peering,clusters
-
-    integration-tests-retry:
-        name: Retry Tests in case of failure after cleanup
-        if: failure() && fromJSON(github.run_attempt) < 3
-        runs-on: ubuntu-latest
-        needs:
-            - integration-tests
-            - cleanup-clusters
-        steps:
-            - name: Retrigger job
-              uses: camunda/infra-global-github-actions/rerun-failed-run@98d1314ca835f199797565423661bc1a66acc802 # main
-              with:
-                  error-messages: '' # retry no matter the error as we want to ensure that the last retries will trigger the cleanup
-                  rerun-whole-workflow: 'true' # we want to rerun the whole workflow instead of just the failed job, to recreate a new cluster
-                  run-id: ${{ github.run_id }}
-                  repository: ${{ github.repository }}
-                  vault-addr: ${{ secrets.VAULT_ADDR }}
-                  vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
-                  vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
     report-success:
         name: Report success
         runs-on: ubuntu-latest

--- a/generic/openshift/dual-region/procedure/acm/auto-import-cluster-secret.yml.tpl
+++ b/generic/openshift/dual-region/procedure/acm/auto-import-cluster-secret.yml.tpl
@@ -3,6 +3,8 @@ kind: Secret
 metadata:
   name: auto-import-secret
   namespace: $CLUSTER_NAME
+  annotations:
+    managedcluster-import-controller.open-cluster-management.io/keeping-auto-import-secret: ""
 stringData:
   autoImportRetry: "5"
   token: $CLUSTER_TOKEN

--- a/generic/openshift/dual-region/procedure/acm/klusterlet-config.yml.tpl
+++ b/generic/openshift/dual-region/procedure/acm/klusterlet-config.yml.tpl
@@ -4,13 +4,6 @@ metadata:
   name: $CLUSTER_NAME
   namespace: $CLUSTER_NAME
 spec:
-  clusterName: $CLUSTER_NAME
-  clusterNamespace: $CLUSTER_NAME
-  clusterLabels:
-    name: $CLUSTER_NAME
-    cloud: auto-detect
-    vendor: auto-detect
-    cluster.open-cluster-management.io/clusterset: oc-clusters
   applicationManager:
     enabled: true
   certPolicyController:

--- a/generic/openshift/dual-region/procedure/acm/klusterlet-global-config.yml
+++ b/generic/openshift/dual-region/procedure/acm/klusterlet-global-config.yml
@@ -1,0 +1,8 @@
+---
+apiVersion: config.open-cluster-management.io/v1alpha1
+kind: KlusterletConfig
+metadata:
+    name: global
+spec:
+    hubKubeAPIServerConfig:
+        serverVerificationStrategy: UseSystemTruststore

--- a/generic/openshift/dual-region/procedure/acm/managed-cluster.yml.tpl
+++ b/generic/openshift/dual-region/procedure/acm/managed-cluster.yml.tpl
@@ -3,7 +3,9 @@ kind: ManagedCluster
 metadata:
   name: $CLUSTER_NAME
   labels:
-    name: $CLUSTER_NAME
+    cloud: auto-detect
+    vendor: auto-detect
+    cluster.open-cluster-management.io/submariner-agent: "true"
     cluster.open-cluster-management.io/clusterset: oc-clusters
   annotations: {}
 spec:


### PR DESCRIPTION
* fix: openshift dual import

* simplify import

* integrate cleanup script

* fix: no respawn on retry

* fix sha

* fix: dual-region acm cleanup condition

* chore: trigger

* fix: remove outdated fields, remove obsolete local-cluster import, remove extra import

* chore: further submariner adjustments and tmp workflow changes

* fix: acm permanent fix

* fix: add missing context for oc label command

* chore: remove ACM cleanup scripts

assume idempotency and that the ACM fix is now working well

* chore: ignore missing file in case of non AWS setups

---------

backport of https://github.com/camunda/camunda-deployment-references/pull/1264