### PR TITLE
chore(ci): bump aws-utility-action pin to 382bb14c [stable/8.8]

### DIFF
--- a/.github/actions/aws-aurora-manage-cluster/action.yml
+++ b/.github/actions/aws-aurora-manage-cluster/action.yml
@@ -117,7 +117,7 @@ runs:
           id: utility
           # see https://github.com/orgs/community/discussions/41927 it's not possible to optimize this yet
           # steps.uses  cannot access the github context.
-          uses: camunda/camunda-deployment-references/.github/actions/aws-utility-action@6a831b43cdc4b5deb3ee35028e2d987134fc00ee # main
+          uses: camunda/camunda-deployment-references/.github/actions/aws-utility-action@382bb14cffdc8280df8e0a64d3a483b8f1b84d49 # main
           with:
               awscli-version: ${{ inputs.awscli-version }}
               terraform-version: ${{ inputs.terraform-version }}

--- a/.github/actions/aws-eks-manage-cluster/action.yml
+++ b/.github/actions/aws-eks-manage-cluster/action.yml
@@ -100,7 +100,7 @@ runs:
           # see https://github.com/orgs/community/discussions/41927 it's not possible to optimize this yet
           # steps.uses  cannot access the github context.
           # uses: ${{ github.action_repository }}/aws-utility-action@${{ github.action_ref }}
-          uses: camunda/camunda-deployment-references/.github/actions/aws-utility-action@6a831b43cdc4b5deb3ee35028e2d987134fc00ee # main
+          uses: camunda/camunda-deployment-references/.github/actions/aws-utility-action@382bb14cffdc8280df8e0a64d3a483b8f1b84d49 # main
           with:
               awscli-version: ${{ inputs.awscli-version }}
               terraform-version: ${{ inputs.terraform-version }}

--- a/.github/actions/aws-opensearch-manage-cluster/action.yml
+++ b/.github/actions/aws-opensearch-manage-cluster/action.yml
@@ -113,7 +113,7 @@ runs:
     steps:
         - name: Use Utility Actions
           id: utility
-          uses: camunda/camunda-deployment-references/.github/actions/aws-utility-action@6a831b43cdc4b5deb3ee35028e2d987134fc00ee # main
+          uses: camunda/camunda-deployment-references/.github/actions/aws-utility-action@382bb14cffdc8280df8e0a64d3a483b8f1b84d49 # main
           with:
               awscli-version: ${{ inputs.awscli-version }}
               terraform-version: ${{ inputs.tf-terraform-version }}


### PR DESCRIPTION
Bumps the cross-repo SHA pin of `aws-utility-action` in the three downstream cluster-manage actions to commit `382bb14c` on `main`, which contains the `.tool-versions`-based Terraform resolution.

Follow-up to the backport PR on `stable/8.8`.