### PR TITLE
fix: missing scheduling

### DIFF
--- a/.github/workflows-config/workflow-scheduler.yml
+++ b/.github/workflows-config/workflow-scheduler.yml
@@ -60,6 +60,10 @@ schedules:
           - .github/workflows/aws_compute_ec2_single_region_tests.yml
           # Azure AKS Single Region
           - .github/workflows/azure_kubernetes_aks_single_region_tests.yml
+          # Generic Kubernetes Operator Based
+          - .github/workflows/generic_kubernetes_operator_based_test.yml
+          # Local Kubernetes Kind Single Region
+          - .github/workflows/local_kubernetes_kind_single_region_tests.yml
 
     - name: Everyday schedules 8.8
       branch: stable/8.8


### PR DESCRIPTION
This pull request adds new scheduled workflows to the `.github/workflows-config/workflow-scheduler.yml` configuration, expanding the test coverage for Kubernetes environments.

**Expanded Kubernetes test scheduling:**

* Added `.github/workflows/generic_kubernetes_operator_based_test.yml` to schedule tests for generic Kubernetes operator-based deployments.
* Added `.github/workflows/local_kubernetes_kind_single_region_tests.yml` to schedule tests for local Kubernetes clusters using Kind in a single region.