### PR TITLE
fix: docker hub rate limiting

### DIFF
--- a/.github/workflows/local_kubernetes_kind_single_region_tests.yml
+++ b/.github/workflows/local_kubernetes_kind_single_region_tests.yml
@@ -152,12 +152,28 @@ jobs:
 
                   ./procedure/certs-create-ca-configmap.sh
 
+            - name: Create Docker Hub pull secret
+              run: |
+                  set -euo pipefail
+
+                  # Create the pull secret to avoid Docker Hub rate limit
+                  kubectl create secret docker-registry index-docker-io \
+                      --docker-server=index.docker.io \
+                      --docker-username="${{ steps.secrets.outputs.DOCKERHUB_USER }}" \
+                      --docker-password="${{ steps.secrets.outputs.DOCKERHUB_PASSWORD }}" \
+                      --namespace="${{ env.CAMUNDA_NAMESPACE }}"
+
             # Deploy Camunda
             - name: Deploy Camunda (domain mode)
               if: matrix.declination.use_tls
               working-directory: ${{ env.REF_ARCH_PATH }}
               run: |
                   set -euo pipefail
+
+                  # Apply registry configuration to avoid Docker Hub rate limit
+                  yq ". *+ load(\"../../../generic/kubernetes/single-region/tests/helm-values/registry.yml\")" \
+                    helm-values/values-domain.yml > helm-values/values-domain.yml.tmp
+                  mv helm-values/values-domain.yml.tmp helm-values/values-domain.yml
 
                   ./procedure/camunda-deploy-domain.sh
 
@@ -166,6 +182,11 @@ jobs:
               working-directory: ${{ env.REF_ARCH_PATH }}
               run: |
                   set -euo pipefail
+
+                  # Apply registry configuration to avoid Docker Hub rate limit
+                  yq ". *+ load(\"../../../generic/kubernetes/single-region/tests/helm-values/registry.yml\")" \
+                    helm-values/values-no-domain.yml > helm-values/values-no-domain.yml.tmp
+                  mv helm-values/values-no-domain.yml.tmp helm-values/values-no-domain.yml
 
                   ./procedure/camunda-deploy-no-domain.sh
 


### PR DESCRIPTION
This pull request updates the workflow for local Kubernetes KIND single-region tests to mitigate Docker Hub rate limits during CI runs. The main changes involve creating a Docker Hub pull secret and updating Helm values to include registry configuration before deploying Camunda.

**Docker Hub rate limit mitigation:**

* Added a step to create a Docker Hub pull secret (`index-docker-io`) using credentials from workflow secrets, ensuring authenticated image pulls to avoid rate limiting. (.github/workflows/local_kubernetes_kind_single_region_tests.yml)

**Registry configuration for Camunda deployments:**

* Updated the Helm values for both domain and no-domain Camunda deployments by merging in registry configuration from `registry.yml`, ensuring all image pulls use the configured registry settings. (.github/workflows/local_kubernetes_kind_single_region_tests.yml) [[1]](diffhunk://#diff-d28c2f68c9359d177fb8bd8935f04955f5b0f0bf6e27e854c466bf1f7be7f366R155-R177) [[2]](diffhunk://#diff-d28c2f68c9359d177fb8bd8935f04955f5b0f0bf6e27e854c466bf1f7be7f366R186-R190)