### PR TITLE
fix(rosa): permissions scp (#1913)

### DIFF
--- a/.github/actions/aws-openshift-rosa-hcp-single-region-create/action.yml
+++ b/.github/actions/aws-openshift-rosa-hcp-single-region-create/action.yml
@@ -132,6 +132,7 @@ runs:
         - name: Verify and enable HCP ROSA on AWS Marketplace
           shell: bash
           run: |
+              set -euo pipefail
               rosa verify quota
               rosa create account-roles --mode auto --yes
               rosa create ocm-role --mode auto --yes


### PR DESCRIPTION
This pull request updates the AWS OpenShift ROSA HCP single region creation workflow to improve automation and reduce manual intervention during account and OCM role creation.


Related to https://camunda.slack.com/archives/C076N4G1162/p1773095106403989?thread_ts=1773094652.080589&cid=C076N4G1162

**Improvements to automation:**

* In `.github/actions/aws-openshift-rosa-hcp-single-region-create/action.yml`, removed the `rosa verify permissions` step, added `--yes` to `rosa create account-roles --mode auto` to auto-confirm prompts, and added a new step to automatically create the OCM role with `rosa create ocm-role --mode auto --yes`.