### PR TITLE
backport: artifactory ro and trap fix main

### DIFF
--- a/.github/workflows/aws_compute_ec2_single_region_tests.yml
+++ b/.github/workflows/aws_compute_ec2_single_region_tests.yml
@@ -202,11 +202,8 @@ jobs:
                   aws-profile: ${{ env.AWS_PROFILE }}
                   aws-region: ${{ env.AWS_REGION }}
 
-            # TODO: Temporary workaround using existing CI credentials for Artifactory authentication.
-            #   Long-term, this should use a dedicated read-only service account.
-            #   See: https://github.com/camunda/team-infrastructure-experience/issues/1053
-            - name: Import Secrets
-              id: secrets
+            - name: Import Artifactory credentials
+              id: artifactory-credentials
               uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3
               with:
                   url: ${{ secrets.VAULT_ADDR }}
@@ -215,8 +212,8 @@ jobs:
                   secretId: ${{ secrets.VAULT_SECRET_ID }}
                   exportEnv: false
                   secrets: |
-                      secret/data/products/infrastructure-experience/ci/common MACHINE_USR;
-                      secret/data/products/infrastructure-experience/ci/common MACHINE_PWD;
+                      secret/data/products/infrastructure-experience/ci/artifactory-ro ARTIFACTORY_USR;
+                      secret/data/products/infrastructure-experience/ci/artifactory-ro ARTIFACTORY_PSW;
 
             - name: 📁 Get a copy of the reference architecture
               timeout-minutes: 10
@@ -264,8 +261,8 @@ jobs:
                   CAMUNDA_PREVIOUS_VERSION: ${{ env.TESTS_CAMUNDA_PREVIOUS_VERSION }}
                   CAMUNDA_CONNECTORS_VERSION: ${{ env.TESTS_CONNECTORS_VERSION }}
                   CAMUNDA_CONNECTORS_PREVIOUS_VERSION: ${{ env.TESTS_CONNECTORS_PREVIOUS_VERSION }}
-                  CAMUNDA_DISTRO_USER: ${{ steps.secrets.outputs.MACHINE_USR }}
-                  CAMUNDA_DISTRO_PASSWORD: ${{ steps.secrets.outputs.MACHINE_PWD }}
+                  CAMUNDA_DISTRO_USER: ${{ steps.artifactory-credentials.outputs.ARTIFACTORY_USR }}
+                  CAMUNDA_DISTRO_PASSWORD: ${{ steps.artifactory-credentials.outputs.ARTIFACTORY_PSW }}
               run: |
                   set -euo pipefail
                   export PATH=$PATH:$(go env GOPATH)/bin

--- a/generic/compute/debian/procedure/camunda-install.sh
+++ b/generic/compute/debian/procedure/camunda-install.sh
@@ -40,7 +40,10 @@ if [[ -n "${CAMUNDA_DISTRO_USER}" && -n "${CAMUNDA_DISTRO_PASSWORD}" ]]; then
     chmod 600 "${CURL_NETRC_FILE}"
     printf 'machine artifacts.camunda.com login %s password %s\n' "${CAMUNDA_DISTRO_USER}" "${CAMUNDA_DISTRO_PASSWORD}" > "${CURL_NETRC_FILE}"
     CURL_AUTH_OPTS=(--netrc-file "${CURL_NETRC_FILE}")
-    trap 'rm -f "${CURL_NETRC_FILE}"' EXIT
+    # Use sudo because ownership of the netrc file is later transferred to the
+    # camunda user (see chown below); without sudo, rm would fail due to the
+    # /tmp sticky bit and the EXIT trap would propagate a non-zero exit code.
+    trap 'sudo rm -f "${CURL_NETRC_FILE}" || true' EXIT
 else
     echo "[WARN] No Artifactory authentication credentials configured. Downloads may fail for Enterprise artifacts."
 fi
@@ -140,12 +143,14 @@ rm -rf "${MNT_DIR}/camunda.tar.gz"
 
 mkdir -p "${MNT_DIR}/connectors/"
 
+# --fail-with-body (instead of -f) keeps the response body on HTTP error so the
+# Artifactory error message (e.g. 401/403 JSON) is visible in CI logs.
 if [[ "${CAMUNDA_CONNECTORS_VERSION}" =~ "SNAPSHOT" ]]; then
     # shellcheck disable=SC2086
-    curl -fL ${CURL_NETRC_OPT} "https://artifacts.camunda.com/artifactory/connectors-snapshots/io/camunda/connector/connector-runtime-bundle/${CAMUNDA_CONNECTORS_VERSION}/connector-runtime-bundle-${CONNECTORS_SNAPSHOT_VERSION}-with-dependencies.jar" -o "${MNT_DIR}/connectors/connectors.jar"
+    curl -L --fail-with-body --show-error -w "[INFO] connectors download: HTTP %{http_code} (%{size_download} bytes)\n" ${CURL_NETRC_OPT} "https://artifacts.camunda.com/artifactory/connectors-snapshots/io/camunda/connector/connector-runtime-bundle/${CAMUNDA_CONNECTORS_VERSION}/connector-runtime-bundle-${CONNECTORS_SNAPSHOT_VERSION}-with-dependencies.jar" -o "${MNT_DIR}/connectors/connectors.jar" || { echo "[FAIL] connectors download failed; response body:"; cat "${MNT_DIR}/connectors/connectors.jar" 2>/dev/null | head -c 4096; echo; exit 1; }
 else
     # shellcheck disable=SC2086
-    curl -fL ${CURL_NETRC_OPT} "https://artifacts.camunda.com/artifactory/connectors/io/camunda/connector/connector-runtime-bundle/${CAMUNDA_CONNECTORS_VERSION}/connector-runtime-bundle-${CAMUNDA_CONNECTORS_VERSION}-with-dependencies.jar" -o "${MNT_DIR}/connectors/connectors.jar"
+    curl -L --fail-with-body --show-error -w "[INFO] connectors download: HTTP %{http_code} (%{size_download} bytes)\n" ${CURL_NETRC_OPT} "https://artifacts.camunda.com/artifactory/connectors/io/camunda/connector/connector-runtime-bundle/${CAMUNDA_CONNECTORS_VERSION}/connector-runtime-bundle-${CAMUNDA_CONNECTORS_VERSION}-with-dependencies.jar" -o "${MNT_DIR}/connectors/connectors.jar" || { echo "[FAIL] connectors download failed; response body:"; cat "${MNT_DIR}/connectors/connectors.jar" 2>/dev/null | head -c 4096; echo; exit 1; }
 fi
 
 curl -fL https://raw.githubusercontent.com/camunda/connectors/main/bundle/default-bundle/start.sh -o "${MNT_DIR}/connectors/start.sh"


### PR DESCRIPTION
This pull request updates the authentication method for Artifactory in the CI pipeline and improves error handling for artifact downloads. The main changes involve switching to a dedicated read-only Artifactory service account, updating credential references in the workflow, and enhancing troubleshooting visibility in the installation script.

**CI/CD Workflow Improvements:**

* The GitHub Actions workflow `.github/workflows/aws_compute_ec2_single_region_tests.yml` now imports credentials from a dedicated Artifactory read-only service account instead of using generic CI credentials.
* Environment variables `CAMUNDA_DISTRO_USER` and `CAMUNDA_DISTRO_PASSWORD` are now populated from the new Artifactory credentials (`ARTIFACTORY_USR` and `ARTIFACTORY_PSW`) rather than the previous generic machine credentials. [[1]](diffhunk://#diff-98dfacd717ad0b252b5c9fa6b989f65f2f45a4579cfe626c1f4c9607cb26265eL218-R216) [[2]](diffhunk://#diff-98dfacd717ad0b252b5c9fa6b989f65f2f45a4579cfe626c1f4c9607cb26265eL267-R265)

**Script Reliability and Debugging:**

* In `camunda-install.sh`, the cleanup of temporary credential files now uses `sudo` to avoid permission issues when the file ownership changes, preventing CI failures due to non-zero exit codes on cleanup.
* Artifact downloads (for connectors) now use `curl` with `--fail-with-body` and improved error reporting, ensuring that HTTP error responses (such as 401/403) are visible in CI logs for easier troubleshooting.