### PR TITLE
fix(security): patch nginx ingress version to address CVEs

### DIFF
--- a/generic/kubernetes/single-region/procedure/export-ingress-setup-vars.sh
+++ b/generic/kubernetes/single-region/procedure/export-ingress-setup-vars.sh
@@ -7,7 +7,7 @@ export MAIL=admin@camunda.example.com
 # Helm chart versions for Ingress components
 
 # renovate: datasource=helm depName=ingress-nginx registryUrl=https://kubernetes.github.io/ingress-nginx
-export INGRESS_HELM_CHART_VERSION="4.14.1"
+export INGRESS_HELM_CHART_VERSION="4.14.3"
 # renovate: datasource=helm depName=external-dns registryUrl=https://kubernetes-sigs.github.io/external-dns/
 export EXTERNAL_DNS_HELM_CHART_VERSION="1.20.0"
 # renovate: datasource=helm depName=cert-manager registryUrl=https://charts.jetstack.io

--- a/local/kubernetes/kind-single-region/procedure/ingress-nginx-deploy.sh
+++ b/local/kubernetes/kind-single-region/procedure/ingress-nginx-deploy.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 # Deploy Ingress NGINX controller
 
 # renovate: datasource=helm depName=ingress-nginx registryUrl=https://kubernetes.github.io/ingress-nginx
-INGRESS_HELM_CHART_VERSION="4.14.1"
+INGRESS_HELM_CHART_VERSION="4.14.3"
 
 echo "Installing Ingress NGINX controller..."
 


### PR DESCRIPTION
This pull request updates the version of the Ingress NGINX Helm chart to ensure deployments use the latest stable release. The version is updated in both the single-region and local Kind deployment scripts.

**Helm Chart Version Updates:**
* Updated the `INGRESS_HELM_CHART_VERSION` from `4.14.1` to `4.14.3` in `generic/kubernetes/single-region/procedure/export-ingress-setup-vars.sh` to use the latest Ingress NGINX chart version.
* Updated the `INGRESS_HELM_CHART_VERSION` from `4.14.1` to `4.14.3` in `local/kubernetes/kind-single-region/procedure/ingress-nginx-deploy.sh` for local Kind deployments.