### PR TITLE
fix: align OpenShift workflows gh-pages checkout with AWS pattern

### DIFF
--- a/.github/workflows/internal_openshift_artifact_acm_versions.yml
+++ b/.github/workflows/internal_openshift_artifact_acm_versions.yml
@@ -17,53 +17,41 @@ jobs:
 
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-              with:
-                  ref: gh-pages
+
+            - name: Switch to gh-pages branch
+              run: |
+                  cp .github/scripts/get_acm_versions.py /tmp/get_acm_versions.py
+                  git fetch origin gh-pages
+                  git checkout gh-pages
 
             - name: Retrieve OpenShift ACM versions
               shell: bash
               run: |
                   set -euo pipefail
 
-                  # Fetch the latest from the main branch
-                  git fetch origin main
-
-                  # Checkout the script from main branch
-                  git checkout origin/main -- .github/scripts/get_acm_versions.py
-
                   python3 -m venv acm-venv
                   source acm-venv/bin/activate
 
                   pip install requests bs4
 
-                  python .github/scripts/get_acm_versions.py
+                  python /tmp/get_acm_versions.py
 
                   echo "Printing: ./docs/openshift_acm_versions.txt"
                   cat "./docs/openshift_acm_versions.txt"
 
-                  echo "Cleanup of the copied script"
-                  rm .github/scripts/get_acm_versions.py
-                  git restore --staged .github/scripts/get_acm_versions.py || true
-
-            - name: Stash changes and checkout gh-pages branch and push OpenShift ACM versions file to gh-pages
+            - name: Commit and push OpenShift ACM versions file to gh-pages
               shell: bash
               run: |
                   set -euo pipefail
 
-                  # stash the changes
-                  git add docs/openshift_acm_versions.txt
-
-                  # Check if there are any staged changes (changes added to the index)
-                  if git diff --cached --exit-code docs/openshift_acm_versions.txt; then
-                    echo "No changes detected. No commit necessary."
-                  else
+                  git diff --exit-code docs/openshift_acm_versions.txt || {
+                    echo "Changes detected, committing and pushing to gh-pages"
                     git config --local user.name "github-actions[bot]"
                     git config --local user.email "github-actions[bot]@users.noreply.github.com"
-
+                    git add docs/openshift_acm_versions.txt
                     git commit -m "Update OpenShift ACM versions"
-
                     git push origin gh-pages
-                  fi
+                  }
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/internal_openshift_artifact_rosa_versions.yml
+++ b/.github/workflows/internal_openshift_artifact_rosa_versions.yml
@@ -32,8 +32,10 @@ jobs:
 
             - name: Switch to gh-pages branch
               run: |
+                  cp .tool-versions /tmp/.tool-versions
                   git fetch origin gh-pages
                   git checkout gh-pages
+                  cp /tmp/.tool-versions .tool-versions
 
             - name: Install ROSA CLI and output rosa versions
               shell: bash


### PR DESCRIPTION
Align ACM and ROSA version artifact workflows to use the same checkout-then-switch pattern as Aurora and OpenSearch workflows.

Previously, the ACM workflow checked out gh-pages directly and cherry-picked the script from main, requiring manual cleanup. Now it checks out main first, preserves the script to /tmp, then switches to gh-pages — matching the established pattern and removing double maintenance of the checkout logic.

The ROSA workflow now also preserves .tool-versions from main when switching to gh-pages, consistent with the AWS workflows.