### PR TITLE
fix: core dns IP retrieval to use correct filter and not too broad

### DIFF
--- a/aws/kubernetes/eks-dual-region/procedure/generate_core_dns_entry.sh
+++ b/aws/kubernetes/eks-dual-region/procedure/generate_core_dns_entry.sh
@@ -36,7 +36,7 @@ if [ -z "$namespace_1" ]; then
     read -r -p "Enter the Kubernetes cluster namespace where Camunda 8 is installed, in region 1: " namespace_1
 fi
 
-if [ "$namespace_0" == "$namespace_1" ]; then
+if [ "$namespace_0" = "$namespace_1" ]; then
     echo "Kubernetes namespaces for Camunda installations must be called differently"
     exit 1
 fi

--- a/aws/kubernetes/eks-dual-region/test/multi_region_aws_dns_chaining_test.go
+++ b/aws/kubernetes/eks-dual-region/test/multi_region_aws_dns_chaining_test.go
@@ -139,7 +139,9 @@ func applyDnsChaining(t *testing.T) {
 	awsHelpers.CreateLoadBalancers(t, secondary, k8sManifests)
 	allPrimaryNamespaces := primaryNamespaceArr
 	allSecondaryNamespaces := secondaryNamespaceArr
+	os.Setenv("KUBECONFIG", kubeConfigPrimary+":"+kubeConfigSecondary)
 	awsHelpers.DNSChaining(t, primary, secondary, k8sManifests, allPrimaryNamespaces, allSecondaryNamespaces)
+	os.Unsetenv("KUBECONFIG")
 }
 
 func testCoreDNSReload(t *testing.T) {


### PR DESCRIPTION
Problem was that back when it was changed from go implementation to scripts, the kubeconfig was forgotten so it always matched all LBs instead of the filtered one as it was an empty value.

Related to https://camunda.slack.com/archives/C076N4G1162/p1770611944631129
