### PR TITLE
fix: correct renovate regex syntax in camunda-install.sh

### DIFF
--- a/aws/kubernetes/eks-dual-region/test/multi_region_aws_camunda_test.go
+++ b/aws/kubernetes/eks-dual-region/test/multi_region_aws_camunda_test.go
@@ -32,14 +32,14 @@ const (
 var (
 	// renovate: datasource=helm depName=camunda-platform registryUrl=https://helm.camunda.io versioning=regex:^14(\.(?<minor>\d+))?(\.(?<patch>\d+))?$
 	remoteChartVersion = helpers.GetEnv("HELM_CHART_VERSION", "14.0.0")
-	remoteChartName = helpers.GetEnv("HELM_CHART_NAME", "camunda/camunda-platform")
-	globalImageTag  = helpers.GetEnv("GLOBAL_IMAGE_TAG", "")                                                                // allows overwriting the image tag via GHA of every Camunda image
-	clusterName     = helpers.GetEnv("CLUSTER_NAME", "nightly")                                                             // allows supplying random cluster name via GHA
-	cluster0Name    = helpers.GetEnv("CLUSTER_0_NAME", fmt.Sprintf("%s-london", helpers.GetEnv("CLUSTER_NAME", "nightly"))) // kubectl context name for cluster 0
-	cluster1Name    = helpers.GetEnv("CLUSTER_1_NAME", fmt.Sprintf("%s-paris", helpers.GetEnv("CLUSTER_NAME", "nightly")))  // kubectl context name for cluster 1
-	backupName      = helpers.GetEnv("BACKUP_NAME", "nightly")                                                              // allows supplying random backup name via GHA
-	backupBucket    = helpers.GetEnv("BACKUP_BUCKET", fmt.Sprintf("%s-elastic-backup", clusterName))                        // allows supplying backup bucket name via GHA
-	awsProfile      = helpers.GetEnv("AWS_PROFILE", "infraex")
+	remoteChartName    = helpers.GetEnv("HELM_CHART_NAME", "camunda/camunda-platform")
+	globalImageTag     = helpers.GetEnv("GLOBAL_IMAGE_TAG", "")                                                                // allows overwriting the image tag via GHA of every Camunda image
+	clusterName        = helpers.GetEnv("CLUSTER_NAME", "nightly")                                                             // allows supplying random cluster name via GHA
+	cluster0Name       = helpers.GetEnv("CLUSTER_0_NAME", fmt.Sprintf("%s-london", helpers.GetEnv("CLUSTER_NAME", "nightly"))) // kubectl context name for cluster 0
+	cluster1Name       = helpers.GetEnv("CLUSTER_1_NAME", fmt.Sprintf("%s-paris", helpers.GetEnv("CLUSTER_NAME", "nightly")))  // kubectl context name for cluster 1
+	backupName         = helpers.GetEnv("BACKUP_NAME", "nightly")                                                              // allows supplying random backup name via GHA
+	backupBucket       = helpers.GetEnv("BACKUP_BUCKET", fmt.Sprintf("%s-elastic-backup", clusterName))                        // allows supplying backup bucket name via GHA
+	awsProfile         = helpers.GetEnv("AWS_PROFILE", "infraex")
 
 	primary   helpers.Cluster
 	secondary helpers.Cluster

--- a/generic/compute/debian/procedure/camunda-install.sh
+++ b/generic/compute/debian/procedure/camunda-install.sh
@@ -10,9 +10,9 @@ set -euo pipefail
 
 # Executed on remote host, defaults should be set here or env vars preconfigured on remote host
 OPENJDK_VERSION=${OPENJDK_VERSION:-"21"}
-# renovate: datasource=github-releases depName=camunda/camunda versioning=regex:^8\.9?(\.(<?patch>\d+))?$
+# renovate: datasource=github-releases depName=camunda/camunda versioning=regex:^8\.9?(\.(?<patch>\d+))?$
 CAMUNDA_VERSION=${CAMUNDA_VERSION:-"8.9.0"}
-# renovate: datasource=github-releases depName=camunda/connectors versioning=regex:^8\.9?(\.(<?patch>\d+))?$
+# renovate: datasource=github-releases depName=camunda/connectors versioning=regex:^8\.9?(\.(?<patch>\d+))?$
 CAMUNDA_CONNECTORS_VERSION=${CAMUNDA_CONNECTORS_VERSION:-"8.9.0"}
 
 MNT_DIR=${MNT_DIR:-"/opt/camunda"}


### PR DESCRIPTION
This pull request makes a minor fix to the versioning regex in the `camunda-install.sh` script to correct the named capture group for the patch version. This ensures compatibility with dependency update tools.

- Maintenance and tooling:
  * Corrected the named capture group from `<?patch>` to `?<patch>` in the `renovate` regex comments for both `camunda/camunda` and `camunda/connectors` dependencies in `camunda-install.sh`.