### PR TITLE
fix: check labels comment id

### DIFF
--- a/.github/actions/internal-triage-skip/action.yml
+++ b/.github/actions/internal-triage-skip/action.yml
@@ -184,17 +184,19 @@ runs:
                     sleep "$poll_interval"
                     attempt=$((attempt + 1))
 
-                    gh_output=$(gh pr view "$pr_number" --repo "$repo" --json comments 2>&1) || {
+                    # Use REST API to get numeric comment IDs (gh pr view returns GraphQL node IDs which break tonumber and REST DELETE)
+                    # Use per_page=100 instead of --paginate to avoid multi-document JSON output (--paginate emits one array per page)
+                    gh_output=$(gh api "/repos/$repo/issues/$pr_number/comments?per_page=100" 2>&1) || {
                       handle_gh_error $? "fetching comments for cleanup (attempt $attempt)" "$gh_output"
                       break
                     }
-                    # Sort by createdAt first, then by id (numeric) for deterministic ordering
+                    # Sort by created_at first, then by id (numeric) for deterministic ordering
                     # This ensures consistent behavior even with identical timestamps
                     # Lowest ID wins as it was created first by GitHub's sequential ID assignment
-                    jq_filter='[.comments[] | select(.body | contains("'"$checklist_marker"'"))'
-                    jq_filter+=' | {id: .id, createdAt: .createdAt,'
+                    jq_filter='[.[] | select(.body | contains("'"$checklist_marker"'"))'
+                    jq_filter+=' | {id: .id, createdAt: .created_at,'
                     jq_filter+=' hasCheckboxChecked: (.body | test("- \\[[xX]\\]"))}]'
-                    jq_filter+=' | sort_by(.createdAt, .id)'
+                    jq_filter+=' | sort_by([.createdAt, .id])'
                     all_checklist_comments=$(echo "$gh_output" | jq "$jq_filter")
                     comment_count=$(echo "$all_checklist_comments" | jq 'length')
 


### PR DESCRIPTION
This pull request updates the comment cleanup logic in the `.github/actions/internal-triage-skip/action.yml` workflow to improve reliability and compatibility with GitHub's REST API. The most important change is switching from the GraphQL API to the REST API for fetching PR comments, which ensures numeric comment IDs are used and fixes issues with ID handling.

Related to https://camunda.slack.com/archives/C076N4G1162/p1770860469429269

Improvements to comment cleanup logic:

* Switched from using `gh pr view` (GraphQL API) to `gh api "/repos/$repo/issues/$pr_number/comments"` (REST API) to fetch PR comments, ensuring numeric comment IDs are available for cleanup operations.
* Updated the sorting logic in the `jq` filter to use `created_at` instead of `createdAt`, matching the REST API field names and improving deterministic ordering of comments.
* Modified the `jq` filter to iterate over the REST API response array (`.[]`) instead of the GraphQL response (`.comments[]`).