### PR TITLE
chore: remove Camunda startup command from template

### DIFF
--- a/aws/modules/ecs/fargate/orchestration-cluster/templates/orchestration-cluster.json.tpl
+++ b/aws/modules/ecs/fargate/orchestration-cluster/templates/orchestration-cluster.json.tpl
@@ -38,11 +38,6 @@
           "awslogs-multiline-pattern": "^\\[\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}\\.\\d{3}\\]"
         }
     },
-    "command": [
-      "bash",
-      "-c",
-      "export ZEEBE_BROKER_NETWORK_HOST=$(hostname -I | awk '{print $2}'); /usr/local/camunda/bin/camunda"
-    ],
     "environment": ${env_vars_json},
     %{ if has_secrets ~}
     "secrets": ${secrets_json},


### PR DESCRIPTION
the command wasn't used anyway.
Hostname -i would work as it's busybox in the new minimus image.

Fixing it up actually breaks the setup.