### PR TITLE
feat(kind): add infra-only make targets

### DIFF
--- a/local/kubernetes/kind-single-region/Makefile
+++ b/local/kubernetes/kind-single-region/Makefile
@@ -112,7 +112,7 @@ domain.infra: cluster.create ingress.deploy coredns.config hosts.add certs.gener
 	@echo "  Before installing Camunda, create the required credentials secret (camunda-credentials):"
 	@echo "    make identity-secrets.create"
 	@echo "  Deploy Camunda with your own values:"
-	@echo "    helm upgrade --install $(CAMUNDA_RELEASE_NAME) oci://registry.camunda.cloud/team-distribution/camunda-platform --version <CHART_VERSION> -n $(CAMUNDA_NAMESPACE) --create-namespace -f your-values.yaml"
+	@echo "    helm upgrade --install camunda oci://registry.camunda.cloud/team-distribution/camunda-platform --version <CHART_VERSION> -n camunda --create-namespace -f your-values.yaml"
 	@echo ""
 
 .PHONY: no-domain.infra
@@ -122,7 +122,7 @@ no-domain.infra: cluster.create hosts.add-keycloak operators.deploy-no-domain
 	@echo "  Before installing Camunda, create the required credentials secret (camunda-credentials):"
 	@echo "    make identity-secrets.create"
 	@echo "  Deploy Camunda with your own values:"
-	@echo "    helm upgrade --install $(CAMUNDA_RELEASE_NAME) oci://registry.camunda.cloud/team-distribution/camunda-platform --version <CHART_VERSION> -n $(CAMUNDA_NAMESPACE) --create-namespace -f your-values.yaml"
+	@echo "    helm upgrade --install camunda oci://registry.camunda.cloud/team-distribution/camunda-platform --version <CHART_VERSION> -n camunda --create-namespace -f your-values.yaml"
 	@echo ""
 
 .PHONY: no-domain.clean


### PR DESCRIPTION
Add domain.infra and no-domain.infra targets that set up the Kind cluster with all infrastructure (operators, ingress, certs, etc.) but without deploying Camunda itself.

This allows users to bring their own values.yaml files to install Camunda with custom configuration.

Requested by @epollum 

---

This pull request adds new Makefile targets to support setting up only the infrastructure (without deploying Camunda), allowing users to bring their own Camunda `values.yaml` file. It also updates the help output to document these new options.

**New infrastructure-only Makefile targets:**

* Added `domain.infra` target to set up domain infrastructure with TLS, excluding Camunda deployment, and provide instructions for installing Camunda with a custom `values.yaml`.
* Added `no-domain.infra` target to set up infrastructure without TLS and without Camunda, also providing instructions for custom deployment.

**Documentation updates:**

* Updated the help section to include the new infrastructure-only targets and clarify their purpose.