### PR TITLE
feat(ci): add docs PR watcher for InfraEx content consistency

### DIFF
--- a/.github/workflows/internal_docs_pr_watcher.yml
+++ b/.github/workflows/internal_docs_pr_watcher.yml
@@ -185,51 +185,11 @@ jobs:
 
                           while IFS= read -r url; do
                             [[ -z "$url" ]] && continue
-
-                            if [[ "$url" =~ github\.com/camunda/([^/]+)/(blob|tree)/([^/]+)/(.*) ]]; then
-                              repo_name="${BASH_REMATCH[1]}"
-                              ref="${BASH_REMATCH[3]}"
-                              path="${BASH_REMATCH[4]}"
-                              path="${path%%#*}"
-                              if ! gh api \
-                                "repos/camunda/${repo_name}/contents/${path}?ref=${ref}" \
-                                --silent > /dev/null 2>&1; then
-                                broken_links+=("$file -> $url")
-                                echo "    ❌ Broken link in $file: $url"
-                              fi
-                            elif [[ "$url" =~ raw\.githubusercontent\.com/camunda/([^/]+)/refs/heads/([^/]+)/(.*) ]]; then
-                              repo_name="${BASH_REMATCH[1]}"
-                              ref="${BASH_REMATCH[2]}"
-                              path="${BASH_REMATCH[3]}"
-                              path="${path%%#*}"
-                              if ! gh api \
-                                "repos/camunda/${repo_name}/contents/${path}?ref=${ref}" \
-                                --silent > /dev/null 2>&1; then
-                                broken_links+=("$file -> $url")
-                                echo "    ❌ Broken link in $file: $url"
-                              fi
-                            elif [[ "$url" =~ raw\.githubusercontent\.com/camunda/([^/]+)/refs/tags/([^/]+)/(.*) ]]; then
-                              repo_name="${BASH_REMATCH[1]}"
-                              ref="${BASH_REMATCH[2]}"
-                              path="${BASH_REMATCH[3]}"
-                              path="${path%%#*}"
-                              if ! gh api \
-                                "repos/camunda/${repo_name}/contents/${path}?ref=${ref}" \
-                                --silent > /dev/null 2>&1; then
-                                broken_links+=("$file -> $url")
-                                echo "    ❌ Broken link in $file: $url"
-                              fi
-                            elif [[ "$url" =~ raw\.githubusercontent\.com/camunda/([^/]+)/([^/]+)/(.*) ]]; then
-                              repo_name="${BASH_REMATCH[1]}"
-                              ref="${BASH_REMATCH[2]}"
-                              path="${BASH_REMATCH[3]}"
-                              path="${path%%#*}"
-                              if ! gh api \
-                                "repos/camunda/${repo_name}/contents/${path}?ref=${ref}" \
-                                --silent > /dev/null 2>&1; then
-                                broken_links+=("$file -> $url")
-                                echo "    ❌ Broken link in $file: $url"
-                              fi
+                            # Strip anchor fragments
+                            clean_url="${url%%#*}"
+                            if ! curl -sfL -o /dev/null "$clean_url"; then
+                              broken_links+=("$file -> $url")
+                              echo "    ❌ Broken link in $file: $url"
                             fi
                           done <<< "$urls"
 


### PR DESCRIPTION
Add a scheduled GitHub Action that monitors PRs on camunda/camunda-docs for changes to files referencing camunda-deployment-references.

When detected, the workflow:
- Dynamically scans changed markdown files for repo references
- Validates that links to camunda-deployment-references are not broken
- Comments on the PR with a detailed report
- Requests review from @camunda/infraex-medic
- Adds component:infraex and component:self-managed labels

Also monitors a static watchlist of critical pages (reference architecture) regardless of whether they link to this repo.

Runs every hour during business hours (UTC) on weekdays. Supports dry-run mode via workflow_dispatch and automatically dry-runs on PR events for safe validation.