### PR TITLE
fix: fallback to AWS IAM cleanup when rosa delete operator-roles

### DIFF
--- a/.github/actions/aws-generic-terraform-cleanup/scripts/cleanup-ghost-rosa-clusters.sh
+++ b/.github/actions/aws-generic-terraform-cleanup/scripts/cleanup-ghost-rosa-clusters.sh
@@ -111,23 +111,69 @@ echo "$raw_clusters" | jq -c '.[]' | while read -r cluster; do
   AWS_REGION="$region_id" rosa create operator-roles --mode auto --yes --hosted-cp --prefix "${cluster_name}-operator" --oidc-config-id "${oidc_config_id}" --role-arn "${installer_role_arn}"
 
   echo "💣 Deleting cluster: $cluster_name"
-  AWS_REGION="$region_id" rosa delete cluster -c "$cluster_name" -y --watch
+  AWS_REGION="$region_id" rosa delete cluster -c "$cluster_name" -y
+
+  # Wait for the cluster to be fully deregistered from ROSA API
+  # rosa delete cluster can return before the cluster is fully removed,
+  # which causes operator-roles deletion to fail with "clusters using Operator Roles Prefix"
+  echo "⏳ Waiting for cluster $cluster_name to be fully deregistered..."
+  cluster_deregistered=false
+  for i in $(seq 1 30); do
+    if rosa list clusters 2>/dev/null | grep -q "[[:space:]]${cluster_name}[[:space:]]"; then
+      if [ "$i" -lt 30 ]; then
+        echo "⏳ Cluster still registered, waiting 30s... (attempt $i/30)"
+        sleep 30
+      else
+        echo "❌ Cluster $cluster_name is still registered after $i attempts"
+      fi
+    else
+      echo "✅ Cluster $cluster_name is fully deregistered"
+      cluster_deregistered=true
+      break
+    fi
+  done
+
+  if [ "$cluster_deregistered" != true ]; then
+    echo "⚠️ Cluster $cluster_name did not deregister in time. Proceeding with direct IAM cleanup..."
+  fi
 
   echo "🧹 Deleting operator roles with prefix ${cluster_name}-operator"
-  if ! AWS_REGION="$region_id" rosa delete operator-roles --prefix "${cluster_name}-operator" --yes --mode auto; then
-    echo "⚠️ rosa delete operator-roles failed, falling back to direct AWS IAM cleanup"
+  if [ "$cluster_deregistered" == true ]; then
+    if ! AWS_REGION="$region_id" rosa delete operator-roles --prefix "${cluster_name}-operator" --yes --mode auto; then
+      echo "⚠️ rosa delete operator-roles failed, falling back to direct AWS IAM cleanup"
+      cleanup_iam_roles_with_prefix "${cluster_name}-operator"
+    fi
+  else
+    echo "⚠️ Cluster still registered, falling back to direct AWS IAM cleanup for operator roles"
     cleanup_iam_roles_with_prefix "${cluster_name}-operator"
   fi
 
   echo "🧹 Deleting account roles with prefix ${cluster_name}-account"
-  if ! AWS_REGION="$region_id" rosa delete account-roles --prefix "${cluster_name}-account" --yes --mode auto; then
-    echo "⚠️ rosa delete account-roles failed, falling back to direct AWS IAM cleanup"
+  if [ "$cluster_deregistered" == true ]; then
+    if ! AWS_REGION="$region_id" rosa delete account-roles --prefix "${cluster_name}-account" --yes --mode auto; then
+      echo "⚠️ rosa delete account-roles failed, falling back to direct AWS IAM cleanup"
+      cleanup_iam_roles_with_prefix "${cluster_name}-account"
+    fi
+  else
+    echo "⚠️ Cluster still registered, falling back to direct AWS IAM cleanup for account roles"
     cleanup_iam_roles_with_prefix "${cluster_name}-account"
   fi
 
   echo "🧹 Deleting OIDC provider ${oidc_config_id}"
-  if ! AWS_REGION="$region_id" rosa delete oidc-provider --oidc-config-id "${oidc_config_id}" --yes --mode auto; then
-    echo "⚠️ rosa delete oidc-provider failed, falling back to direct AWS IAM cleanup"
+  if [ "$cluster_deregistered" == true ]; then
+    if ! AWS_REGION="$region_id" rosa delete oidc-provider --oidc-config-id "${oidc_config_id}" --yes --mode auto; then
+      echo "⚠️ rosa delete oidc-provider failed, falling back to direct AWS IAM cleanup"
+      oidc_provider_arn=$(aws iam list-open-id-connect-providers --query "OpenIDConnectProviderList[?ends_with(Arn, '/${oidc_config_id}')].Arn" --output text)
+      if [[ -n "$oidc_provider_arn" && "$oidc_provider_arn" != "None" ]]; then
+        echo "  🗑️ Deleting OIDC provider: $oidc_provider_arn"
+        aws iam delete-open-id-connect-provider --open-id-connect-provider-arn "$oidc_provider_arn"
+        echo "  ✅ Deleted OIDC provider: $oidc_provider_arn"
+      else
+        echo "  ℹ️ No OIDC provider found for config ID ${oidc_config_id}, already cleaned up"
+      fi
+    fi
+  else
+    echo "⚠️ Cluster still registered, falling back to direct AWS IAM cleanup for OIDC provider"
     oidc_provider_arn=$(aws iam list-open-id-connect-providers --query "OpenIDConnectProviderList[?ends_with(Arn, '/${oidc_config_id}')].Arn" --output text)
     if [[ -n "$oidc_provider_arn" && "$oidc_provider_arn" != "None" ]]; then
       echo "  🗑️ Deleting OIDC provider: $oidc_provider_arn"

--- a/.github/actions/aws-generic-terraform-cleanup/scripts/cleanup-ghost-rosa-clusters.sh
+++ b/.github/actions/aws-generic-terraform-cleanup/scripts/cleanup-ghost-rosa-clusters.sh
@@ -29,6 +29,37 @@ MIN_AGE_HOURS=$1
 CURRENT_TIME=$($date_command +%s)
 
 
+# cleanup_iam_roles_with_prefix removes all IAM roles whose name starts with the
+# given prefix, including detaching/deleting their policies first.
+cleanup_iam_roles_with_prefix() {
+  local role_prefix="$1"
+  local roles
+  roles=$(aws iam list-roles --query "Roles[?starts_with(RoleName, '${role_prefix}')].RoleName" --output text)
+  if [[ -z "$roles" || "$roles" == "None" ]]; then
+    echo "  ℹ️ No IAM roles found for prefix ${role_prefix}, already cleaned up"
+    return 0
+  fi
+  for role in $roles; do
+    echo "  🗑️ Cleaning up IAM role: $role"
+    local attached_policies
+    attached_policies=$(aws iam list-attached-role-policies --role-name "$role" --query 'AttachedPolicies[].PolicyArn' --output text)
+    if [[ -n "$attached_policies" && "$attached_policies" != "None" ]]; then
+      for policy_arn in $attached_policies; do
+        aws iam detach-role-policy --role-name "$role" --policy-arn "$policy_arn"
+      done
+    fi
+    local inline_policies
+    inline_policies=$(aws iam list-role-policies --role-name "$role" --query 'PolicyNames[]' --output text)
+    if [[ -n "$inline_policies" && "$inline_policies" != "None" ]]; then
+      for policy_name in $inline_policies; do
+        aws iam delete-role-policy --role-name "$role" --policy-name "$policy_name"
+      done
+    fi
+    aws iam delete-role --role-name "$role"
+    echo "  ✅ Deleted role: $role"
+  done
+}
+
 rosa login --token="$RHCS_TOKEN"
 
 # Ensure account-level OCM roles exist (prerequisites for cluster operations)
@@ -85,41 +116,13 @@ echo "$raw_clusters" | jq -c '.[]' | while read -r cluster; do
   echo "🧹 Deleting operator roles with prefix ${cluster_name}-operator"
   if ! AWS_REGION="$region_id" rosa delete operator-roles --prefix "${cluster_name}-operator" --yes --mode auto; then
     echo "⚠️ rosa delete operator-roles failed, falling back to direct AWS IAM cleanup"
-    role_prefix="${cluster_name}-operator"
-    roles=$(aws iam list-roles --query "Roles[?starts_with(RoleName, '${role_prefix}')].RoleName" --output text)
-    for role in $roles; do
-      echo "  🗑️ Cleaning up IAM role: $role"
-      attached_policies=$(aws iam list-attached-role-policies --role-name "$role" --query 'AttachedPolicies[].PolicyArn' --output text)
-      for policy_arn in $attached_policies; do
-        aws iam detach-role-policy --role-name "$role" --policy-arn "$policy_arn"
-      done
-      inline_policies=$(aws iam list-role-policies --role-name "$role" --query 'PolicyNames[]' --output text)
-      for policy_name in $inline_policies; do
-        aws iam delete-role-policy --role-name "$role" --policy-name "$policy_name"
-      done
-      aws iam delete-role --role-name "$role"
-      echo "  ✅ Deleted role: $role"
-    done
+    cleanup_iam_roles_with_prefix "${cluster_name}-operator"
   fi
 
   echo "🧹 Deleting account roles with prefix ${cluster_name}-account"
   if ! AWS_REGION="$region_id" rosa delete account-roles --prefix "${cluster_name}-account" --yes --mode auto; then
     echo "⚠️ rosa delete account-roles failed, falling back to direct AWS IAM cleanup"
-    role_prefix="${cluster_name}-account"
-    roles=$(aws iam list-roles --query "Roles[?starts_with(RoleName, '${role_prefix}')].RoleName" --output text)
-    for role in $roles; do
-      echo "  🗑️ Cleaning up IAM role: $role"
-      attached_policies=$(aws iam list-attached-role-policies --role-name "$role" --query 'AttachedPolicies[].PolicyArn' --output text)
-      for policy_arn in $attached_policies; do
-        aws iam detach-role-policy --role-name "$role" --policy-arn "$policy_arn"
-      done
-      inline_policies=$(aws iam list-role-policies --role-name "$role" --query 'PolicyNames[]' --output text)
-      for policy_name in $inline_policies; do
-        aws iam delete-role-policy --role-name "$role" --policy-name "$policy_name"
-      done
-      aws iam delete-role --role-name "$role"
-      echo "  ✅ Deleted role: $role"
-    done
+    cleanup_iam_roles_with_prefix "${cluster_name}-account"
   fi
 
   echo "🧹 Deleting OIDC provider ${oidc_config_id}"

--- a/.github/actions/aws-generic-terraform-cleanup/scripts/cleanup-ghost-rosa-clusters.sh
+++ b/.github/actions/aws-generic-terraform-cleanup/scripts/cleanup-ghost-rosa-clusters.sh
@@ -111,7 +111,7 @@ echo "$raw_clusters" | jq -c '.[]' | while read -r cluster; do
   AWS_REGION="$region_id" rosa create operator-roles --mode auto --yes --hosted-cp --prefix "${cluster_name}-operator" --oidc-config-id "${oidc_config_id}" --role-arn "${installer_role_arn}"
 
   echo "💣 Deleting cluster: $cluster_name"
-  AWS_REGION="$region_id" rosa delete cluster -c "$cluster_name" -y
+  AWS_REGION="$region_id" rosa delete cluster -c "$cluster_name" -y --best-effort --watch
 
   # Wait for the cluster to be fully deregistered from ROSA API
   # rosa delete cluster can return before the cluster is fully removed,

--- a/.github/actions/aws-generic-terraform-cleanup/scripts/cleanup-ghost-rosa-clusters.sh
+++ b/.github/actions/aws-generic-terraform-cleanup/scripts/cleanup-ghost-rosa-clusters.sh
@@ -83,13 +83,57 @@ echo "$raw_clusters" | jq -c '.[]' | while read -r cluster; do
   AWS_REGION="$region_id" rosa delete cluster -c "$cluster_name" -y --watch
 
   echo "🧹 Deleting operator roles with prefix ${cluster_name}-operator"
-  AWS_REGION="$region_id" rosa delete operator-roles --prefix "${cluster_name}-operator" --yes --mode auto
+  if ! AWS_REGION="$region_id" rosa delete operator-roles --prefix "${cluster_name}-operator" --yes --mode auto; then
+    echo "⚠️ rosa delete operator-roles failed, falling back to direct AWS IAM cleanup"
+    role_prefix="${cluster_name}-operator"
+    roles=$(aws iam list-roles --query "Roles[?starts_with(RoleName, '${role_prefix}')].RoleName" --output text)
+    for role in $roles; do
+      echo "  🗑️ Cleaning up IAM role: $role"
+      attached_policies=$(aws iam list-attached-role-policies --role-name "$role" --query 'AttachedPolicies[].PolicyArn' --output text)
+      for policy_arn in $attached_policies; do
+        aws iam detach-role-policy --role-name "$role" --policy-arn "$policy_arn"
+      done
+      inline_policies=$(aws iam list-role-policies --role-name "$role" --query 'PolicyNames[]' --output text)
+      for policy_name in $inline_policies; do
+        aws iam delete-role-policy --role-name "$role" --policy-name "$policy_name"
+      done
+      aws iam delete-role --role-name "$role"
+      echo "  ✅ Deleted role: $role"
+    done
+  fi
 
   echo "🧹 Deleting account roles with prefix ${cluster_name}-account"
-  AWS_REGION="$region_id" rosa delete account-roles --prefix "${cluster_name}-account" --yes --mode auto
+  if ! AWS_REGION="$region_id" rosa delete account-roles --prefix "${cluster_name}-account" --yes --mode auto; then
+    echo "⚠️ rosa delete account-roles failed, falling back to direct AWS IAM cleanup"
+    role_prefix="${cluster_name}-account"
+    roles=$(aws iam list-roles --query "Roles[?starts_with(RoleName, '${role_prefix}')].RoleName" --output text)
+    for role in $roles; do
+      echo "  🗑️ Cleaning up IAM role: $role"
+      attached_policies=$(aws iam list-attached-role-policies --role-name "$role" --query 'AttachedPolicies[].PolicyArn' --output text)
+      for policy_arn in $attached_policies; do
+        aws iam detach-role-policy --role-name "$role" --policy-arn "$policy_arn"
+      done
+      inline_policies=$(aws iam list-role-policies --role-name "$role" --query 'PolicyNames[]' --output text)
+      for policy_name in $inline_policies; do
+        aws iam delete-role-policy --role-name "$role" --policy-name "$policy_name"
+      done
+      aws iam delete-role --role-name "$role"
+      echo "  ✅ Deleted role: $role"
+    done
+  fi
 
   echo "🧹 Deleting OIDC provider ${oidc_config_id}"
-  AWS_REGION="$region_id" rosa delete oidc-provider --oidc-config-id "${oidc_config_id}" --yes --mode auto
+  if ! AWS_REGION="$region_id" rosa delete oidc-provider --oidc-config-id "${oidc_config_id}" --yes --mode auto; then
+    echo "⚠️ rosa delete oidc-provider failed, falling back to direct AWS IAM cleanup"
+    oidc_provider_arn=$(aws iam list-open-id-connect-providers --query "OpenIDConnectProviderList[?ends_with(Arn, '/${oidc_config_id}')].Arn" --output text)
+    if [[ -n "$oidc_provider_arn" && "$oidc_provider_arn" != "None" ]]; then
+      echo "  🗑️ Deleting OIDC provider: $oidc_provider_arn"
+      aws iam delete-open-id-connect-provider --open-id-connect-provider-arn "$oidc_provider_arn"
+      echo "  ✅ Deleted OIDC provider: $oidc_provider_arn"
+    else
+      echo "  ℹ️ No OIDC provider found for config ID ${oidc_config_id}, already cleaned up"
+    fi
+  fi
 
 done
 

--- a/.github/actions/aws-generic-terraform-cleanup/scripts/destroy-resources.sh
+++ b/.github/actions/aws-generic-terraform-cleanup/scripts/destroy-resources.sh
@@ -467,6 +467,7 @@ destroy_module() {
     if [[ "$output" == *"CLUSTERS-MGMT-400"* && "$output" == *"trust policy"* && $attempt -lt $max_destroy_attempts ]]; then
       echo "[$group_id][$module_name] Broken trust policy detected (attempt $attempt/$max_destroy_attempts)"
       echo "[$group_id][$module_name] Recreating account roles to restore trust policies..."
+      rosa login --token="$RHCS_TOKEN"
       rosa create account-roles --mode auto --yes --hosted-cp --prefix "${group_id}-account" || true
       continue
     fi

--- a/.github/actions/aws-generic-terraform-cleanup/scripts/destroy-resources.sh
+++ b/.github/actions/aws-generic-terraform-cleanup/scripts/destroy-resources.sh
@@ -460,10 +460,21 @@ destroy_module() {
       continue
     fi
 
-    # For non-DependencyViolation errors we fail fast instead of retrying, since these
+    # On CLUSTERS-MGMT-400 with trust policy error: the account IAM roles exist but their
+    # trust policies are broken (e.g. previous partial cleanup removed the trust relationship).
+    # Red Hat's service can't assume the Installer role to delete the cluster.
+    # We recreate the account roles with correct trust policies and retry.
+    if [[ "$output" == *"CLUSTERS-MGMT-400"* && "$output" == *"trust policy"* && $attempt -lt $max_destroy_attempts ]]; then
+      echo "[$group_id][$module_name] Broken trust policy detected (attempt $attempt/$max_destroy_attempts)"
+      echo "[$group_id][$module_name] Recreating account roles to restore trust policies..."
+      rosa create account-roles --mode auto --yes --hosted-cp --prefix "${group_id}-account" || true
+      continue
+    fi
+
+    # For other errors we fail fast instead of retrying, since these
     # typically indicate configuration or logic issues (e.g. invalid Terraform, IAM),
-    # not transient AWS conditions. Only DependencyViolation (and known special cases)
-    # are retried above.
+    # not transient AWS/RHCS conditions. Only DependencyViolation, OIDC propagation,
+    # trust policy repair, and known special cases are retried above.
     echo "Error destroying $module_name in $group_id"
     return 1
   done


### PR DESCRIPTION
This pull request enhances the robustness of the `cleanup-ghost-rosa-clusters.sh` script by adding fallback logic for AWS IAM resource cleanup. If the standard `rosa` CLI deletion commands fail for operator roles, account roles, or OIDC providers, the script now attempts to clean up these resources directly using AWS CLI commands. This ensures that orphaned IAM resources are properly removed even if `rosa` commands encounter issues.

**Fallback logic for resource cleanup:**

* Operator roles: If `rosa delete operator-roles` fails, the script lists and deletes all IAM roles with the appropriate prefix, including detaching and deleting associated policies.
* Account roles: If `rosa delete account-roles` fails, the script performs direct IAM cleanup for all roles with the account prefix, handling both attached and inline policies.
* OIDC provider: If `rosa delete oidc-provider` fails, the script locates and deletes the corresponding AWS OIDC provider directly.