### PR TITLE
fix: update openshift versions minimal from 4.17 to 4.18

### DIFF
--- a/.github/workflows-config/aws-openshift-rosa-hcp-single-region/test_matrix.yml
+++ b/.github/workflows-config/aws-openshift-rosa-hcp-single-region/test_matrix.yml
@@ -17,12 +17,11 @@ matrix:
           # Therefore, to ensure compatibility and support, we test the latest and the older.
           # For more details, refer to the official support policy at https://endoflife.date/red-hat-openshift.
 
-        - name: OpenShift 4.17
+        - name: OpenShift 4.18
           schedule_only: true
           private_vpc: false
-          # TODO: EOL this version on 2026-04-01
-          # renovate: datasource=custom.rosa-camunda depName=red-hat-openshift versioning=regex:^4.17(\.(?<patch>\d+))?$
-          version: 4.17.44
+          # renovate: datasource=custom.rosa-camunda depName=red-hat-openshift versioning=regex:^4.18(\.(?<patch>\d+))?$
+          version: 4.18.28
 
     scenario:
         - name: rosa-hcp-single-region

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,8 +31,6 @@ repos:
       hooks:
           - id: renovate-config-validator
             args: [--strict]
-            # TODO : revert this when https://github.com/renovatebot/pre-commit-hooks/issues/2460 is fixed
-            language_version: lts
 
     - repo: https://github.com/compilerla/conventional-pre-commit
       rev: v4.4.0 # use tags until renovate supports sha: https://github.com/renovatebot/renovate/issues/22567


### PR DESCRIPTION
This pull request updates the OpenShift version in the test matrix to ensure compatibility with the latest supported release and cleans up the pre-commit configuration by removing a temporary workaround.

**Test matrix update:**
* Updated the OpenShift version tested in the `.github/workflows-config/aws-openshift-rosa-hcp-single-region/test_matrix.yml` file from `4.17.44` to `4.18.28` to reflect the latest supported release and adjusted related comments accordingly.

**Pre-commit configuration cleanup:**
* Removed the `language_version: lts` workaround for the `renovate-config-validator` hook in `.pre-commit-config.yaml`, as it is no longer needed.