### PR TITLE
fix: aws risa

### DIFF
--- a/.github/workflows/aws_kubernetes_eks_single_region_tests.yml
+++ b/.github/workflows/aws_kubernetes_eks_single_region_tests.yml
@@ -77,9 +77,7 @@ env:
     TLD: camunda.ie
     MAIL_OVERWRITE: admin@camunda.ie
 
-    # CLEANUP_CLUSTERS: ${{ github.event.inputs.delete_clusters || 'true' }}
-    # TODO: revert before merge
-    CLEANUP_CLUSTERS: false
+    CLEANUP_CLUSTERS: ${{ github.event.inputs.delete_clusters || 'true' }}
 
     # TEST VARIABLES
 
@@ -91,6 +89,7 @@ env:
     TESTS_ENABLED: ${{ github.event.inputs.enable_tests || 'true' }}
     # TODO: [release-duty] before the release, update repo ref!
     # renovate: datasource=github-tags depName=camunda/camunda-platform-helm
+    # TODO: resolve this branch when merging to playwright
     TESTS_CAMUNDA_HELM_CHART_REPO_REF: fix-venom-8-8   # git reference used to clone the camunda/camunda-platform-helm repository to perform the tests
     TESTS_CAMUNDA_HELM_CHART_REPO_PATH: ./.camunda_helm_repo   # where to clone it
 
@@ -130,9 +129,7 @@ jobs:
               id: matrix
               with:
                   ci_matrix_file: ${{ env.CI_MATRIX_FILE }}
-                  # cluster_name: ${{ inputs.cluster_name }}
-                  # TODO: revert before merge
-                  cluster_name: dgirsa
+                  cluster_name: ${{ inputs.cluster_name }}
                   ref_arch: ${{ inputs.ref-arch }}
                   cluster_prefix: eks-${{ github.event.pull_request.number || '' }}
                   is_schedule: ${{ env.IS_SCHEDULE }}
@@ -928,8 +925,6 @@ jobs:
                   test-client-secret: ${{ steps.secrets.outputs.CI_CAMUNDA_USER_TEST_CLIENT_SECRET }}
                   keycloak-service-name: ${{ matrix.scenario.auth_provider == 'keycloak-operator' && 'keycloak-service:18080' || '' }}
                   enable-c8sm-irsa-check: ${{ contains(matrix.scenario.name, 'irsa') }}
-                  # TODO: revert to main once c8-sm-checks PR is merged (https://github.com/camunda/c8-sm-checks/pull/292)
-                  tests-c8-sm-checks-repo-ref: fix/aws-irsa-exclude-pattern-and-opensearch-url
 
             - name: 🔬🚨 Get failed certificate info
               if: failure() && matrix.declination.name == 'domain'

--- a/.github/workflows/aws_kubernetes_eks_single_region_tests.yml
+++ b/.github/workflows/aws_kubernetes_eks_single_region_tests.yml
@@ -879,6 +879,7 @@ jobs:
                   namespace: ${{ env.CAMUNDA_NAMESPACE }}
                   # global.opensearch.enabled is deprecated but still required for the legacy Operate
                   # OpensearchConnector which gates awsEnabled on this flag (see values-domain.yml)
+                  # TODO: remove exclude-patterns and global.opensearch from values once the legacy Operate connector is removed from the Helm chart
                   exclude-patterns: |
                       global.opensearch.enabled
 
@@ -923,6 +924,8 @@ jobs:
                   test-client-secret: ${{ steps.secrets.outputs.CI_CAMUNDA_USER_TEST_CLIENT_SECRET }}
                   keycloak-service-name: ${{ matrix.scenario.auth_provider == 'keycloak-operator' && 'keycloak-service:18080' || '' }}
                   enable-c8sm-irsa-check: ${{ contains(matrix.scenario.name, 'irsa') }}
+                  # TODO: revert to main once c8-sm-checks PR is merged (https://github.com/camunda/c8-sm-checks/pull/292)
+                  tests-c8-sm-checks-repo-ref: fix/aws-irsa-exclude-pattern-and-opensearch-url
 
             - name: 🔬🚨 Get failed certificate info
               if: failure() && matrix.declination.name == 'domain'

--- a/.github/workflows/aws_kubernetes_eks_single_region_tests.yml
+++ b/.github/workflows/aws_kubernetes_eks_single_region_tests.yml
@@ -27,6 +27,7 @@ on:
             - .github/actions/internal-tests-matrix/**
             - .github/actions/internal-terraform-drift-detect/**
             - .github/actions/internal-clean-namespace/**
+            - .github/actions/internal-helm-deprecation-check/**
             - .github/actions/kubernetes-restart-coredns/**
             - .github/actions/aws-kubernetes-ingress-setup/**
             - .github/actions/kubernetes-wildcard-certificate/**

--- a/.github/workflows/aws_kubernetes_eks_single_region_tests.yml
+++ b/.github/workflows/aws_kubernetes_eks_single_region_tests.yml
@@ -89,7 +89,7 @@ env:
     TESTS_ENABLED: ${{ github.event.inputs.enable_tests || 'true' }}
     # TODO: [release-duty] before the release, update repo ref!
     # renovate: datasource=github-tags depName=camunda/camunda-platform-helm
-    TESTS_CAMUNDA_HELM_CHART_REPO_REF: main   # git reference used to clone the camunda/camunda-platform-helm repository to perform the tests
+    TESTS_CAMUNDA_HELM_CHART_REPO_REF: fix-venom-8-8   # git reference used to clone the camunda/camunda-platform-helm repository to perform the tests
     TESTS_CAMUNDA_HELM_CHART_REPO_PATH: ./.camunda_helm_repo   # where to clone it
 
     # Optional components that are not enabled by default in the doc

--- a/.github/workflows/aws_kubernetes_eks_single_region_tests.yml
+++ b/.github/workflows/aws_kubernetes_eks_single_region_tests.yml
@@ -77,7 +77,9 @@ env:
     TLD: camunda.ie
     MAIL_OVERWRITE: admin@camunda.ie
 
-    CLEANUP_CLUSTERS: ${{ github.event.inputs.delete_clusters || 'true' }}
+    # CLEANUP_CLUSTERS: ${{ github.event.inputs.delete_clusters || 'true' }}
+    # TODO: revert before merge
+    CLEANUP_CLUSTERS: false
 
     # TEST VARIABLES
 
@@ -128,7 +130,9 @@ jobs:
               id: matrix
               with:
                   ci_matrix_file: ${{ env.CI_MATRIX_FILE }}
-                  cluster_name: ${{ inputs.cluster_name }}
+                  # cluster_name: ${{ inputs.cluster_name }}
+                  # TODO: revert before merge
+                  cluster_name: dgirsa
                   ref_arch: ${{ inputs.ref-arch }}
                   cluster_prefix: eks-${{ github.event.pull_request.number || '' }}
                   is_schedule: ${{ env.IS_SCHEDULE }}

--- a/.github/workflows/aws_kubernetes_eks_single_region_tests.yml
+++ b/.github/workflows/aws_kubernetes_eks_single_region_tests.yml
@@ -89,8 +89,7 @@ env:
     TESTS_ENABLED: ${{ github.event.inputs.enable_tests || 'true' }}
     # TODO: [release-duty] before the release, update repo ref!
     # renovate: datasource=github-tags depName=camunda/camunda-platform-helm
-    # TODO: resolve this branch when merging to playwright
-    TESTS_CAMUNDA_HELM_CHART_REPO_REF: fix-venom-8-8   # git reference used to clone the camunda/camunda-platform-helm repository to perform the tests
+    TESTS_CAMUNDA_HELM_CHART_REPO_REF: main   # git reference used to clone the camunda/camunda-platform-helm repository to perform the tests
     TESTS_CAMUNDA_HELM_CHART_REPO_PATH: ./.camunda_helm_repo   # where to clone it
 
     # Optional components that are not enabled by default in the doc

--- a/.github/workflows/aws_kubernetes_eks_single_region_tests.yml
+++ b/.github/workflows/aws_kubernetes_eks_single_region_tests.yml
@@ -877,6 +877,10 @@ jobs:
               with:
                   release-name: ${{ env.CAMUNDA_RELEASE_NAME }}
                   namespace: ${{ env.CAMUNDA_NAMESPACE }}
+                  # global.opensearch.enabled is deprecated but still required for the legacy Operate
+                  # OpensearchConnector which gates awsEnabled on this flag (see values-domain.yml)
+                  exclude-patterns: |
+                      global.opensearch.enabled
 
             - name: 👀⏳ Wait for the deployment to be healthy using generic/kubernetes/single-region
               timeout-minutes: 20

--- a/.github/workflows/aws_kubernetes_eks_single_region_tests.yml
+++ b/.github/workflows/aws_kubernetes_eks_single_region_tests.yml
@@ -802,13 +802,21 @@ jobs:
 
                   kubectl apply -f ./aws/kubernetes/${{ matrix.scenario.name }}/setup-opensearch-fgac.yml --namespace "$CAMUNDA_NAMESPACE"
 
-                  # Wait for the job to complete
+                  # Wait for the job to complete or fail
                   while true; do
-                      STATUS=$(kubectl get job setup-opensearch-fgac --namespace "$CAMUNDA_NAMESPACE" -o jsonpath='{.status.succeeded}')
+                      SUCCEEDED=$(kubectl get job setup-opensearch-fgac --namespace "$CAMUNDA_NAMESPACE" -o jsonpath='{.status.succeeded}')
+                      FAILED=$(kubectl get job setup-opensearch-fgac --namespace "$CAMUNDA_NAMESPACE" -o jsonpath='{.status.failed}')
 
-                      if [[ "$STATUS" == "1" ]]; then
+                      if [[ "$SUCCEEDED" == "1" ]]; then
                           echo "Job completed successfully."
                           break
+                      fi
+
+                      if [[ "$FAILED" -ge "1" ]]; then
+                          echo "❌ FGAC job failed!"
+                          echo "[DEBUG] Job log:"
+                          kubectl logs job/setup-opensearch-fgac --namespace "$CAMUNDA_NAMESPACE" || true
+                          exit 1
                       fi
 
                       echo "Waiting for job to complete..."

--- a/aws/kubernetes/eks-single-region-irsa/helm-values/values-domain.yml
+++ b/aws/kubernetes/eks-single-region-irsa/helm-values/values-domain.yml
@@ -14,6 +14,11 @@
 #   - Various IRSA role ARNs and service account names (from Terraform outputs)
 
 global:
+    opensearch:
+        enabled: true
+        aws:
+            enabled: true
+
     security:
         authentication:
             method: oidc

--- a/aws/kubernetes/eks-single-region-irsa/helm-values/values-domain.yml
+++ b/aws/kubernetes/eks-single-region-irsa/helm-values/values-domain.yml
@@ -14,6 +14,10 @@
 #   - Various IRSA role ARNs and service account names (from Terraform outputs)
 
 global:
+    # DEPRECATION: global.opensearch.enabled is deprecated in favor of orchestration.data.secondaryStorage.opensearch.enabled
+    # and optimize.database.opensearch.enabled (both already set below).
+    # However, it is still required for the legacy Operate OpensearchConnector (io.camunda.operate.connect.OpensearchConnector)
+    # which gates its awsEnabled config on this flag. Without it, Operate falls back to basic auth and gets 401 from AWS OpenSearch.
     opensearch:
         enabled: true
         aws:

--- a/aws/kubernetes/eks-single-region-irsa/helm-values/values-domain.yml
+++ b/aws/kubernetes/eks-single-region-irsa/helm-values/values-domain.yml
@@ -22,6 +22,9 @@ global:
         enabled: true
         aws:
             enabled: true
+        url:
+            host: ${OPENSEARCH_HOST}
+            port: 443
 
     security:
         authentication:

--- a/aws/kubernetes/eks-single-region-irsa/helm-values/values-no-domain.yml
+++ b/aws/kubernetes/eks-single-region-irsa/helm-values/values-no-domain.yml
@@ -21,6 +21,9 @@ global:
         enabled: true
         aws:
             enabled: true
+        url:
+            host: ${OPENSEARCH_HOST}
+            port: 443
 
     security:
         authentication:

--- a/aws/kubernetes/eks-single-region-irsa/helm-values/values-no-domain.yml
+++ b/aws/kubernetes/eks-single-region-irsa/helm-values/values-no-domain.yml
@@ -13,6 +13,11 @@
 #   - Various IRSA role ARNs and service account names (from Terraform outputs)
 
 global:
+    opensearch:
+        enabled: true
+        aws:
+            enabled: true
+
     security:
         authentication:
             method: oidc

--- a/aws/kubernetes/eks-single-region-irsa/helm-values/values-no-domain.yml
+++ b/aws/kubernetes/eks-single-region-irsa/helm-values/values-no-domain.yml
@@ -13,6 +13,10 @@
 #   - Various IRSA role ARNs and service account names (from Terraform outputs)
 
 global:
+    # DEPRECATION: global.opensearch.enabled is deprecated in favor of orchestration.data.secondaryStorage.opensearch.enabled
+    # and optimize.database.opensearch.enabled (both already set below).
+    # However, it is still required for the legacy Operate OpensearchConnector (io.camunda.operate.connect.OpensearchConnector)
+    # which gates its awsEnabled config on this flag. Without it, Operate falls back to basic auth and gets 401 from AWS OpenSearch.
     opensearch:
         enabled: true
         aws:

--- a/aws/kubernetes/eks-single-region-irsa/procedure/vars-create-os.sh
+++ b/aws/kubernetes/eks-single-region-irsa/procedure/vars-create-os.sh
@@ -2,4 +2,5 @@
 
 # OpenSearch Credentials (replace with your own values from the #opensearch-module-setup step)
 export OPENSEARCH_MASTER_USERNAME="$(terraform console <<<local.opensearch_master_username | tail -n 1 | jq -r)"
-export OPENSEARCH_MASTER_PASSWORD="$(terraform console <<<local.opensearch_master_password | tail -n 1 | jq -r)"
+# terraform output -raw handles sensitive values correctly (terraform console prints "(sensitive value)" for them)
+export OPENSEARCH_MASTER_PASSWORD="$(terraform output -raw opensearch_master_password)"

--- a/aws/kubernetes/eks-single-region-irsa/setup-opensearch-fgac.yml
+++ b/aws/kubernetes/eks-single-region-irsa/setup-opensearch-fgac.yml
@@ -19,15 +19,16 @@ spec:
                       - -c
                       - |
                         /bin/bash <<'EOF'
-                        set -o pipefail
+                        set -euo pipefail
 
                         echo "Configuring Fine-Grained Access Control for OpenSearch..."
 
-                        # If the following script moves outside of lines 28 - 42, adjust the documentation referencing this file.
+                        # If the following script moves outside of lines 28 - 48, adjust the documentation referencing this file.
                         # Beginning of Script
 
                         # Send the PATCH request to map the IAM role to OpenSearch role
-                        curl -sS -u "$OPENSEARCH_MASTER_USERNAME:$OPENSEARCH_MASTER_PASSWORD" \
+                        HTTP_CODE=$(curl -sS -o /tmp/response.json -w "%{http_code}" \
+                          -u "$OPENSEARCH_MASTER_USERNAME:$OPENSEARCH_MASTER_PASSWORD" \
                           -X PATCH \
                           "https://$OPENSEARCH_HOST/_opendistro/_security/api/rolesmapping/all_access?pretty" \
                           -H 'Content-Type: application/json' \
@@ -38,7 +39,17 @@ spec:
                               "path": "/backend_roles",
                               "value": ["'$OPENSEARCH_ROLE_ARN'"]
                             }
-                          ]'
+                          ]')
+
+                        echo "Response (HTTP $HTTP_CODE):"
+                        cat /tmp/response.json
+
+                        if [[ "$HTTP_CODE" -lt 200 || "$HTTP_CODE" -ge 300 ]]; then
+                          echo "ERROR: FGAC role mapping failed with HTTP $HTTP_CODE"
+                          exit 1
+                        fi
+
+                        echo "FGAC role mapping configured successfully."
 
                         # End of Script
                         EOF


### PR DESCRIPTION

### TODO

- [ ] update doc snippet

This pull request makes improvements to the OpenSearch Fine-Grained Access Control (FGAC) setup script and updates the workflow trigger paths for internal GitHub Actions. The key changes include enhancing error handling and output visibility in the OpenSearch configuration script and ensuring the workflow runs when changes are made to a new internal action.

**OpenSearch FGAC Setup Enhancements:**

* The OpenSearch FGAC role mapping script now uses `set -euo pipefail` for stricter error handling and captures the HTTP response code and body from the `curl` command, providing clearer output and failing explicitly on errors. [[1]](diffhunk://#diff-843a4427eaa9cf58035a6f76cfda168fa6fd74c46ee6a81017341abb2690d35bL22-R31) [[2]](diffhunk://#diff-843a4427eaa9cf58035a6f76cfda168fa6fd74c46ee6a81017341abb2690d35bL41-R52)

**Workflow Trigger Updates:**

* The `.github/workflows/aws_kubernetes_eks_single_region_tests.yml` workflow will now also be triggered by changes to the `.github/actions/internal-helm-deprecation-check/**` path.