### PR TITLE
fix: explicity enable Elasticsearch - was turned off by Helm Chart

### DIFF
--- a/generic/openshift/dual-region/helm-values/values-base.yml
+++ b/generic/openshift/dual-region/helm-values/values-base.yml
@@ -22,6 +22,8 @@ global:
             # Disable the Identity authentication
             # it will fall back to basic-auth: demo/demo as default user
             enabled: false
+    elasticsearch:
+        enabled: true
 
     compatibility:
         openshift:

--- a/generic/openshift/single-region/helm-values/base.yml
+++ b/generic/openshift/single-region/helm-values/base.yml
@@ -107,3 +107,6 @@ webModelerPostgresql:
         secretKeys:
             adminPasswordKey: identity-webmodeler-pg-admin-password
             userPasswordKey: identity-webmodeler-pg-user-password
+
+elasticsearch:
+    enabled: true # use the embbeded elasticsearch


### PR DESCRIPTION
The Helm Chart turned off the embedded Elasticsearch last week.
For now I'd keep it enabled for the tests till we migrated away to alternatives.

Related to [Slack alert](https://camunda.slack.com/archives/C076N4G1162/p1768196465630739)