### PR TITLE
fix: cleaup dual region format

### DIFF
--- a/.github/actions/aws-generic-terraform-cleanup/scripts/destroy-resources.sh
+++ b/.github/actions/aws-generic-terraform-cleanup/scripts/destroy-resources.sh
@@ -258,8 +258,15 @@ destroy_module() {
     }
 
     local cluster_1_name cluster_2_name
-    cluster_1_name=$(echo "$group_id" | awk -F"-oOo-" '{print $1}')
-    cluster_2_name=$(echo "$group_id" | awk -F"-oOo-" '{print $2}')
+    if [[ "$group_id" == *"-oOo-"* ]]; then
+      # ROSA-style: two distinct cluster names separated by -oOo-
+      cluster_1_name=$(echo "$group_id" | awk -F"-oOo-" '{print $1}')
+      cluster_2_name=$(echo "$group_id" | awk -F"-oOo-" '{print $2}')
+    else
+      # EKS-style: single prefix used for both clusters (suffixed with region names)
+      cluster_1_name="$group_id"
+      cluster_2_name="$group_id"
+    fi
 
     # Validate that both cluster names are non-empty to avoid overly broad regex patterns
     if [[ -z "$cluster_1_name" || -z "$cluster_2_name" ]]; then


### PR DESCRIPTION
This pull request updates the logic for determining cluster names in the `destroy_module()` function of the AWS Terraform cleanup script. The main improvement is supporting both ROSA-style and EKS-style cluster naming conventions, making the script more flexible for different cluster setups.

Cluster name handling enhancements:

* The script now detects if the `group_id` contains `-oOo-` to distinguish between ROSA-style (two distinct cluster names) and EKS-style (single prefix for both clusters) naming conventions, and sets `cluster_1_name` and `cluster_2_name` accordingly.