### PR TITLE
chore(ci): bump aws-utility-action pin to 382bb14c

### DIFF
--- a/.github/actions/aws-aurora-manage-cluster/action.yml
+++ b/.github/actions/aws-aurora-manage-cluster/action.yml
@@ -116,7 +116,7 @@ runs:
           id: utility
           # see https://github.com/orgs/community/discussions/41927 it's not possible to optimize this yet
           # steps.uses  cannot access the github context.
-          uses: camunda/camunda-deployment-references/.github/actions/aws-utility-action@8de886461890f528287be2b5bdaa5df20902f45d # main
+          uses: camunda/camunda-deployment-references/.github/actions/aws-utility-action@382bb14cffdc8280df8e0a64d3a483b8f1b84d49 # main
           with:
               awscli-version: ${{ inputs.awscli-version }}
               terraform-version: ${{ inputs.terraform-version }}

--- a/.github/actions/aws-eks-manage-cluster/action.yml
+++ b/.github/actions/aws-eks-manage-cluster/action.yml
@@ -99,7 +99,7 @@ runs:
           # see https://github.com/orgs/community/discussions/41927 it's not possible to optimize this yet
           # steps.uses  cannot access the github context.
           # uses: ${{ github.action_repository }}/aws-utility-action@${{ github.action_ref }}
-          uses: camunda/camunda-deployment-references/.github/actions/aws-utility-action@8de886461890f528287be2b5bdaa5df20902f45d # main
+          uses: camunda/camunda-deployment-references/.github/actions/aws-utility-action@382bb14cffdc8280df8e0a64d3a483b8f1b84d49 # main
           with:
               awscli-version: ${{ inputs.awscli-version }}
               terraform-version: ${{ inputs.terraform-version }}

--- a/.github/actions/aws-opensearch-manage-cluster/action.yml
+++ b/.github/actions/aws-opensearch-manage-cluster/action.yml
@@ -113,7 +113,7 @@ runs:
     steps:
         - name: Use Utility Actions
           id: utility
-          uses: camunda/camunda-deployment-references/.github/actions/aws-utility-action@8de886461890f528287be2b5bdaa5df20902f45d # main
+          uses: camunda/camunda-deployment-references/.github/actions/aws-utility-action@382bb14cffdc8280df8e0a64d3a483b8f1b84d49 # main
           with:
               awscli-version: ${{ inputs.awscli-version }}
               terraform-version: ${{ inputs.tf-terraform-version }}


### PR DESCRIPTION
Bumps the cross-repo SHA pin of `aws-utility-action` in the three downstream cluster-manage actions to commit `382bb14c`, which contains the `.tool-versions`-based Terraform resolution merged in #2386.

Without this bump the consumer composite actions still install Terraform `latest`, which currently resolves to v1.15.0 and breaks `terraform validate` on partial S3 backend blocks.

Follow-up to #2386.