### PR TITLE
fix: correct renovate chart regex from ^15 to ^14 on stable/8.9

### DIFF
--- a/generic/kubernetes/single-region/procedure/chart-env.sh
+++ b/generic/kubernetes/single-region/procedure/chart-env.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # The Camunda 8 Helm Chart version
-# renovate: datasource=helm depName=camunda-platform versioning=regex:^15(\.(?<minor>\d+))?(\.(?<patch>\d+))?$ registryUrl=https://helm.camunda.io
+# renovate: datasource=helm depName=camunda-platform versioning=regex:^14(\.(?<minor>\d+))?(\.(?<patch>\d+))?$ registryUrl=https://helm.camunda.io
 export CAMUNDA_HELM_CHART_VERSION="14.0.0"
 
 export CAMUNDA_NAMESPACE="camunda"


### PR DESCRIPTION
This pull request updates the Helm chart version for Camunda 8 in the Kubernetes deployment script. The most important change is a rollback of the chart version from 15.x to 14.0.0, which affects both the version comment for Renovate and the exported environment variable.

Helm chart version rollback:

* [`generic/kubernetes/single-region/procedure/chart-env.sh`](diffhunk://#diff-4bc3b395b4254b7da9dfbfa57e0a5eaf76302aa59dd052e24667120ec47fa548L4-R4): Changed the Helm chart version pattern in the Renovate comment and set `CAMUNDA_HELM_CHART_VERSION` to `"14.0.0"` instead of a 15.x version.