### PR TITLE
fix: use new identity client structure for extra venom client

### DIFF
--- a/generic/kubernetes/single-region/tests/helm-values/identity.yml
+++ b/generic/kubernetes/single-region/tests/helm-values/identity.yml
@@ -1,59 +1,32 @@
 ---
 # TODO: [release-duty] when release update the link with the related Camunda version of the release
-# keep it synced with https://github.com/camunda/camunda-platform-helm/blob/main/charts/camunda-platform-8.8/test/integration/scenarios/common/values-integration-test.yaml
+# keep it synced with https://github.com/camunda/camunda-platform-helm/blob/main/charts/camunda-platform-8.9/test/integration/scenarios/common/values-integration-test.yaml
 # it generates the CI user used to connect to the platform
 identity:
-    env:
-        - name: KEYCLOAK_CLIENTS_2_ID
-          value: venom
-        - name: KEYCLOAK_CLIENTS_2_NAME
-          value: Venom
-        - name: KEYCLOAK_CLIENTS_2_SECRET
-          valueFrom:
-              secretKeyRef:
-                  # adjusted to align with our tests
-                  name: identity-secret-for-components-integration
-                  key: identity-admin-client-secret
-        - name: KEYCLOAK_CLIENTS_2_REDIRECT_URIS_0
-          value: /dummy
-        - name: KEYCLOAK_CLIENTS_2_ROOT_URL
-          value: http://dummy
-        - name: KEYCLOAK_CLIENTS_2_TYPE
-          value: CONFIDENTIAL
-        # Identity access.
-        - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_0_RESOURCE_SERVER_ID
-          value: camunda-identity-resource-server
-        - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_0_DEFINITION
-          value: read
-        - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_1_RESOURCE_SERVER_ID
-          value: camunda-identity-resource-server
-        - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_1_DEFINITION
-          value: write
-        # Orchestration access.
-        - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_2_RESOURCE_SERVER_ID
-          value: orchestration-api
-        - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_2_DEFINITION
-          value: read:*
-        - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_3_RESOURCE_SERVER_ID
-          value: orchestration-api
-        - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_3_DEFINITION
-          value: write:*
-        # Optimize access.
-        - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_4_RESOURCE_SERVER_ID
-          value: optimize-api
-        - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_4_DEFINITION
-          value: write:*
-        # WebModeler access.
-        - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_5_RESOURCE_SERVER_ID
-          value: web-modeler-api
-        - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_5_DEFINITION
-          value: write:*
-        # Console access.
-        - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_6_RESOURCE_SERVER_ID
-          value: console-api
-        - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_6_DEFINITION
-          value: write:*
-
+    clients:
+        - id: venom
+          name: Venom
+          # adjusted to align with our tests
+          existingSecret: identity-secret-for-components-integration
+          existingSecretKey: identity-admin-client-secret
+          redirectUris: /dummy
+          rootUrl: http://dummy
+          type: confidential
+          permissions:
+              - resourceServerId: camunda-identity-resource-server
+                definition: read
+              - resourceServerId: camunda-identity-resource-server
+                definition: write
+              - resourceServerId: orchestration-api
+                definition: read:*
+              - resourceServerId: orchestration-api
+                definition: write:*
+              - resourceServerId: optimize-api
+                definition: write:*
+              - resourceServerId: web-modeler-api
+                definition: write:*
+              - resourceServerId: console-api
+                definition: write:*
 
 orchestration:
     security:


### PR DESCRIPTION
related to [slack thread](https://camunda.slack.com/archives/C076N4G1162/p1763352230651699)

related to https://github.com/camunda/camunda-platform-helm/pull/4710

Uses the new client structure for Identity as otherwise we would get an index out of bound exception.
Alternative could have been to just decrease the index from 2 to 0