### PR TITLE
fix(actions): set HELM_CHART_NAME for stable versions to public repo

### DIFF
--- a/.github/actions/internal-multi-region-tests/action.yml
+++ b/.github/actions/internal-multi-region-tests/action.yml
@@ -109,6 +109,10 @@ runs:
                 {
                   echo "HELM_CHART_NAME=oci://registry.camunda.cloud/team-distribution/camunda-platform"
                 } >> "$GITHUB_ENV"
+              else
+                {
+                  echo "HELM_CHART_NAME=camunda/camunda-platform"
+                } >> "$GITHUB_ENV"
               fi
 
               # create empty file if not exists


### PR DESCRIPTION
The Go test code defaults to the private OCI registry (registry.camunda.cloud/team-distribution) when HELM_CHART_NAME is not set. For stable chart versions (non dev-latest), this causes a 404 since stable releases are only on the public helm.camunda.io repo.

Now we always export HELM_CHART_NAME: OCI for dev-latest, public repo (camunda/camunda-platform) for everything else.