### PR TITLE
fix(renovate): base branch patterns

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,17 +4,9 @@
   packageRules: [],
   baseBranchPatterns: [
     'main',
-    // stable/8.4 and stable/8.5 excluded as maintenance period ended
-    // Note: Some branches listed above may not exist yet but are included to avoid regex complexity
+    // TODO [release-duty]: remove branches whose maintenance period has ended and add the new stable branch
     'stable/8.6',
     'stable/8.7',
     'stable/8.8',
-    'stable/8.9',
-    'stable/8.10',
-    'stable/8.11',
-    'stable/8.12',
-    'stable/8.13',
-    'stable/8.14',
-    'stable/8.15',
   ]
 }

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -65,6 +65,13 @@ When a new version is ready for release, we need to cut the `main` branch to cre
    * Update version references in relevant files to reflect the new development cycle.
    * **Update `.target-branch`** so that it continues to point to `main` (or whichever branch is the new default target).
 
+7. **Update Renovate branch patterns**
+
+   * In `.github/renovate.json5`, update the `baseBranchPatterns` list:
+     * Add the newly created `stable/8.x` branch.
+     * Remove any branches whose maintenance period has ended.
+   * This ensures Renovate only creates dependency update PRs for actively maintained branches.
+
 ---
 
 ## Modules


### PR DESCRIPTION
This pull request updates the Renovate configuration to specify which branches Renovate should target for dependency updates. The main change is the addition of a `baseBranchPatterns` array listing all currently supported stable branches, as well as `main`.

Related to https://github.com/camunda/infraex-common-config/pull/398

Configuration updates:

* Added a `baseBranchPatterns` array to `.github/renovate.json5` to explicitly list `main` and all stable branches from `stable/8.6` through `stable/8.15`, ensuring Renovate only runs on these branches. (`[.github/renovate.json5L4-R19](diffhunk://#diff-20ab1190d08a53a3012bc191ed56205c8f0ffb8fa1715e9d36ecfd1d2ea8a790L4-R19)`)