### PR TITLE
chore: bump AKS kubernetes version from 1.32 to 1.34

### DIFF
--- a/.github/actions/azure-kubernetes-aks-single-region-create/README.md
+++ b/.github/actions/azure-kubernetes-aks-single-region-create/README.md
@@ -13,7 +13,7 @@ The kube context will be set on the created cluster.
 | `resource-prefix` | <p>Prefix for the resources to be created</p> | `true` | `camunda` |
 | `resource-group-name` | <p>Name of the resource group</p> | `true` | `""` |
 | `cluster-name` | <p>Name of the AKS cluster to deploy</p> | `true` | `camunda-aks-cluster` |
-| `kubernetes-version` | <p>Version of Kubernetes to install</p> | `false` | `1.32` |
+| `kubernetes-version` | <p>Version of Kubernetes to install</p> | `false` | `1.34` |
 | `s3-backend-bucket` | <p>Name of the S3 bucket to store Terraform state</p> | `true` | `""` |
 | `s3-bucket-region` | <p>Region of the bucket containing the resources states, if not set, will fallback on aws-region</p> | `false` | `""` |
 | `s3-bucket-key-prefix` | <p>Key prefix of the bucket containing the resources states. It must contain a / at the end e.g 'my-prefix/'.</p> | `false` | `""` |
@@ -64,7 +64,7 @@ This action is a `composite` action.
     # Version of Kubernetes to install
     #
     # Required: false
-    # Default: 1.32
+    # Default: 1.34
 
     s3-backend-bucket:
     # Name of the S3 bucket to store Terraform state

--- a/.github/actions/azure-kubernetes-aks-single-region-create/action.yml
+++ b/.github/actions/azure-kubernetes-aks-single-region-create/action.yml
@@ -20,7 +20,7 @@ inputs:
     kubernetes-version:
         description: Version of Kubernetes to install
         required: false
-        default: '1.32'
+        default: '1.34'
     # using S3 backend for terraform state even with Azure, to profit from existing cleanup capabilities
     s3-backend-bucket:
         description: Name of the S3 bucket to store Terraform state

--- a/azure/kubernetes/aks-single-region/aks.tf
+++ b/azure/kubernetes/aks-single-region/aks.tf
@@ -1,6 +1,6 @@
 locals {
   # renovate: datasource=endoflife-date depName=azure-kubernetes-service versioning=loose
-  kubernetes_version = "1.32" # Change this to your desired Kubernetes version (aks - major.minor)
+  kubernetes_version = "1.34" # Change this to your desired Kubernetes version (aks - major.minor)
 }
 
 module "aks" {

--- a/azure/kubernetes/aks-single-region/test/fixtures/fixture_main_override.tf
+++ b/azure/kubernetes/aks-single-region/test/fixtures/fixture_main_override.tf
@@ -3,5 +3,5 @@ locals {
   resource_group_name = ""                              # Change this to a name of your choice, if not provided, it will be set to resource_prefix-rg, if provided, it will be used as the resource group name
   location            = "swedencentral"                 # Change this to your desired Azure region
   # renovate: datasource=endoflife-date depName=azure-kubernetes-service versioning=loose
-  kubernetes_version = "1.32" # Change this to your desired Kubernetes version (aks - major.minor)
+  kubernetes_version = "1.34" # Change this to your desired Kubernetes version (aks - major.minor)
 }

--- a/azure/modules/aks/README.md
+++ b/azure/modules/aks/README.md
@@ -19,7 +19,7 @@ No modules.
 | <a name="input_dns_service_ip"></a> [dns\_service\_ip](#input\_dns\_service\_ip) | IP address within the service CIDR that will be used for DNS | `string` | `"10.0.0.10"` | no |
 | <a name="input_dns_zone_id"></a> [dns\_zone\_id](#input\_dns\_zone\_id) | The Azure DNS zone resource id for ExternalDNS or cert-manager | `string` | `null` | no |
 | <a name="input_kms_key_id"></a> [kms\_key\_id](#input\_kms\_key\_id) | Key Vault Key ID for envelope-encryption | `string` | n/a | yes |
-| <a name="input_kubernetes_version"></a> [kubernetes\_version](#input\_kubernetes\_version) | Kubernetes version to use for the AKS cluster | `string` | `"1.32"` | no |
+| <a name="input_kubernetes_version"></a> [kubernetes\_version](#input\_kubernetes\_version) | Kubernetes version to use for the AKS cluster | `string` | `"1.34"` | no |
 | <a name="input_location"></a> [location](#input\_location) | Region where the AKS cluster will be deployed | `string` | n/a | yes |
 | <a name="input_network_plugin"></a> [network\_plugin](#input\_network\_plugin) | Network plugin to use for Kubernetes networking | `string` | `"azure"` | no |
 | <a name="input_network_policy"></a> [network\_policy](#input\_network\_policy) | Network policy to use for Kubernetes networking | `string` | `"calico"` | no |

--- a/azure/modules/aks/variables.tf
+++ b/azure/modules/aks/variables.tf
@@ -22,7 +22,7 @@ variable "kubernetes_version" {
   description = "Kubernetes version to use for the AKS cluster"
   type        = string
   # renovate: datasource=endoflife-date depName=azure-kubernetes-service versioning=loose
-  default = "1.32"
+  default = "1.34"
 }
 
 variable "tags" {


### PR DESCRIPTION
## Summary
- Bumps AKS Kubernetes version from 1.32 to 1.34 on the stable/8.7 branch
- Updates all Terraform configs, GitHub Action defaults, and associated READMEs

This is a manual bump because Renovate's shared config (`infraex-common-config`) restricts maintenance branches to patch-only updates, and the `endoflife-date` datasource for AKS only produces minor version bumps (e.g. 1.32 → 1.34), so they are never applied automatically.

## Test plan
- [ ] Verify AKS cluster provisioning with Kubernetes 1.34
- [ ] Confirm no breaking changes in AKS 1.34 for Camunda 8.7 workloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)