### PR TITLE
fix: dual-reg cleanup by pre-defining regions

### DIFF
--- a/.github/workflows/aws_kubernetes_eks_dual_region_daily_cleanup.yml
+++ b/.github/workflows/aws_kubernetes_eks_dual_region_daily_cleanup.yml
@@ -36,6 +36,8 @@ env:
     S3_BACKEND_BUCKET: tests-ra-aws-rosa-hcp-tf-state-eu-central-1
     S3_BUCKET_REGION: eu-central-1
     AWS_REGION: eu-west-2
+    CLUSTER_1_AWS_REGION: eu-west-2
+    CLUSTER_2_AWS_REGION: eu-west-3
 
 jobs:
     triage:


### PR DESCRIPTION
related to https://camunda.slack.com/archives/C076N4G1162/p1770957719098969

Region definition was missing for the dual-reg setup to allow destroying it.