### PR TITLE
chore/bump aks stable 8.8

### DIFF
--- a/azure/kubernetes/aks-single-region/aks.tf
+++ b/azure/kubernetes/aks-single-region/aks.tf
@@ -1,6 +1,6 @@
 locals {
   # renovate: datasource=endoflife-date depName=azure-kubernetes-service versioning=loose
-  kubernetes_version = "1.33" # Change this to your desired Kubernetes version (aks - major.minor)
+  kubernetes_version = "1.34" # Change this to your desired Kubernetes version (aks - major.minor)
 }
 
 module "aks" {

--- a/azure/kubernetes/aks-single-region/test/golden/tfplan-golden.json
+++ b/azure/kubernetes/aks-single-region/test/golden/tfplan-golden.json
@@ -128,7 +128,7 @@
                 "node_public_ip_enabled": null,
                 "node_public_ip_prefix_id": null,
                 "only_critical_addons_enabled": true,
-                "orchestrator_version": "1.33",
+                "orchestrator_version": "1.34",
                 "os_disk_size_gb": 30,
                 "os_disk_type": "Managed",
                 "pod_subnet_id": null,

--- a/azure/modules/aks/README.md
+++ b/azure/modules/aks/README.md
@@ -19,7 +19,7 @@ No modules.
 | <a name="input_dns_service_ip"></a> [dns\_service\_ip](#input\_dns\_service\_ip) | IP address within the service CIDR that will be used for DNS | `string` | `"10.0.0.10"` | no |
 | <a name="input_dns_zone_id"></a> [dns\_zone\_id](#input\_dns\_zone\_id) | The Azure DNS zone resource id for ExternalDNS or cert-manager | `string` | `null` | no |
 | <a name="input_kms_key_id"></a> [kms\_key\_id](#input\_kms\_key\_id) | Key Vault Key ID for envelope-encryption | `string` | n/a | yes |
-| <a name="input_kubernetes_version"></a> [kubernetes\_version](#input\_kubernetes\_version) | Kubernetes version to use for the AKS cluster | `string` | `"1.33"` | no |
+| <a name="input_kubernetes_version"></a> [kubernetes\_version](#input\_kubernetes\_version) | Kubernetes version to use for the AKS cluster | `string` | `"1.34"` | no |
 | <a name="input_location"></a> [location](#input\_location) | Region where the AKS cluster will be deployed | `string` | n/a | yes |
 | <a name="input_network_plugin"></a> [network\_plugin](#input\_network\_plugin) | Network plugin to use for Kubernetes networking | `string` | `"azure"` | no |
 | <a name="input_network_policy"></a> [network\_policy](#input\_network\_policy) | Network policy to use for Kubernetes networking | `string` | `"calico"` | no |

--- a/azure/modules/aks/variables.tf
+++ b/azure/modules/aks/variables.tf
@@ -22,7 +22,7 @@ variable "kubernetes_version" {
   description = "Kubernetes version to use for the AKS cluster"
   type        = string
   # renovate: datasource=endoflife-date depName=azure-kubernetes-service versioning=loose
-  default = "1.33"
+  default = "1.34"
 }
 
 variable "tags" {


### PR DESCRIPTION
This pull request updates the default Kubernetes version used in the Azure Kubernetes Service (AKS) modules from 1.33 to 1.34. This ensures that new AKS clusters will be created with the latest supported version by default, and the documentation and test plans are kept in sync.

**Kubernetes Version Upgrade:**

* Updated the default Kubernetes version in `azure/kubernetes/aks-single-region/aks.tf` from `"1.33"` to `"1.34"`.
* Changed the default value for the `kubernetes_version` variable in `azure/modules/aks/variables.tf` to `"1.34"`.

**Documentation Update:**

* Updated the documented default Kubernetes version in `azure/modules/aks/README.md` to `"1.34"`.

**Test Plan Update:**

* Updated the expected `orchestrator_version` in the golden test plan file `azure/kubernetes/aks-single-region/test/golden/tfplan-golden.json` to `"1.34"`.