### PR TITLE
fix(rosa): ci missing eck service name

### DIFF
--- a/.github/workflows/aws_openshift_rosa_hcp_single_region_tests.yml
+++ b/.github/workflows/aws_openshift_rosa_hcp_single_region_tests.yml
@@ -645,6 +645,7 @@ jobs:
                   test-client-id: ${{ steps.secrets.outputs.CI_CAMUNDA_USER_TEST_CLIENT_ID }}
                   test-client-secret: ${{ steps.secrets.outputs.CI_CAMUNDA_USER_TEST_CLIENT_SECRET }}
                   keycloak-service-name: ${{ matrix.scenario.auth_provider == 'keycloak-operator' && 'keycloak-service:18080' || '' }}
+                  elasticsearch-service-name: elasticsearch-es-http:9200
                   skip-c8sm-connectivity-ingress-class-check: 'true' # OpenShift uses different ingress class names
 
             - name: 🔬🚨 Get failed Pods info


### PR DESCRIPTION
Spotted during the review of AKS, the service name for ROSA is missing following ECK implementation

This pull request introduces a small update to the workflow configuration for AWS OpenShift ROSA HCP single region tests. The change adds a new environment variable for the Elasticsearch service name to the job configuration.

* Workflow configuration update:
  * [`.github/workflows/aws_openshift_rosa_hcp_single_region_tests.yml`](diffhunk://#diff-dcd18f4a46c500fe2ec1f85caa14905f0ef9986911df9004be5b2b1e020e059aR648): Added the `elasticsearch-service-name` variable with the value `elasticsearch-es-http:9200` to the job environment.