### PR TITLE
fix(ci): resolve Terraform version from .tool-versions

### DIFF
--- a/.github/actions/aws-utility-action/README.md
+++ b/.github/actions/aws-utility-action/README.md
@@ -14,7 +14,7 @@ A set of utility steps to be used across different workflows, including:
 | name | description | required | default |
 | --- | --- | --- | --- |
 | `awscli-version` | <p>Version of the AWS CLI to install</p> | `false` | `2.15.52` |
-| `terraform-version` | <p>Version of Terraform to install</p> | `false` | `latest` |
+| `terraform-version` | <p>Version of Terraform to install. Use an empty string or 'latest' to read the version from the consumer repo's .tool-versions file (falls back to 'latest' when neither is present).</p> | `false` | `""` |
 | `s3-backend-bucket` | <p>Name of the S3 bucket to store Terraform state</p> | `true` | `""` |
 | `s3-bucket-region` | <p>Region of the bucket containing the resources states, if not set, will fallback on aws-region</p> | `false` | `""` |
 | `aws-region` | <p>AWS region to use for S3 bucket operations</p> | `true` | `""` |
@@ -50,10 +50,12 @@ This action is a `composite` action.
     # Default: 2.15.52
 
     terraform-version:
-    # Version of Terraform to install
+    # Version of Terraform to install. Use an empty string or 'latest' to
+    # read the version from the consumer repo's .tool-versions file
+    # (falls back to 'latest' when neither is present).
     #
     # Required: false
-    # Default: latest
+    # Default: ""
 
     s3-backend-bucket:
     # Name of the S3 bucket to store Terraform state

--- a/.github/actions/aws-utility-action/action.yml
+++ b/.github/actions/aws-utility-action/action.yml
@@ -16,8 +16,11 @@ inputs:
         default: 2.15.52
 
     terraform-version:
-        description: Version of Terraform to install
-        default: latest
+        description: |
+            Version of Terraform to install. Use an empty string or 'latest' to
+            read the version from the consumer repo's .tool-versions file
+            (falls back to 'latest' when neither is present).
+        default: ''
 
     s3-backend-bucket:
         description: Name of the S3 bucket to store Terraform state
@@ -66,12 +69,32 @@ outputs:
 runs:
     using: composite
     steps:
+        - name: Resolve Terraform version
+          id: resolve-terraform-version
+          shell: bash
+          run: |
+              set -euo pipefail
+              version="${{ inputs.terraform-version }}"
+              if [[ -z "$version" || "$version" == "latest" ]]; then
+                  if [[ -f "${GITHUB_WORKSPACE}/.tool-versions" ]]; then
+                      from_file=$(awk '$1=="terraform"{print $2; exit}' "${GITHUB_WORKSPACE}/.tool-versions" || true)
+                      if [[ -n "$from_file" ]]; then
+                          version="$from_file"
+                          echo "Using Terraform version from .tool-versions: $version"
+                      fi
+                  fi
+              fi
+              if [[ -z "$version" ]]; then
+                  version="latest"
+              fi
+              echo "version=$version" >> "$GITHUB_OUTPUT"
+
         - name: Install Terraform
           uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4
           with:
               cli_config_credentials_hostname: ${{ inputs.tf-cli-config-credentials-hostname }}
               cli_config_credentials_token: ${{ inputs.tf-cli-config-credentials-token }}
-              terraform_version: ${{ inputs.terraform-version }}
+              terraform_version: ${{ steps.resolve-terraform-version.outputs.version }}
               terraform_wrapper: ${{ inputs.tf-terraform-wrapper }}
 
         - name: Install AWS CLI


### PR DESCRIPTION
The aws-utility-action used hashicorp/setup-terraform with terraform_version=latest by default, which started installing Terraform v1.15.0 and broke terraform validate on backend "s3" {} blocks. Read the version from .tool-versions when the input is empty or latest so Renovate-managed updates flow into CI.

Note: this fix only takes effect once the SHA pin to aws-utility-action in aws-{eks,aurora,opensearch}-manage-cluster actions is bumped to a main commit that contains the same change.