### PR TITLE
feat: add configurable ES_INDEX_PREFIXES for custom index prefixes

### DIFF
--- a/generic/kubernetes/migration/README.md
+++ b/generic/kubernetes/migration/README.md
@@ -155,6 +155,7 @@ Edit `env.sh` before starting. The file is organized into 4 sections — see com
 | `MIGRATE_WEBMODELER`         | `true`          | Migrate WebModeler PostgreSQL                |
 | `MIGRATE_ELASTICSEARCH`      | `true`          | Migrate Elasticsearch                        |
 | `ES_WARM_REINDEX`            | `false`         | When `true`, Phase 2 pre-copies ES data to the target (no downtime). Phase 3 then runs a fast delta reindex, reducing cutover from O(data-size) to ~5 min. For external targets, you must configure `reindex.remote.whitelist` on the target ES |
+| `ES_INDEX_PREFIXES`          | `zeebe-* operate-* tasklist-* optimize-* connectors-* camunda-*` | Space-separated list of index prefix patterns used to identify Camunda indices. Update if your installation uses custom index prefixes |
 
 Set any `MIGRATE_*` to `false` to skip a component (e.g. if it's not deployed or already uses an external service).
 

--- a/generic/kubernetes/migration/env.sh
+++ b/generic/kubernetes/migration/env.sh
@@ -56,6 +56,15 @@ export MIGRATE_ELASTICSEARCH="${MIGRATE_ELASTICSEARCH:-true}"
 # target ES to allow pulling data from the source Bitnami ES service.
 export ES_WARM_REINDEX="${ES_WARM_REINDEX:-false}"
 
+# ---[ Elasticsearch index prefixes ]------------------------------------------
+# Space-separated list of index prefix patterns used to identify Camunda indices.
+# The default patterns match the standard Camunda index naming. If your
+# installation uses custom index prefixes (e.g. via
+# camunda.data.exporters.elasticsearch.args.index-prefix), replace these
+# patterns with your actual prefixes followed by a wildcard.
+# Example: ES_INDEX_PREFIXES="my-prefix-zeebe-* my-prefix-operate-*"
+export ES_INDEX_PREFIXES="${ES_INDEX_PREFIXES:-zeebe-* operate-* tasklist-* optimize-* connectors-* camunda-*}"
+
 # ┌───────────────────────────────────────────────────────────────────────────┐
 # │                          TARGET MODE                                    │
 # │                                                                         │

--- a/generic/kubernetes/migration/jobs/es-backup.job.yml
+++ b/generic/kubernetes/migration/jobs/es-backup.job.yml
@@ -51,10 +51,13 @@ spec:
                         curl -sf "${AUTH[@]}" "http://${ES_HOST}:${ES_PORT}/_cluster/health?pretty"
                         echo ""
 
+                        # Build index-matching regex from ES_INDEX_PREFIXES
+                        INDEX_GREP_PATTERN="^(index|$(echo "${ES_INDEX_PREFIXES}" | tr ' ' '\n' | sed 's/\*$//' | paste -sd '|' -))"
+
                         # List Camunda indices
                         echo "Camunda indices:"
                         INDEX_INFO=$(curl -sf "${AUTH[@]}" "http://${ES_HOST}:${ES_PORT}/_cat/indices?h=index,docs.count,store.size&v" \
-                          | grep -E "^(index|zeebe|operate|tasklist|optimize|connectors)" || echo "(none found)")
+                          | grep -E "$INDEX_GREP_PATTERN" || echo "(none found)")
                         echo "$INDEX_INFO"
                         echo ""
 

--- a/generic/kubernetes/migration/jobs/es-backup.job.yml
+++ b/generic/kubernetes/migration/jobs/es-backup.job.yml
@@ -52,7 +52,8 @@ spec:
                         echo ""
 
                         # Build index-matching regex from ES_INDEX_PREFIXES
-                        INDEX_GREP_PATTERN="^(index|$(echo "${ES_INDEX_PREFIXES}" | tr ' ' '\n' | sed 's/\*$//' | paste -sd '|' -))"
+                        # Normalizes whitespace, removes trailing globs, escapes regex metacharacters
+                        INDEX_GREP_PATTERN="^(index|$(echo "${ES_INDEX_PREFIXES}" | tr -s ' ' '\n' | sed '/^$/d; s/\*$//; s/[].[\\^$*+?{}()|]/\\&/g' | paste -sd '|' -))"
 
                         # List Camunda indices
                         echo "Camunda indices:"

--- a/generic/kubernetes/migration/jobs/es-restore.job.yml
+++ b/generic/kubernetes/migration/jobs/es-restore.job.yml
@@ -49,6 +49,11 @@ spec:
                         SOURCE_AUTH=()
                         [ -n "${SOURCE_ES_PASSWORD:-}" ] && SOURCE_AUTH=(-u "elastic:$SOURCE_ES_PASSWORD")
 
+                        # Build index-matching regex from ES_INDEX_PREFIXES
+                        # Converts "zeebe-* operate-* camunda-*" → "^(zeebe-|operate-|camunda-)"
+                        INDEX_GREP_PATTERN="^($(echo "${ES_INDEX_PREFIXES}" | tr ' ' '\n' | sed 's/\*$//' | paste -sd '|' -))"
+                        echo "Index prefixes: ${ES_INDEX_PREFIXES}"
+
                         # Wait for target ES
                         MAX_RETRIES=60; RETRY=0
                         until curl -sf "${TARGET_AUTH[@]}" "$TARGET/_cluster/health" >/dev/null; do
@@ -82,7 +87,7 @@ spec:
                         INDEX_DATA=$(curl -sf "${SOURCE_AUTH[@]}" \
                           "$SOURCE/_cat/indices?h=index,docs.count&format=text" \
                           | tr -d '\r' \
-                          | grep -E "^(zeebe|operate|tasklist|optimize|connectors|camunda-)" | sort)
+                          | grep -E "$INDEX_GREP_PATTERN" | sort)
 
                         if [ -z "$INDEX_DATA" ]; then
                           echo "WARNING: No Camunda indices found on source. Nothing to reindex."
@@ -117,7 +122,7 @@ spec:
                         # the warm reindex and will only sync new/updated documents.
                         if [ "${REINDEX_MODE:-full}" = "full" ]; then
                         EXISTING=""
-                        for pattern in "zeebe-*" "operate-*" "tasklist-*" "optimize-*" "connectors-*" "camunda-*"; do
+                        for pattern in ${ES_INDEX_PREFIXES}; do
                           MATCH=$(curl -sf "${TARGET_AUTH[@]}" "$TARGET/_cat/indices/$pattern?h=index" 2>/dev/null || true)
                           if [ -n "$MATCH" ]; then
                             EXISTING=$(printf '%s\n%s' "$EXISTING" "$MATCH")
@@ -138,7 +143,7 @@ spec:
                           echo "  ⚠  THIS IS A DESTRUCTIVE OPERATION — the data in these indices will be lost."
                           echo ""
                           echo "  ES_TARGET=http://${TARGET_ES_HOST}:${TARGET_ES_PORT}"
-                          for pattern in "zeebe-*" "operate-*" "tasklist-*" "optimize-*" "connectors-*" "camunda-*"; do
+                          for pattern in ${ES_INDEX_PREFIXES}; do
                             echo "  curl -X DELETE \"\$ES_TARGET/$pattern\""
                           done
                           echo ""
@@ -259,7 +264,7 @@ spec:
                         echo "Disabling refresh and replicas on target indices..."
                         TARGET_INDICES=$(curl -sf "${TARGET_AUTH[@]}" \
                           "$TARGET/_cat/indices?h=index&format=text" \
-                          | grep -E "^(zeebe|operate|tasklist|optimize|connectors|camunda-)" || true)
+                          | grep -E "$INDEX_GREP_PATTERN" || true)
                         SAVED_REPLICAS_DIR=$(mktemp -d)
                         if [ -n "$TARGET_INDICES" ]; then
                           IDX_LIST=$(echo "$TARGET_INDICES" | paste -sd ',' -)
@@ -382,7 +387,7 @@ spec:
                         echo "Restoring target ES index settings..."
                         TARGET_INDICES=$(curl -sf "${TARGET_AUTH[@]}" \
                           "$TARGET/_cat/indices?h=index&format=text" \
-                          | grep -E "^(zeebe|operate|tasklist|optimize|connectors|camunda-)" || true)
+                          | grep -E "$INDEX_GREP_PATTERN" || true)
                         if [ -n "$TARGET_INDICES" ]; then
                           IDX_LIST=$(echo "$TARGET_INDICES" | paste -sd ',' -)
                           # Restore refresh_interval and translog durability for all indices
@@ -635,9 +640,11 @@ spec:
 
                         # Use _cat/aliases to get alias→index mappings in plain text
                         # Format: alias  index  filter  routing.search  routing.index  is_write_index
+                        # Build alias grep pattern: matches prefixes in the index column (2nd field)
+                        ALIAS_INDEX_PATTERN="[[:space:]]($(echo "${ES_INDEX_PREFIXES}" | tr ' ' '\n' | sed 's/\*$//' | paste -sd '|' -))"
                         ALIAS_DATA=$(curl -sf "${SOURCE_AUTH[@]}" \
                           "$SOURCE/_cat/aliases?h=alias,index,is_write_index&format=text" \
-                          | grep -E "[[:space:]](zeebe|operate|tasklist|optimize|connectors|camunda-)" || true)
+                          | grep -E "$ALIAS_INDEX_PATTERN" || true)
 
                         ALIAS_FAILED=0
                         if [ -n "$ALIAS_DATA" ]; then

--- a/generic/kubernetes/migration/jobs/es-restore.job.yml
+++ b/generic/kubernetes/migration/jobs/es-restore.job.yml
@@ -50,8 +50,9 @@ spec:
                         [ -n "${SOURCE_ES_PASSWORD:-}" ] && SOURCE_AUTH=(-u "elastic:$SOURCE_ES_PASSWORD")
 
                         # Build index-matching regex from ES_INDEX_PREFIXES
-                        # Converts "zeebe-* operate-* camunda-*" → "^(zeebe-|operate-|camunda-)"
-                        INDEX_GREP_PATTERN="^($(echo "${ES_INDEX_PREFIXES}" | tr ' ' '\n' | sed 's/\*$//' | paste -sd '|' -))"
+                        # Normalizes whitespace, removes trailing globs, escapes regex metacharacters
+                        # Converts "zeebe-* operate-* camunda-*" → "^(zeebe\-|operate\-|camunda\-)"
+                        INDEX_GREP_PATTERN="^($(echo "${ES_INDEX_PREFIXES}" | tr -s ' ' '\n' | sed '/^$/d; s/\*$//; s/[].[\\^$*+?{}()|]/\\&/g' | paste -sd '|' -))"
                         echo "Index prefixes: ${ES_INDEX_PREFIXES}"
 
                         # Wait for target ES
@@ -122,12 +123,15 @@ spec:
                         # the warm reindex and will only sync new/updated documents.
                         if [ "${REINDEX_MODE:-full}" = "full" ]; then
                         EXISTING=""
+                        set -f  # disable globbing to preserve literal * in patterns
                         for pattern in ${ES_INDEX_PREFIXES}; do
+                          [ -z "$pattern" ] && continue
                           MATCH=$(curl -sf "${TARGET_AUTH[@]}" "$TARGET/_cat/indices/$pattern?h=index" 2>/dev/null || true)
                           if [ -n "$MATCH" ]; then
                             EXISTING=$(printf '%s\n%s' "$EXISTING" "$MATCH")
                           fi
                         done
+                        set +f  # re-enable globbing
                         EXISTING=$(echo "$EXISTING" | sed '/^$/d' | sort)
 
                         if [ -n "$EXISTING" ]; then
@@ -143,9 +147,12 @@ spec:
                           echo "  ⚠  THIS IS A DESTRUCTIVE OPERATION — the data in these indices will be lost."
                           echo ""
                           echo "  ES_TARGET=http://${TARGET_ES_HOST}:${TARGET_ES_PORT}"
+                          set -f  # disable globbing to preserve literal * in patterns
                           for pattern in ${ES_INDEX_PREFIXES}; do
+                            [ -z "$pattern" ] && continue
                             echo "  curl -X DELETE \"\$ES_TARGET/$pattern\""
                           done
+                          set +f  # re-enable globbing
                           echo ""
                           echo "Then re-run the migration."
                           exit 1
@@ -641,7 +648,8 @@ spec:
                         # Use _cat/aliases to get alias→index mappings in plain text
                         # Format: alias  index  filter  routing.search  routing.index  is_write_index
                         # Build alias grep pattern: matches prefixes in the index column (2nd field)
-                        ALIAS_INDEX_PATTERN="[[:space:]]($(echo "${ES_INDEX_PREFIXES}" | tr ' ' '\n' | sed 's/\*$//' | paste -sd '|' -))"
+                        # Uses same normalization/escaping as INDEX_GREP_PATTERN
+                        ALIAS_INDEX_PATTERN="[[:space:]]($(echo "${ES_INDEX_PREFIXES}" | tr -s ' ' '\n' | sed '/^$/d; s/\*$//; s/[].[\\^$*+?{}()|]/\\&/g' | paste -sd '|' -))"
                         ALIAS_DATA=$(curl -sf "${SOURCE_AUTH[@]}" \
                           "$SOURCE/_cat/aliases?h=alias,index,is_write_index&format=text" \
                           | grep -E "$ALIAS_INDEX_PATTERN" || true)

--- a/generic/kubernetes/migration/lib.sh
+++ b/generic/kubernetes/migration/lib.sh
@@ -1690,7 +1690,7 @@ backup_es() {
     ensure_backup_pvc
     export JOB_NAME="es-backup-${TIMESTAMP}"
     # shellcheck disable=SC2016
-    local es_varlist='${JOB_NAME} ${NAMESPACE} ${ES_IMAGE} ${ES_HOST} ${ES_PORT} ${ES_SECRET_NAME}'
+    local es_varlist='${JOB_NAME} ${NAMESPACE} ${ES_IMAGE} ${ES_HOST} ${ES_PORT} ${ES_SECRET_NAME} ${ES_INDEX_PREFIXES}'
     run_job "${JOBS_DIR}/es-backup.job.yml" "${JOB_NAME}" 1800 "$es_varlist"
 }
 
@@ -1705,7 +1705,7 @@ restore_es() {
     export REINDEX_MODE="${REINDEX_MODE:-full}"
     export JOB_NAME="es-restore-${TIMESTAMP}"
     # shellcheck disable=SC2016
-    local es_varlist='${ES_IMAGE} ${JOB_NAME} ${NAMESPACE} ${REINDEX_MODE} ${SOURCE_ES_HOST} ${SOURCE_ES_PORT} ${SOURCE_ES_SECRET_NAME} ${TARGET_ES_HOST} ${TARGET_ES_PORT} ${TARGET_ES_SECRET_NAME}'
+    local es_varlist='${ES_IMAGE} ${JOB_NAME} ${NAMESPACE} ${REINDEX_MODE} ${SOURCE_ES_HOST} ${SOURCE_ES_PORT} ${SOURCE_ES_SECRET_NAME} ${TARGET_ES_HOST} ${TARGET_ES_PORT} ${TARGET_ES_SECRET_NAME} ${ES_INDEX_PREFIXES}'
     run_job "${JOBS_DIR}/es-restore.job.yml" "${JOB_NAME}" "${ES_RESTORE_TIMEOUT:-1800}" "$es_varlist"
     _parse_es_reindex_metrics "${STATE_DIR}/${JOB_NAME}.log" "CUTOVER"
 }
@@ -1721,7 +1721,7 @@ warm_reindex_es() {
     export REINDEX_MODE="delta"
     export JOB_NAME="es-warm-reindex-${TIMESTAMP}"
     # shellcheck disable=SC2016
-    local es_varlist='${ES_IMAGE} ${JOB_NAME} ${NAMESPACE} ${REINDEX_MODE} ${SOURCE_ES_HOST} ${SOURCE_ES_PORT} ${SOURCE_ES_SECRET_NAME} ${TARGET_ES_HOST} ${TARGET_ES_PORT} ${TARGET_ES_SECRET_NAME}'
+    local es_varlist='${ES_IMAGE} ${JOB_NAME} ${NAMESPACE} ${REINDEX_MODE} ${SOURCE_ES_HOST} ${SOURCE_ES_PORT} ${SOURCE_ES_SECRET_NAME} ${TARGET_ES_HOST} ${TARGET_ES_PORT} ${TARGET_ES_SECRET_NAME} ${ES_INDEX_PREFIXES}'
     run_job "${JOBS_DIR}/es-restore.job.yml" "${JOB_NAME}" "${ES_RESTORE_TIMEOUT:-5400}" "$es_varlist"
     _parse_es_reindex_metrics "${STATE_DIR}/${JOB_NAME}.log" "WARM"
 }


### PR DESCRIPTION
Related to https://github.com/camunda/team-infrastructure-experience/issues/1095

The migration scripts previously hardcoded the default Camunda ES index prefixes (zeebe-*, operate-*, tasklist-*, etc.). Installations using custom index prefixes would have their indices silently skipped.

Add ES_INDEX_PREFIXES variable to env.sh with the default patterns. Replace all hardcoded patterns in es-restore.job.yml, es-backup.job.yml, and update the envsubst variable lists in lib.sh.

Users with custom prefixes can now set ES_INDEX_PREFIXES in env.sh before running the migration.