### PR TITLE
fix: align OpenShift workflows gh-pages checkout with AWS pattern

### DIFF
--- a/.github/workflows/internal_openshift_artifact_rosa_versions.yml
+++ b/.github/workflows/internal_openshift_artifact_rosa_versions.yml
@@ -17,8 +17,6 @@ jobs:
 
         steps:
             - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-              with:
-                  ref: gh-pages
 
             - name: Import Secrets
               id: secrets
@@ -31,6 +29,13 @@ jobs:
                   exportEnv: false
                   secrets: |
                       secret/data/products/infrastructure-experience/ci/common RH_OPENSHIFT_TOKEN;
+
+            - name: Switch to gh-pages branch
+              run: |
+                  cp .tool-versions /tmp/.tool-versions
+                  git fetch origin gh-pages
+                  git checkout gh-pages
+                  cp /tmp/.tool-versions .tool-versions
 
             - name: Install ROSA CLI and output rosa versions
               shell: bash


### PR DESCRIPTION
Align ACM and ROSA version artifact workflows to use the same checkout-then-switch pattern as Aurora and OpenSearch workflows.

Previously, the ACM workflow checked out gh-pages directly and cherry-picked the script from main, requiring manual cleanup. Now it checks out main first, preserves the script to /tmp, then switches to gh-pages — matching the established pattern and removing double maintenance of the checkout logic.

The ROSA workflow now also preserves .tool-versions from main when switching to gh-pages, consistent with the AWS workflows.