### PR TITLE
feat/exec playwright e2e tests

### DIFF
--- a/.github/actions/internal-camunda-playwright-tests/README.md
+++ b/.github/actions/internal-camunda-playwright-tests/README.md
@@ -1,0 +1,106 @@
+# Camunda Playwright E2E Tests
+
+## Description
+
+Run Playwright-based E2E tests from the camunda-platform-helm repository. Requires the Helm chart to be deployed and cluster access granted. Uses the helm chart's run-e2e-tests.sh script for environment setup and test execution.
+
+
+## Inputs
+
+| name | description | required | default |
+| --- | --- | --- | --- |
+| `camunda-helm-repo-ref` | <p>Git ref for camunda-platform-helm checkout</p> | `false` | `main` |
+| `camunda-helm-repo-path` | <p>Path to clone the Helm chart repository</p> | `false` | `./.camunda_helm_repo` |
+| `camunda-version` | <p>The Camunda version (e.g., 8.9). Used to locate the chart directory.</p> | `true` | `""` |
+| `test-namespace` | <p>Kubernetes namespace where Camunda is deployed</p> | `false` | `camunda` |
+| `test-project` | <p>Playwright test project to run. Options: smoke-tests, full-suite</p> | `false` | `smoke-tests` |
+| `test-exclude` | <p>Tests to exclude (passed to --test-exclude flag). Example: 'identity.spec.ts' or 'console.spec.ts|identity.spec.ts'</p> | `false` | `""` |
+| `test-auth-type` | <p>Authentication type: keycloak, basic, hybrid. Passed as TEST<em>AUTH</em>TYPE env var.</p> | `false` | `keycloak` |
+| `ingress-host` | <p>Override the ingress hostname detection. If set, this value is used instead of auto-detecting from cluster ingress resources. Required for Kind clusters where the domain is configured via /etc/hosts.</p> | `false` | `""` |
+| `ignore-tls-errors` | <p>Set to 'true' to disable TLS certificate verification (NODE<em>TLS</em>REJECT_UNAUTHORIZED=0). Required for Kind clusters using self-signed certificates.</p> | `false` | `false` |
+| `upload-artifacts` | <p>Whether to upload Playwright test artifacts (report + results)</p> | `false` | `true` |
+| `artifact-retention-days` | <p>Number of days to retain test artifacts</p> | `false` | `10` |
+| `artifact-name-suffix` | <p>Suffix appended to artifact names for uniqueness in matrix builds. Defaults to run-id and attempt.</p> | `false` | `""` |
+
+
+## Runs
+
+This action is a `composite` action.
+
+## Usage
+
+```yaml
+- uses: camunda/camunda-deployment-references/.github/actions/internal-camunda-playwright-tests@main
+  with:
+    camunda-helm-repo-ref:
+    # Git ref for camunda-platform-helm checkout
+    #
+    # Required: false
+    # Default: main
+
+    camunda-helm-repo-path:
+    # Path to clone the Helm chart repository
+    #
+    # Required: false
+    # Default: ./.camunda_helm_repo
+
+    camunda-version:
+    # The Camunda version (e.g., 8.9). Used to locate the chart directory.
+    #
+    # Required: true
+    # Default: ""
+
+    test-namespace:
+    # Kubernetes namespace where Camunda is deployed
+    #
+    # Required: false
+    # Default: camunda
+
+    test-project:
+    # Playwright test project to run. Options: smoke-tests, full-suite
+    #
+    # Required: false
+    # Default: smoke-tests
+
+    test-exclude:
+    # Tests to exclude (passed to --test-exclude flag). Example: 'identity.spec.ts' or 'console.spec.ts|identity.spec.ts'
+    #
+    # Required: false
+    # Default: ""
+
+    test-auth-type:
+    # Authentication type: keycloak, basic, hybrid. Passed as TEST_AUTH_TYPE env var.
+    #
+    # Required: false
+    # Default: keycloak
+
+    ingress-host:
+    # Override the ingress hostname detection. If set, this value is used instead of auto-detecting from cluster ingress resources. Required for Kind clusters where the domain is configured via /etc/hosts.
+    #
+    # Required: false
+    # Default: ""
+
+    ignore-tls-errors:
+    # Set to 'true' to disable TLS certificate verification (NODE_TLS_REJECT_UNAUTHORIZED=0). Required for Kind clusters using self-signed certificates.
+    #
+    # Required: false
+    # Default: false
+
+    upload-artifacts:
+    # Whether to upload Playwright test artifacts (report + results)
+    #
+    # Required: false
+    # Default: true
+
+    artifact-retention-days:
+    # Number of days to retain test artifacts
+    #
+    # Required: false
+    # Default: 10
+
+    artifact-name-suffix:
+    # Suffix appended to artifact names for uniqueness in matrix builds. Defaults to run-id and attempt.
+    #
+    # Required: false
+    # Default: ""
+```

--- a/.github/actions/internal-camunda-playwright-tests/README.md
+++ b/.github/actions/internal-camunda-playwright-tests/README.md
@@ -16,6 +16,8 @@ Run Playwright-based E2E tests from the camunda-platform-helm repository. Requir
 | `test-project` | <p>Playwright test project to run. Options: smoke-tests, full-suite</p> | `false` | `smoke-tests` |
 | `test-exclude` | <p>Tests to exclude (passed to --test-exclude flag). Example: 'identity.spec.ts' or 'console.spec.ts|identity.spec.ts'</p> | `false` | `""` |
 | `test-auth-type` | <p>Authentication type: keycloak, basic, hybrid. Passed as TEST<em>AUTH</em>TYPE env var.</p> | `false` | `keycloak` |
+| `identity-firstuser-username` | <p>Username exported as DISTRO<em>QA</em>E2E<em>TESTS</em>IDENTITY<em>FIRSTUSER</em>USERNAME for Playwright tests.</p> | `false` | `admin` |
+| `keycloak-username` | <p>Username exported as DISTRO<em>QA</em>E2E<em>TESTS</em>KEYCLOAK_USERNAME for Playwright tests.</p> | `false` | `temp-admin` |
 | `ingress-host` | <p>Override the ingress hostname detection. If set, this value is used instead of auto-detecting from cluster ingress resources. Required for Kind clusters where the domain is configured via /etc/hosts.</p> | `false` | `""` |
 | `ignore-tls-errors` | <p>Set to 'true' to disable TLS certificate verification for both Node.js requests and Playwright browser navigation. Required for Kind clusters using self-signed certificates.</p> | `false` | `false` |
 | `upload-artifacts` | <p>Whether to upload Playwright test artifacts (report + results)</p> | `false` | `true` |
@@ -73,6 +75,18 @@ This action is a `composite` action.
     #
     # Required: false
     # Default: keycloak
+
+    identity-firstuser-username:
+    # Username exported as DISTRO_QA_E2E_TESTS_IDENTITY_FIRSTUSER_USERNAME for Playwright tests.
+    #
+    # Required: false
+    # Default: admin
+
+    keycloak-username:
+    # Username exported as DISTRO_QA_E2E_TESTS_KEYCLOAK_USERNAME for Playwright tests.
+    #
+    # Required: false
+    # Default: temp-admin
 
     ingress-host:
     # Override the ingress hostname detection. If set, this value is used instead of auto-detecting from cluster ingress resources. Required for Kind clusters where the domain is configured via /etc/hosts.

--- a/.github/actions/internal-camunda-playwright-tests/README.md
+++ b/.github/actions/internal-camunda-playwright-tests/README.md
@@ -16,6 +16,9 @@ Run Playwright-based E2E tests from the camunda-platform-helm repository. Requir
 | `test-project` | <p>Playwright test project to run. Options: smoke-tests, full-suite</p> | `false` | `smoke-tests` |
 | `test-exclude` | <p>Tests to exclude (passed to --test-exclude flag). Example: 'identity.spec.ts' or 'console.spec.ts|identity.spec.ts'</p> | `false` | `""` |
 | `test-auth-type` | <p>Authentication type: keycloak, basic, hybrid. Passed as TEST<em>AUTH</em>TYPE env var.</p> | `false` | `keycloak` |
+| `test-client-secret` | <p>Client secret exported as DISTRO<em>QA</em>E2E<em>TESTS</em>KEYCLOAK<em>CLIENTS</em>SECRET for Playwright tests.</p> | `false` | `""` |
+| `orchestration-context-path` | <p>Orchestration context path used by the Camunda deployment. Exported as ORCHESTRATION<em>CONTEXT</em>PATH for Playwright tests.</p> | `false` | `""` |
+| `management-identity-context-path` | <p>Management Identity context path used by the Camunda deployment. Exported as MANAGEMENT<em>IDENTITY</em>CONTEXT_PATH for Playwright tests.</p> | `false` | `/managementidentity` |
 | `identity-firstuser-username` | <p>Username exported as DISTRO<em>QA</em>E2E<em>TESTS</em>IDENTITY<em>FIRSTUSER</em>USERNAME for Playwright tests.</p> | `false` | `admin` |
 | `keycloak-username` | <p>Username exported as DISTRO<em>QA</em>E2E<em>TESTS</em>KEYCLOAK_USERNAME for Playwright tests.</p> | `false` | `temp-admin` |
 | `ingress-host` | <p>Override the ingress hostname detection. If set, this value is used instead of auto-detecting from cluster ingress resources. Required for Kind clusters where the domain is configured via /etc/hosts.</p> | `false` | `""` |
@@ -75,6 +78,24 @@ This action is a `composite` action.
     #
     # Required: false
     # Default: keycloak
+
+    test-client-secret:
+    # Client secret exported as DISTRO_QA_E2E_TESTS_KEYCLOAK_CLIENTS_SECRET for Playwright tests.
+    #
+    # Required: false
+    # Default: ""
+
+    orchestration-context-path:
+    # Orchestration context path used by the Camunda deployment. Exported as ORCHESTRATION_CONTEXT_PATH for Playwright tests.
+    #
+    # Required: false
+    # Default: ""
+
+    management-identity-context-path:
+    # Management Identity context path used by the Camunda deployment. Exported as MANAGEMENT_IDENTITY_CONTEXT_PATH for Playwright tests.
+    #
+    # Required: false
+    # Default: /managementidentity
 
     identity-firstuser-username:
     # Username exported as DISTRO_QA_E2E_TESTS_IDENTITY_FIRSTUSER_USERNAME for Playwright tests.

--- a/.github/actions/internal-camunda-playwright-tests/README.md
+++ b/.github/actions/internal-camunda-playwright-tests/README.md
@@ -17,7 +17,7 @@ Run Playwright-based E2E tests from the camunda-platform-helm repository. Requir
 | `test-exclude` | <p>Tests to exclude (passed to --test-exclude flag). Example: 'identity.spec.ts' or 'console.spec.ts|identity.spec.ts'</p> | `false` | `""` |
 | `test-auth-type` | <p>Authentication type: keycloak, basic, hybrid. Passed as TEST<em>AUTH</em>TYPE env var.</p> | `false` | `keycloak` |
 | `ingress-host` | <p>Override the ingress hostname detection. If set, this value is used instead of auto-detecting from cluster ingress resources. Required for Kind clusters where the domain is configured via /etc/hosts.</p> | `false` | `""` |
-| `ignore-tls-errors` | <p>Set to 'true' to disable TLS certificate verification (NODE<em>TLS</em>REJECT_UNAUTHORIZED=0). Required for Kind clusters using self-signed certificates.</p> | `false` | `false` |
+| `ignore-tls-errors` | <p>Set to 'true' to disable TLS certificate verification for both Node.js requests and Playwright browser navigation. Required for Kind clusters using self-signed certificates.</p> | `false` | `false` |
 | `upload-artifacts` | <p>Whether to upload Playwright test artifacts (report + results)</p> | `false` | `true` |
 | `artifact-retention-days` | <p>Number of days to retain test artifacts</p> | `false` | `10` |
 | `artifact-name-suffix` | <p>Suffix appended to artifact names for uniqueness in matrix builds. Defaults to run-id and attempt.</p> | `false` | `""` |
@@ -81,7 +81,7 @@ This action is a `composite` action.
     # Default: ""
 
     ignore-tls-errors:
-    # Set to 'true' to disable TLS certificate verification (NODE_TLS_REJECT_UNAUTHORIZED=0). Required for Kind clusters using self-signed certificates.
+    # Set to 'true' to disable TLS certificate verification for both Node.js requests and Playwright browser navigation. Required for Kind clusters using self-signed certificates.
     #
     # Required: false
     # Default: false

--- a/.github/actions/internal-camunda-playwright-tests/README.md
+++ b/.github/actions/internal-camunda-playwright-tests/README.md
@@ -19,7 +19,7 @@ Run Playwright-based E2E tests from the camunda-platform-helm repository. Requir
 | `identity-firstuser-username` | <p>Username exported as DISTRO<em>QA</em>E2E<em>TESTS</em>IDENTITY<em>FIRSTUSER</em>USERNAME for Playwright tests.</p> | `false` | `admin` |
 | `keycloak-username` | <p>Username exported as DISTRO<em>QA</em>E2E<em>TESTS</em>KEYCLOAK_USERNAME for Playwright tests.</p> | `false` | `temp-admin` |
 | `ingress-host` | <p>Override the ingress hostname detection. If set, this value is used instead of auto-detecting from cluster ingress resources. Required for Kind clusters where the domain is configured via /etc/hosts.</p> | `false` | `""` |
-| `ignore-tls-errors` | <p>Set to 'true' to disable TLS certificate verification for both Node.js requests and Playwright browser navigation. Required for Kind clusters using self-signed certificates.</p> | `false` | `false` |
+| `ignore-tls-errors` | <p>Set to 'true' to configure Playwright browser navigation to ignore HTTPS certificate errors. Required for Kind clusters using self-signed certificates.</p> | `false` | `false` |
 | `upload-artifacts` | <p>Whether to upload Playwright test artifacts (report + results)</p> | `false` | `true` |
 | `artifact-retention-days` | <p>Number of days to retain test artifacts</p> | `false` | `10` |
 | `artifact-name-suffix` | <p>Suffix appended to artifact names for uniqueness in matrix builds. Defaults to run-id and attempt.</p> | `false` | `""` |
@@ -95,7 +95,7 @@ This action is a `composite` action.
     # Default: ""
 
     ignore-tls-errors:
-    # Set to 'true' to disable TLS certificate verification for both Node.js requests and Playwright browser navigation. Required for Kind clusters using self-signed certificates.
+    # Set to 'true' to configure Playwright browser navigation to ignore HTTPS certificate errors. Required for Kind clusters using self-signed certificates.
     #
     # Required: false
     # Default: false

--- a/.github/actions/internal-camunda-playwright-tests/action.yml
+++ b/.github/actions/internal-camunda-playwright-tests/action.yml
@@ -52,8 +52,8 @@ inputs:
         default: ''
     ignore-tls-errors:
         description: >
-            Set to 'true' to disable TLS certificate verification for both Node.js requests
-            and Playwright browser navigation. Required for Kind clusters using self-signed
+            Set to 'true' to configure Playwright browser navigation to ignore HTTPS
+            certificate errors. Required for Kind clusters using self-signed
             certificates.
         default: 'false'
     upload-artifacts:
@@ -171,7 +171,6 @@ runs:
               DISTRO_QA_E2E_TESTS_IDENTITY_FIRSTUSER_USERNAME: ${{ inputs.identity-firstuser-username }}
               DISTRO_QA_E2E_TESTS_KEYCLOAK_USERNAME: ${{ inputs.keycloak-username }}
               TEST_INGRESS_HOST: ${{ inputs.ingress-host }}
-              NODE_TLS_REJECT_UNAUTHORIZED: ${{ inputs.ignore-tls-errors == 'true' && '0' || '' }}
               PLAYWRIGHT_JUNIT_OUTPUT_NAME: ${{ steps.chart-path.outputs.test-suite-path }}/test-results/junit.xml
               CHART_DIR: ${{ steps.chart-path.outputs.chart-dir }}
               HELM_REPO_PATH: ${{ inputs.camunda-helm-repo-path }}

--- a/.github/actions/internal-camunda-playwright-tests/action.yml
+++ b/.github/actions/internal-camunda-playwright-tests/action.yml
@@ -42,8 +42,9 @@ inputs:
         default: ''
     ignore-tls-errors:
         description: >
-            Set to 'true' to disable TLS certificate verification (NODE_TLS_REJECT_UNAUTHORIZED=0).
-            Required for Kind clusters using self-signed certificates.
+            Set to 'true' to disable TLS certificate verification for both Node.js requests
+            and Playwright browser navigation. Required for Kind clusters using self-signed
+            certificates.
         default: 'false'
     upload-artifacts:
         description: Whether to upload Playwright test artifacts (report + results)
@@ -120,6 +121,37 @@ runs:
               echo "::group::Install Chromium"
               npx playwright install --with-deps chromium
               echo "::endgroup::"
+
+        - name: Patch Playwright config to ignore HTTPS errors
+          if: ${{ inputs.ignore-tls-errors == 'true' }}
+          shell: bash
+          working-directory: ${{ steps.chart-path.outputs.test-suite-path }}
+          run: |
+              set -euo pipefail
+
+              node - <<'EOF'
+              const fs = require('fs');
+              const path = 'playwright.config.ts';
+              const config = fs.readFileSync(path, 'utf8');
+
+              if (config.includes('ignoreHTTPSErrors: true')) {
+                console.log('playwright.config.ts already ignores HTTPS errors');
+                process.exit(0);
+              }
+
+              const updated = config.replace(
+                /(\n\s*use:\s*\{)/,
+                '$1\n    ignoreHTTPSErrors: true,'
+              );
+
+              if (updated === config) {
+                console.error('Failed to patch playwright.config.ts: could not find use block');
+                process.exit(1);
+              }
+
+              fs.writeFileSync(path, updated);
+              console.log('Patched playwright.config.ts to ignore HTTPS errors');
+              EOF
 
         - name: Run Playwright E2E tests
           id: run-tests

--- a/.github/actions/internal-camunda-playwright-tests/action.yml
+++ b/.github/actions/internal-camunda-playwright-tests/action.yml
@@ -34,6 +34,16 @@ inputs:
             Authentication type: keycloak, basic, hybrid.
             Passed as TEST_AUTH_TYPE env var.
         default: keycloak
+    identity-firstuser-username:
+        description: >
+            Username exported as DISTRO_QA_E2E_TESTS_IDENTITY_FIRSTUSER_USERNAME
+            for Playwright tests.
+        default: admin
+    keycloak-username:
+        description: >
+            Username exported as DISTRO_QA_E2E_TESTS_KEYCLOAK_USERNAME
+            for Playwright tests.
+        default: temp-admin
     ingress-host:
         description: >
             Override the ingress hostname detection. If set, this value is used
@@ -158,6 +168,8 @@ runs:
           shell: bash
           env:
               TEST_AUTH_TYPE: ${{ inputs.test-auth-type }}
+              DISTRO_QA_E2E_TESTS_IDENTITY_FIRSTUSER_USERNAME: ${{ inputs.identity-firstuser-username }}
+              DISTRO_QA_E2E_TESTS_KEYCLOAK_USERNAME: ${{ inputs.keycloak-username }}
               TEST_INGRESS_HOST: ${{ inputs.ingress-host }}
               NODE_TLS_REJECT_UNAUTHORIZED: ${{ inputs.ignore-tls-errors == 'true' && '0' || '' }}
               PLAYWRIGHT_JUNIT_OUTPUT_NAME: ${{ steps.chart-path.outputs.test-suite-path }}/test-results/junit.xml

--- a/.github/actions/internal-camunda-playwright-tests/action.yml
+++ b/.github/actions/internal-camunda-playwright-tests/action.yml
@@ -1,0 +1,183 @@
+---
+name: Camunda Playwright E2E Tests
+
+description: >
+    Run Playwright-based E2E tests from the camunda-platform-helm repository.
+    Requires the Helm chart to be deployed and cluster access granted.
+    Uses the helm chart's run-e2e-tests.sh script for environment setup and test execution.
+
+inputs:
+    camunda-helm-repo-ref:
+        description: Git ref for camunda-platform-helm checkout
+        default: main
+    camunda-helm-repo-path:
+        description: Path to clone the Helm chart repository
+        default: ./.camunda_helm_repo
+    camunda-version:
+        description: The Camunda version (e.g., 8.9). Used to locate the chart directory.
+        required: true
+    test-namespace:
+        description: Kubernetes namespace where Camunda is deployed
+        default: camunda
+    test-project:
+        description: >
+            Playwright test project to run.
+            Options: smoke-tests, full-suite
+        default: smoke-tests
+    test-exclude:
+        description: >
+            Tests to exclude (passed to --test-exclude flag).
+            Example: 'identity.spec.ts' or 'console.spec.ts|identity.spec.ts'
+        default: ''
+    test-auth-type:
+        description: >
+            Authentication type: keycloak, basic, hybrid.
+            Passed as TEST_AUTH_TYPE env var.
+        default: keycloak
+    ingress-host:
+        description: >
+            Override the ingress hostname detection. If set, this value is used
+            instead of auto-detecting from cluster ingress resources.
+            Required for Kind clusters where the domain is configured via /etc/hosts.
+        default: ''
+    ignore-tls-errors:
+        description: >
+            Set to 'true' to disable TLS certificate verification (NODE_TLS_REJECT_UNAUTHORIZED=0).
+            Required for Kind clusters using self-signed certificates.
+        default: 'false'
+    upload-artifacts:
+        description: Whether to upload Playwright test artifacts (report + results)
+        default: 'true'
+    artifact-retention-days:
+        description: Number of days to retain test artifacts
+        default: '10'
+    artifact-name-suffix:
+        description: >
+            Suffix appended to artifact names for uniqueness in matrix builds.
+            Defaults to run-id and attempt.
+        default: ''
+
+runs:
+    using: composite
+    steps:
+        - name: Clone camunda/camunda-platform-helm
+          uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+          with:
+              repository: camunda/camunda-platform-helm
+              ref: ${{ inputs.camunda-helm-repo-ref }}
+              path: ${{ inputs.camunda-helm-repo-path }}
+
+        - name: Resolve chart path
+          id: chart-path
+          shell: bash
+          env:
+              CAMUNDA_VERSION: ${{ inputs.camunda-version }}
+              HELM_REPO_PATH: ${{ inputs.camunda-helm-repo-path }}
+          run: |
+              set -euo pipefail
+
+              CHART_DIR="${HELM_REPO_PATH}/charts/camunda-platform-${CAMUNDA_VERSION}"
+              TEST_SUITE_PATH="${CHART_DIR}/test/e2e"
+
+              if [[ ! -d "$CHART_DIR" ]]; then
+                echo "::error::Chart directory not found: $CHART_DIR"
+                exit 1
+              fi
+
+              if [[ ! -d "$TEST_SUITE_PATH" ]]; then
+                echo "::error::Test suite path not found: $TEST_SUITE_PATH"
+                exit 1
+              fi
+
+              ABSOLUTE_CHART_DIR="$(cd "$CHART_DIR" && pwd)"
+              echo "chart-dir=$ABSOLUTE_CHART_DIR" >> "$GITHUB_OUTPUT"
+              echo "test-suite-path=$(cd "$TEST_SUITE_PATH" && pwd)" >> "$GITHUB_OUTPUT"
+
+              echo "Chart directory: $ABSOLUTE_CHART_DIR"
+              echo "Test suite: $TEST_SUITE_PATH"
+
+        - name: Setup Node.js
+          uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+          with:
+              node-version: '24'
+
+        - name: Install npm dependencies
+          shell: bash
+          working-directory: ${{ steps.chart-path.outputs.test-suite-path }}
+          run: |
+              set -euo pipefail
+
+              echo "::group::npm install"
+              npm install
+              echo "::endgroup::"
+
+        - name: Install Playwright browsers
+          shell: bash
+          working-directory: ${{ steps.chart-path.outputs.test-suite-path }}
+          run: |
+              set -euo pipefail
+
+              echo "::group::Install Chromium"
+              npx playwright install --with-deps chromium
+              echo "::endgroup::"
+
+        - name: Run Playwright E2E tests
+          id: run-tests
+          shell: bash
+          env:
+              TEST_AUTH_TYPE: ${{ inputs.test-auth-type }}
+              TEST_INGRESS_HOST: ${{ inputs.ingress-host }}
+              NODE_TLS_REJECT_UNAUTHORIZED: ${{ inputs.ignore-tls-errors == 'true' && '0' || '' }}
+              PLAYWRIGHT_JUNIT_OUTPUT_NAME: ${{ steps.chart-path.outputs.test-suite-path }}/test-results/junit.xml
+          run: |
+              set -euo pipefail
+
+              CHART_DIR="${{ steps.chart-path.outputs.chart-dir }}"
+              HELM_REPO_PATH="${{ inputs.camunda-helm-repo-path }}"
+              NAMESPACE="${{ inputs.test-namespace }}"
+
+              # Build script arguments
+              ARGS=(
+                --absolute-chart-path "$CHART_DIR"
+                --namespace "$NAMESPACE"
+                --verbose
+              )
+
+              # Add smoke tests flag if requested
+              if [[ "${{ inputs.test-project }}" == "smoke-tests" ]]; then
+                ARGS+=(--run-smoke-tests)
+              fi
+
+              # Add test exclusions
+              if [[ -n "${{ inputs.test-exclude }}" ]]; then
+                ARGS+=(--test-exclude "${{ inputs.test-exclude }}")
+              fi
+
+              echo "Running: ${HELM_REPO_PATH}/scripts/run-e2e-tests.sh ${ARGS[*]}"
+
+              if "${HELM_REPO_PATH}/scripts/run-e2e-tests.sh" "${ARGS[@]}"; then
+                echo "result=success" >> "$GITHUB_OUTPUT"
+                echo "All Playwright tests passed"
+              else
+                echo "result=failure" >> "$GITHUB_OUTPUT"
+                echo "::error::Some Playwright tests failed"
+                exit 1
+              fi
+
+        - name: Generate test summary
+          if: ${{ !cancelled() }}
+          uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69571f8f # v2
+          with:
+              paths: ${{ steps.chart-path.outputs.test-suite-path }}/test-results/**/junit.xml
+              show: fail, skip
+          continue-on-error: true
+
+        - name: Upload Playwright report
+          if: ${{ !cancelled() && inputs.upload-artifacts == 'true' }}
+          uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a # v4
+          with:
+              name: playwright-report-${{ inputs.artifact-name-suffix || format('{0}-{1}', github.run_id, github.run_attempt) }}
+              path: |
+                  ${{ steps.chart-path.outputs.test-suite-path }}/playwright-report
+                  ${{ steps.chart-path.outputs.test-suite-path }}/test-results
+              retention-days: ${{ inputs.artifact-retention-days }}

--- a/.github/actions/internal-camunda-playwright-tests/action.yml
+++ b/.github/actions/internal-camunda-playwright-tests/action.yml
@@ -129,12 +129,13 @@ runs:
               TEST_INGRESS_HOST: ${{ inputs.ingress-host }}
               NODE_TLS_REJECT_UNAUTHORIZED: ${{ inputs.ignore-tls-errors == 'true' && '0' || '' }}
               PLAYWRIGHT_JUNIT_OUTPUT_NAME: ${{ steps.chart-path.outputs.test-suite-path }}/test-results/junit.xml
+              CHART_DIR: ${{ steps.chart-path.outputs.chart-dir }}
+              HELM_REPO_PATH: ${{ inputs.camunda-helm-repo-path }}
+              NAMESPACE: ${{ inputs.test-namespace }}
+              TEST_PROJECT: ${{ inputs.test-project }}
+              TEST_EXCLUDE: ${{ inputs.test-exclude }}
           run: |
               set -euo pipefail
-
-              CHART_DIR="${{ steps.chart-path.outputs.chart-dir }}"
-              HELM_REPO_PATH="${{ inputs.camunda-helm-repo-path }}"
-              NAMESPACE="${{ inputs.test-namespace }}"
 
               # Build script arguments
               ARGS=(
@@ -144,13 +145,13 @@ runs:
               )
 
               # Add smoke tests flag if requested
-              if [[ "${{ inputs.test-project }}" == "smoke-tests" ]]; then
+              if [[ "$TEST_PROJECT" == "smoke-tests" ]]; then
                 ARGS+=(--run-smoke-tests)
               fi
 
               # Add test exclusions
-              if [[ -n "${{ inputs.test-exclude }}" ]]; then
-                ARGS+=(--test-exclude "${{ inputs.test-exclude }}")
+              if [[ -n "$TEST_EXCLUDE" ]]; then
+                ARGS+=(--test-exclude "$TEST_EXCLUDE")
               fi
 
               echo "Running: ${HELM_REPO_PATH}/scripts/run-e2e-tests.sh ${ARGS[*]}"

--- a/.github/actions/internal-camunda-playwright-tests/action.yml
+++ b/.github/actions/internal-camunda-playwright-tests/action.yml
@@ -167,7 +167,7 @@ runs:
 
         - name: Generate test summary
           if: ${{ !cancelled() }}
-          uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69571f8f # v2
+          uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86 # v2
           with:
               paths: ${{ steps.chart-path.outputs.test-suite-path }}/test-results/**/junit.xml
               show: fail, skip

--- a/.github/actions/internal-camunda-playwright-tests/action.yml
+++ b/.github/actions/internal-camunda-playwright-tests/action.yml
@@ -34,6 +34,21 @@ inputs:
             Authentication type: keycloak, basic, hybrid.
             Passed as TEST_AUTH_TYPE env var.
         default: keycloak
+    test-client-secret:
+        description: >
+            Client secret exported as DISTRO_QA_E2E_TESTS_KEYCLOAK_CLIENTS_SECRET
+            for Playwright tests.
+        default: ''
+    orchestration-context-path:
+        description: >
+            Orchestration context path used by the Camunda deployment. Exported as
+            ORCHESTRATION_CONTEXT_PATH for Playwright tests.
+        default: ''
+    management-identity-context-path:
+        description: >
+            Management Identity context path used by the Camunda deployment.
+            Exported as MANAGEMENT_IDENTITY_CONTEXT_PATH for Playwright tests.
+        default: /managementidentity
     identity-firstuser-username:
         description: >
             Username exported as DISTRO_QA_E2E_TESTS_IDENTITY_FIRSTUSER_USERNAME
@@ -125,6 +140,8 @@ runs:
         - name: Install Playwright browsers
           shell: bash
           working-directory: ${{ steps.chart-path.outputs.test-suite-path }}
+          env:
+              PLAYWRIGHT_BROWSERS_PATH: ${{ steps.chart-path.outputs.test-suite-path }}/.playwright-browsers
           run: |
               set -euo pipefail
 
@@ -167,7 +184,11 @@ runs:
           id: run-tests
           shell: bash
           env:
+              PLAYWRIGHT_BROWSERS_PATH: ${{ steps.chart-path.outputs.test-suite-path }}/.playwright-browsers
+              ORCHESTRATION_CONTEXT_PATH: ${{ inputs.orchestration-context-path }}
+              MANAGEMENT_IDENTITY_CONTEXT_PATH: ${{ inputs.management-identity-context-path }}
               TEST_AUTH_TYPE: ${{ inputs.test-auth-type }}
+              DISTRO_QA_E2E_TESTS_KEYCLOAK_CLIENTS_SECRET: ${{ inputs.test-client-secret }}
               DISTRO_QA_E2E_TESTS_IDENTITY_FIRSTUSER_USERNAME: ${{ inputs.identity-firstuser-username }}
               DISTRO_QA_E2E_TESTS_KEYCLOAK_USERNAME: ${{ inputs.keycloak-username }}
               TEST_INGRESS_HOST: ${{ inputs.ingress-host }}
@@ -184,6 +205,7 @@ runs:
               ARGS=(
                 --absolute-chart-path "$CHART_DIR"
                 --namespace "$NAMESPACE"
+                --retries 0
                 --verbose
               )
 

--- a/.github/workflows/local_kubernetes_kind_single_region_tests.yml
+++ b/.github/workflows/local_kubernetes_kind_single_region_tests.yml
@@ -16,6 +16,7 @@ on:
             - .github/actions/internal-apply-skip-label/**
             - .github/actions/internal-tests-matrix/**
             - .github/actions/internal-camunda-chart-tests/**
+            - .github/actions/internal-camunda-playwright-tests/**
             - .tool-versions
             - local/kubernetes/kind-single-region/**
     workflow_dispatch:
@@ -348,6 +349,21 @@ jobs:
                       || 'false' }}
                   # Enable local domain mode for Kind - configures /etc/hosts for domain resolution
                   local-domain-mode: ${{ matrix.declination.use_tls && 'true' || 'false' }}
+
+            - name: 🎭 Run Playwright E2E smoke tests
+              if: env.TESTS_ENABLED == 'true' && matrix.declination.use_tls == true
+              timeout-minutes: 20
+              uses: ./.github/actions/internal-camunda-playwright-tests
+              with:
+                  camunda-version: ${{ steps.camunda-version.outputs.CAMUNDA_VERSION }}
+                  camunda-helm-repo-ref: ${{ env.TESTS_CAMUNDA_HELM_CHART_REPO_REF }}
+                  camunda-helm-repo-path: ${{ env.TESTS_CAMUNDA_HELM_CHART_REPO_PATH }}
+                  test-namespace: ${{ env.CAMUNDA_NAMESPACE }}
+                  test-project: smoke-tests
+                  test-auth-type: keycloak
+                  ingress-host: ${{ env.CAMUNDA_DOMAIN }}
+                  ignore-tls-errors: 'true'
+                  artifact-name-suffix: kind-${{ matrix.declination.name }}-${{ github.run_id }}
 
             - name: 🔬🚨 Debug - Show pod details on failure
               if: failure()

--- a/.github/workflows/local_kubernetes_kind_single_region_tests.yml
+++ b/.github/workflows/local_kubernetes_kind_single_region_tests.yml
@@ -77,7 +77,7 @@ jobs:
             - clusters-info
         if: needs.triage.outputs.should_skip == 'false'
         runs-on: aws-core-8-default
-        timeout-minutes: 45
+        timeout-minutes: 50
         strategy:
             fail-fast: false
             matrix:
@@ -376,7 +376,7 @@ jobs:
 
             - name: 🎭 Run Playwright E2E smoke tests
               if: env.TESTS_ENABLED == 'true' && matrix.declination.use_tls == true
-              timeout-minutes: 20
+              timeout-minutes: 25
               uses: ./.github/actions/internal-camunda-playwright-tests
               with:
                   camunda-version: ${{ steps.camunda-version.outputs.CAMUNDA_VERSION }}
@@ -385,6 +385,7 @@ jobs:
                   test-namespace: ${{ env.CAMUNDA_NAMESPACE }}
                   test-project: smoke-tests
                   test-auth-type: keycloak
+                  test-client-secret: ${{ steps.local-credentials.outputs.LOCAL_CLIENT_SECRET }}
                   ingress-host: ${{ env.CAMUNDA_DOMAIN }}
                   ignore-tls-errors: 'true'
                   artifact-name-suffix: kind-${{ matrix.declination.name }}-${{ github.run_id }}

--- a/.github/workflows/local_kubernetes_kind_single_region_tests.yml
+++ b/.github/workflows/local_kubernetes_kind_single_region_tests.yml
@@ -285,10 +285,34 @@ jobs:
 
             - name: Set current Camunda version
               id: camunda-version
+              env:
+                  CAMUNDA_NAMESPACE: ${{ env.CAMUNDA_NAMESPACE }}
+                  CAMUNDA_RELEASE_NAME: ${{ env.CAMUNDA_RELEASE_NAME }}
               run: |
                   set -euo pipefail
 
-                  CAMUNDA_VERSION=$(cat .camunda-version)
+                  CAMUNDA_APP_VERSION=$(helm list -n "$CAMUNDA_NAMESPACE" -f "^${CAMUNDA_RELEASE_NAME}$" -o json \
+                    | jq -r '.[0].app_version // empty')
+
+                  if [[ -z "$CAMUNDA_APP_VERSION" ]]; then
+                      CAMUNDA_APP_VERSION=$(helm status "$CAMUNDA_RELEASE_NAME" -n "$CAMUNDA_NAMESPACE" \
+                        | sed -n 's/^# (Chart version: .* - Camunda compatibility version: \([^)]*\))$/\1/p' \
+                        | head -n 1)
+                  fi
+
+                  if [[ -z "$CAMUNDA_APP_VERSION" ]]; then
+                      echo "::error::Could not detect Camunda app version from Helm release ${CAMUNDA_RELEASE_NAME} in namespace ${CAMUNDA_NAMESPACE}"
+                      exit 1
+                  fi
+
+                  if [[ "$CAMUNDA_APP_VERSION" =~ ^([0-9]+\.[0-9]+)(\..+)?$ ]]; then
+                      CAMUNDA_VERSION="${BASH_REMATCH[1]}"
+                  else
+                      echo "::error::Unexpected Camunda app version format: $CAMUNDA_APP_VERSION"
+                      exit 1
+                  fi
+
+                  echo "Detected Camunda app version: $CAMUNDA_APP_VERSION"
                   echo "CAMUNDA_VERSION=$CAMUNDA_VERSION" | tee -a "$GITHUB_OUTPUT"
 
             - name: Extract auto-generated credentials from Helm deployment
@@ -356,7 +380,7 @@ jobs:
               uses: ./.github/actions/internal-camunda-playwright-tests
               with:
                   camunda-version: ${{ steps.camunda-version.outputs.CAMUNDA_VERSION }}
-                  camunda-helm-repo-ref: ${{ env.TESTS_CAMUNDA_HELM_CHART_REPO_REF }}
+                  camunda-helm-repo-ref: main
                   camunda-helm-repo-path: ${{ env.TESTS_CAMUNDA_HELM_CHART_REPO_PATH }}
                   test-namespace: ${{ env.CAMUNDA_NAMESPACE }}
                   test-project: smoke-tests


### PR DESCRIPTION

## feat/exec playwright e2e tests

- **feat: add internal-camunda-playwright-tests action**
- **fix: use env mappings instead of direct input interpolation in shell**
- **feat: add internal-camunda-playwright-tests to kind setup**

ref: https://github.com/camunda/team-infrastructure-experience/issues/752