### PR TITLE
fix(trivy): Disable Trivy usage

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,15 +56,6 @@ repos:
                 - --hook-config=--add-to-existing-file=true
                 - --args=--config=.lint/terraform_docs/.terraform-docs.yml
 
-    - repo: local
-      hooks:
-          - id: trivy-scan
-            name: Trivy Scan
-            entry: .lint/trivy/trivy-scan.sh
-            language: script
-            types: [terraform]
-            pass_filenames: false
-
     - repo: https://github.com/tekwizely/pre-commit-golang
       rev: v1.0.0-rc.4
       hooks:

--- a/.tool-versions
+++ b/.tool-versions
@@ -60,6 +60,4 @@ terraform-docs 0.21.0
 
 tflint 0.61.0
 
-trivy 0.69.2
-
 yq 4.52.4


### PR DESCRIPTION
## fix(trivy): Disable Trivy usage

This pull request removes support for Trivy vulnerability scanning from the codebase. The most important changes are:

**Pre-commit configuration updates:**

* Removed the local Trivy scan hook from `.pre-commit-config.yaml`, which disables automatic Trivy vulnerability scans during pre-commit checks.

**Tool version management:**

* Removed the Trivy tool version entry from `.tool-versions`, meaning Trivy will no longer be managed or required as part of the project's toolchain.

