### PR TITLE
feat(aws): enable EBS encryption by default in StorageClass

### DIFF
--- a/aws/kubernetes/eks-dual-region/procedure/manifests/storage-class.yml
+++ b/aws/kubernetes/eks-dual-region/procedure/manifests/storage-class.yml
@@ -17,3 +17,4 @@ parameters:
     type: gp3
     iops: '3000'
     throughput: '125'
+    encrypted: 'true'

--- a/aws/kubernetes/eks-single-region/procedure/manifests/storage-class.yml
+++ b/aws/kubernetes/eks-single-region/procedure/manifests/storage-class.yml
@@ -17,3 +17,4 @@ parameters:
     type: gp3
     iops: '3000'
     throughput: '125'
+    encrypted: 'true'


### PR DESCRIPTION
just a small suggestion.
It by default will encrypt the underlying volumes that are spawned through gp3-ebs.
For that it uses the default KMS key of an AWS account, can be adjusted but it's a cheap win.
