### PR TITLE
fix: bump OpenShift to lowest supported version

### DIFF
--- a/.github/workflows-config/aws-openshift-rosa-hcp-single-region/test_matrix.yml
+++ b/.github/workflows-config/aws-openshift-rosa-hcp-single-region/test_matrix.yml
@@ -5,7 +5,7 @@ matrix:
         # /!\ Please keep this matrix synced with the official documentation:
         # https://github.com/camunda/camunda-docs/blob/main/docs/self-managed/setup/deploy/openshift/redhat-openshift.md?plain=1#L2
         # According to https://access.redhat.com/support/policy/updates/openshift, this matrix should reference the first and the last of the supported versions of OpenShift
-        - name: OpenShift 4.19
+        - name: OpenShift latest
           schedule_only: false
           # ! Unlike EKS, 'private_vpc' is defined in 'distro' and not in 'scenario'.
           private_vpc: true # latest always use vpn, olders use public


### PR DESCRIPTION
4.16 reached EOL end of December

related to: https://camunda.slack.com/archives/C076N4G1162/p1767584666056779

TODO left on purpose.
After it works, will merge to unblock other topics.
Nice by Léo that the reference is in a single place, makes updating easy.

Got the 4.17 version from our renovate list that uses the cli to update it, so should be fine.