### PR TITLE
fix: remove Helm chart 14.x schema-invalid keys from values files

### DIFF
--- a/azure/kubernetes/aks-single-region-rdbms/helm-values/values-domain.yml
+++ b/azure/kubernetes/aks-single-region-rdbms/helm-values/values-domain.yml
@@ -72,7 +72,6 @@ webModeler:
 
     restapi:
         externalDatabase:
-            enabled: true
             url: jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_WEBMODELER_NAME}?sslmode=require
             user: ${DB_WEBMODELER_USERNAME}
             secret:

--- a/azure/kubernetes/aks-single-region-rdbms/helm-values/values-no-domain.yml
+++ b/azure/kubernetes/aks-single-region-rdbms/helm-values/values-no-domain.yml
@@ -82,7 +82,6 @@ webModeler:
 
     restapi:
         externalDatabase:
-            enabled: true
             url: jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_WEBMODELER_NAME}?sslmode=require
             user: ${DB_WEBMODELER_USERNAME}
             secret:

--- a/azure/kubernetes/aks-single-region/helm-values/values-domain.yml
+++ b/azure/kubernetes/aks-single-region/helm-values/values-domain.yml
@@ -71,7 +71,6 @@ webModeler:
 
     restapi:
         externalDatabase:
-            enabled: true
             url: jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_WEBMODELER_NAME}?sslmode=require
             user: ${DB_WEBMODELER_USERNAME}
             secret:

--- a/azure/kubernetes/aks-single-region/helm-values/values-no-domain.yml
+++ b/azure/kubernetes/aks-single-region/helm-values/values-no-domain.yml
@@ -65,7 +65,6 @@ webModeler:
 
     restapi:
         externalDatabase:
-            enabled: true
             url: jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_WEBMODELER_NAME}?sslmode=require
             user: ${DB_WEBMODELER_USERNAME}
             secret:

--- a/generic/kubernetes/operator-based/keycloak/camunda-keycloak-domain-values.yml
+++ b/generic/kubernetes/operator-based/keycloak/camunda-keycloak-domain-values.yml
@@ -26,11 +26,6 @@ global:
         keycloak:
             # For external Keycloak managed by operator
             internal: false # Disable internal Keycloak
-            url:
-                # Configuration for external Keycloak service
-                protocol: http
-                host: keycloak-service
-                port: '18080'
             contextPath: /auth
             realm: /realms/camunda-platform
             auth:
@@ -49,8 +44,6 @@ orchestration:
 
 identityKeycloak:
     enabled: false
-    postgresql:
-        enabled: false
 
 identity:
     enabled: true

--- a/generic/kubernetes/operator-based/keycloak/camunda-keycloak-no-domain-values.yml
+++ b/generic/kubernetes/operator-based/keycloak/camunda-keycloak-no-domain-values.yml
@@ -29,11 +29,6 @@ global:
         keycloak:
             # For external Keycloak managed by operator
             internal: false # Disable internal Keycloak
-            url:
-                # Configuration for external Keycloak service
-                protocol: http
-                host: keycloak-service
-                port: '18080'
             contextPath: /auth
             realm: /realms/camunda-platform
             auth:
@@ -52,8 +47,6 @@ orchestration:
 
 identityKeycloak:
     enabled: false
-    postgresql:
-        enabled: false
 
 identity:
     enabled: true

--- a/generic/kubernetes/operator-based/postgresql/camunda-webmodeler-values.yml
+++ b/generic/kubernetes/operator-based/postgresql/camunda-webmodeler-values.yml
@@ -13,7 +13,6 @@ webModeler:
     # Use external PostgreSQL for WebModeler
     restapi:
         externalDatabase:
-            enabled: true
             host: pg-webmodeler-rw
             port: 5432
             database: webmodeler

--- a/generic/kubernetes/operator-based/tests/utils/camunda-values-identity-secrets.yml
+++ b/generic/kubernetes/operator-based/tests/utils/camunda-values-identity-secrets.yml
@@ -12,11 +12,6 @@ global:
                     existingSecret: identity-secret-for-components
                     existingSecretKey: identity-optimize-client-token
 
-            console:
-                secret:
-                    existingSecret: identity-secret-for-components
-                    existingSecretKey: identity-console-client-token
-
 identity:
     contextPath: /managementidentity
 

--- a/generic/kubernetes/single-region/tests/helm-values/identity.yml
+++ b/generic/kubernetes/single-region/tests/helm-values/identity.yml
@@ -35,11 +35,3 @@ identity:
                 definition: delete:*
               - resourceServerId: console-api
                 definition: write:*
-
-orchestration:
-    security:
-        initialization:
-            defaultRoles:
-                admin:
-                    clients:
-                        - venom

--- a/generic/kubernetes/single-region/tests/helm-values/registry-harbor.yml
+++ b/generic/kubernetes/single-region/tests/helm-values/registry-harbor.yml
@@ -8,8 +8,3 @@ global:
         pullSecrets:
             - name: registry-camunda-cloud
             - name: index-docker-io
-
-elasticsearch:
-    global:
-        imagePullSecrets:
-            - name: index-docker-io

--- a/generic/kubernetes/single-region/tests/helm-values/registry.yml
+++ b/generic/kubernetes/single-region/tests/helm-values/registry.yml
@@ -4,17 +4,7 @@
 
 # Auth to avoid Docker download rate limit.
 # https://docs.docker.com/docker-hub/download-rate-limit/
-identityKeycloak:
-    image:
-        pullSecrets:
-            - name: index-docker-io
-
 global:
     image:
         pullSecrets:
-            - name: index-docker-io
-
-elasticsearch:
-    global:
-        imagePullSecrets:
             - name: index-docker-io


### PR DESCRIPTION
## Summary

Fixes pre-existing schema validation failures on `stable/8.9` where the `internal-helm-deprecation-check` action flags unknown configuration keys against the strict Helm chart 14.0.1 JSON schema.

The `validate-unknown-keys.py` script makes every object schema strict by adding `additionalProperties: false` recursively. Keys that exist in values files but are absent from the published 14.0.1 schema cause CI failures.

### Keys removed and why

| Key | Reason |
|-----|--------|
| `global.identity.keycloak.url.{protocol,host,port}` | `url` is defined as an empty `{}` object in the schema — strict validation rejects all sub-keys. The Keycloak URL is already fully covered by `issuerBackendUrl`/`issuer`/`publicIssuerUrl` |
| `identityKeycloak.postgresql.enabled` | Not in schema; the whole `identityKeycloak` sub-chart is already disabled via `identityKeycloak.enabled: false` |
| `identityKeycloak.image.pullSecrets` | Not in schema; `global.image.pullSecrets` already provides image pull secret coverage globally |
| `elasticsearch.global.imagePullSecrets` | Not in schema; `elasticsearch.global` only has `compatibility` in 14.0.1 |
| `orchestration.security.initialization.defaultRoles.admin.clients` | Not in schema (only `.admin.users` exists); the `venom` test client's permissions are already granted via `identity.clients[].permissions` |
| `global.identity.auth.console.secret` | Not in schema; `console` only has `clientId`, `audience`, `wellKnown`, `redirectUrl` in 14.0.1 |
| `webModeler.restapi.externalDatabase.enabled` | Not in schema; the chart detects external DB from presence of `host`/`url`, not an explicit `enabled` flag |

### Behavior preserved

- Keycloak URL is still fully specified via `issuerBackendUrl`/`issuer`/`publicIssuerUrl`
- Image pull secrets are still applied globally via `global.image.pullSecrets`
- The `venom` integration test client retains all API permissions via `identity.clients[].permissions`
- External databases for WebModeler continue to work via `host`/`url` fields

## Test plan

- [ ] CI schema validation (`check-unknown-keys`) passes on all test scenarios
- [ ] Keycloak operator-based tests still deploy correctly
- [ ] Integration tests with venom client still authenticate successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)