### PR TITLE
fix: skip sm ingress class check for OpenShift

### DIFF
--- a/.github/actions/internal-camunda-chart-tests/README.md
+++ b/.github/actions/internal-camunda-chart-tests/README.md
@@ -44,6 +44,7 @@ All C8 SM checks can be individually enabled/disabled via inputs.
 | `test-client-secret` | <p>Client secret for Camunda authentication tests</p> | `true` | `""` |
 | `enable-c8sm-deployment-check` | <p>Whether the C8 SM deployment check should be run</p> | `false` | `true` |
 | `enable-c8sm-connectivity-check` | <p>Whether the C8 SM Kubernetes connectivity check should be run</p> | `false` | `true` |
+| `skip-c8sm-connectivity-ingress-class-check` | <p>Whether to skip the ingress class check part of the C8 SM Kubernetes connectivity check</p> | `false` | `false` |
 | `enable-c8sm-irsa-check` | <p>Whether the C8 SM AWS IRSA check should be run (only applicable for EKS)</p> | `false` | `false` |
 | `enable-c8sm-zeebe-token-check` | <p>Whether the C8 SM Zeebe token generation check should be run</p> | `false` | `true` |
 | `enable-c8sm-zeebe-connectivity-check` | <p>Whether the C8 SM Zeebe connectivity check should be run</p> | `false` | `true` |
@@ -225,6 +226,12 @@ This action is a `composite` action.
     #
     # Required: false
     # Default: true
+
+    skip-c8sm-connectivity-ingress-class-check:
+    # Whether to skip the ingress class check part of the C8 SM Kubernetes connectivity check
+    #
+    # Required: false
+    # Default: false
 
     enable-c8sm-irsa-check:
     # Whether the C8 SM AWS IRSA check should be run (only applicable for EKS)

--- a/.github/actions/internal-camunda-chart-tests/action.yml
+++ b/.github/actions/internal-camunda-chart-tests/action.yml
@@ -100,6 +100,9 @@ inputs:
     enable-c8sm-connectivity-check:
         description: Whether the C8 SM Kubernetes connectivity check should be run
         default: 'true'
+    skip-c8sm-connectivity-ingress-class-check:
+        description: Whether to skip the ingress class check part of the C8 SM Kubernetes connectivity check
+        default: 'false'
     enable-c8sm-irsa-check:
         description: Whether the C8 SM AWS IRSA check should be run (only applicable for EKS)
         default: 'false'
@@ -576,7 +579,7 @@ runs:
               chmod +x "$C8_SM_CHECKS_PATH/checks/kube/connectivity.sh"
 
               # Skip ingress checks if no domain is configured
-              if [[ -z "$CAMUNDA_DOMAIN" ]]; then
+              if [[ -z "$CAMUNDA_DOMAIN" ]] || [[ "${{ inputs.skip-c8sm-connectivity-ingress-class-check }}" == "true" ]]; then
                 echo "ℹ️ No domain configured, skipping ingress checks"
                 "$C8_SM_CHECKS_PATH/checks/kube/connectivity.sh" -n "$NAMESPACE" -i
               else

--- a/.github/workflows/aws_openshift_rosa_hcp_single_region_tests.yml
+++ b/.github/workflows/aws_openshift_rosa_hcp_single_region_tests.yml
@@ -563,6 +563,7 @@ jobs:
                   test-release-name: ${{ env.CAMUNDA_RELEASE_NAME }}
                   test-client-id: ${{ steps.secrets.outputs.CI_CAMUNDA_USER_TEST_CLIENT_ID }}
                   test-client-secret: ${{ steps.secrets.outputs.CI_CAMUNDA_USER_TEST_CLIENT_SECRET }}
+                  skip-c8sm-connectivity-ingress-class-check: 'true' # OpenShift uses different ingress class names
 
             - name: 🔬🚨 Get failed Pods info
               if: failure()


### PR DESCRIPTION
related to [slack alert](https://camunda.slack.com/archives/C076N4G1162/p1762994905221869)

OpenShift doesn't use `nginx` ingress class names.