### PR TITLE
backport: artifactory ro and trap fix stable 8.8

### DIFF
--- a/.github/workflows/aws_compute_ec2_single_region_tests.yml
+++ b/.github/workflows/aws_compute_ec2_single_region_tests.yml
@@ -198,6 +198,22 @@ jobs:
                   aws-profile: ${{ env.AWS_PROFILE }}
                   aws-region: ${{ env.AWS_REGION }}
 
+            # TODO: Temporary workaround using existing CI credentials for Artifactory authentication.
+            #   Long-term, this should use a dedicated read-only service account.
+            #   See: https://github.com/camunda/team-infrastructure-experience/issues/1053
+            - name: Import Secrets
+              id: secrets
+              uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3
+              with:
+                  url: ${{ secrets.VAULT_ADDR }}
+                  method: approle
+                  roleId: ${{ secrets.VAULT_ROLE_ID }}
+                  secretId: ${{ secrets.VAULT_SECRET_ID }}
+                  exportEnv: false
+                  secrets: |
+                      secret/data/products/infrastructure-experience/ci/common MACHINE_USR;
+                      secret/data/products/infrastructure-experience/ci/common MACHINE_PWD;
+
             - name: 📁 Get a copy of the reference architecture
               timeout-minutes: 10
               run: |
@@ -244,6 +260,8 @@ jobs:
                   CAMUNDA_PREVIOUS_VERSION: ${{ env.TESTS_CAMUNDA_PREVIOUS_VERSION }}
                   CAMUNDA_CONNECTORS_VERSION: ${{ env.TESTS_CONNECTORS_VERSION }}
                   CAMUNDA_CONNECTORS_PREVIOUS_VERSION: ${{ env.TESTS_CONNECTORS_PREVIOUS_VERSION }}
+                  CAMUNDA_DISTRO_USER: ${{ steps.secrets.outputs.MACHINE_USR }}
+                  CAMUNDA_DISTRO_PASSWORD: ${{ steps.secrets.outputs.MACHINE_PWD }}
               run: |
                   set -euo pipefail
                   export PATH=$PATH:$(go env GOPATH)/bin

--- a/.github/workflows/aws_compute_ec2_single_region_tests.yml
+++ b/.github/workflows/aws_compute_ec2_single_region_tests.yml
@@ -198,11 +198,8 @@ jobs:
                   aws-profile: ${{ env.AWS_PROFILE }}
                   aws-region: ${{ env.AWS_REGION }}
 
-            # TODO: Temporary workaround using existing CI credentials for Artifactory authentication.
-            #   Long-term, this should use a dedicated read-only service account.
-            #   See: https://github.com/camunda/team-infrastructure-experience/issues/1053
-            - name: Import Secrets
-              id: secrets
+            - name: Import Artifactory credentials
+              id: artifactory-credentials
               uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3
               with:
                   url: ${{ secrets.VAULT_ADDR }}
@@ -211,8 +208,8 @@ jobs:
                   secretId: ${{ secrets.VAULT_SECRET_ID }}
                   exportEnv: false
                   secrets: |
-                      secret/data/products/infrastructure-experience/ci/common MACHINE_USR;
-                      secret/data/products/infrastructure-experience/ci/common MACHINE_PWD;
+                      secret/data/products/infrastructure-experience/ci/artifactory-ro ARTIFACTORY_USR;
+                      secret/data/products/infrastructure-experience/ci/artifactory-ro ARTIFACTORY_PSW;
 
             - name: 📁 Get a copy of the reference architecture
               timeout-minutes: 10
@@ -260,8 +257,8 @@ jobs:
                   CAMUNDA_PREVIOUS_VERSION: ${{ env.TESTS_CAMUNDA_PREVIOUS_VERSION }}
                   CAMUNDA_CONNECTORS_VERSION: ${{ env.TESTS_CONNECTORS_VERSION }}
                   CAMUNDA_CONNECTORS_PREVIOUS_VERSION: ${{ env.TESTS_CONNECTORS_PREVIOUS_VERSION }}
-                  CAMUNDA_DISTRO_USER: ${{ steps.secrets.outputs.MACHINE_USR }}
-                  CAMUNDA_DISTRO_PASSWORD: ${{ steps.secrets.outputs.MACHINE_PWD }}
+                  CAMUNDA_DISTRO_USER: ${{ steps.artifactory-credentials.outputs.ARTIFACTORY_USR }}
+                  CAMUNDA_DISTRO_PASSWORD: ${{ steps.artifactory-credentials.outputs.ARTIFACTORY_PSW }}
               run: |
                   set -euo pipefail
                   export PATH=$PATH:$(go env GOPATH)/bin

--- a/aws/compute/ec2-single-region/procedure/all-in-one-install.sh
+++ b/aws/compute/ec2-single-region/procedure/all-in-one-install.sh
@@ -12,6 +12,9 @@ MNT_DIR=${MNT_DIR:-"/opt/camunda"}
 BROKER_PORT=${BROKER_PORT:-26502}
 TERRAFORM_DIR=${TERRAFORM_DIR:-"${CURRENT_DIR}/../terraform/cluster"}
 
+CAMUNDA_DISTRO_USER=${CAMUNDA_DISTRO_USER:-""}
+CAMUNDA_DISTRO_PASSWORD=${CAMUNDA_DISTRO_PASSWORD:-""}
+
 check_tool_installed "ssh"
 check_tool_installed "openssl"
 check_tool_installed "sftp"
@@ -70,6 +73,16 @@ total_ip_count=${#IPS[@]}
 # The idea is to divide the logic into smaller scripts for better readability and maintainability
 for index in "${!IPS[@]}"; do
     ip=${IPS[$index]}
+
+    # Write credentials to a temp file on the remote host via stdin to avoid
+    # leaking them in process listings or CI logs. The install script reads and
+    # deletes this file. A separate SSH call is used so that the install script's
+    # stdin remains clean (the script uses a heredoc internally).
+    if [[ -n "${CAMUNDA_DISTRO_USER}" && -n "${CAMUNDA_DISTRO_PASSWORD}" ]]; then
+        printf '%s\n%s\n' "${CAMUNDA_DISTRO_USER}" "${CAMUNDA_DISTRO_PASSWORD}" | \
+            ssh -J "${ADMIN_USERNAME}@${BASTION_IP}" "${ADMIN_USERNAME}@${ip}" \
+            'cat > /tmp/.camunda-distro-credentials && chmod 600 /tmp/.camunda-distro-credentials'
+    fi
 
     ssh -J "${ADMIN_USERNAME}@${BASTION_IP}" "${ADMIN_USERNAME}@${ip}" < "${CURRENT_DIR}/camunda-install.sh"
 

--- a/generic/compute/debian/procedure/camunda-install.sh
+++ b/generic/compute/debian/procedure/camunda-install.sh
@@ -11,8 +11,7 @@ set -euo pipefail
 # Executed on remote host, defaults should be set here or env vars preconfigured on remote host
 OPENJDK_VERSION=${OPENJDK_VERSION:-"21"}
 # renovate: datasource=github-releases depName=camunda/camunda versioning=regex:^8\.8?(\.(?<patch>\d+))?$
-CAMUNDA_VERSION=${CAMUNDA_VERSION:-"8.8.21"}
-# TODO: [release-duty] adjust renovate comment to bump the minor version to the new stable release
+CAMUNDA_VERSION=${CAMUNDA_VERSION:-"8.8.22"}
 # renovate: datasource=github-releases depName=camunda/connectors versioning=regex:^8\.8?(\.(?<patch>\d+))?$
 CAMUNDA_CONNECTORS_VERSION=${CAMUNDA_CONNECTORS_VERSION:-"8.8.10"}
 

--- a/generic/compute/debian/procedure/camunda-install.sh
+++ b/generic/compute/debian/procedure/camunda-install.sh
@@ -11,7 +11,8 @@ set -euo pipefail
 # Executed on remote host, defaults should be set here or env vars preconfigured on remote host
 OPENJDK_VERSION=${OPENJDK_VERSION:-"21"}
 # renovate: datasource=github-releases depName=camunda/camunda versioning=regex:^8\.8?(\.(?<patch>\d+))?$
-CAMUNDA_VERSION=${CAMUNDA_VERSION:-"8.8.22"}
+CAMUNDA_VERSION=${CAMUNDA_VERSION:-"8.8.21"}
+# TODO: [release-duty] adjust renovate comment to bump the minor version to the new stable release
 # renovate: datasource=github-releases depName=camunda/connectors versioning=regex:^8\.8?(\.(?<patch>\d+))?$
 CAMUNDA_CONNECTORS_VERSION=${CAMUNDA_CONNECTORS_VERSION:-"8.8.10"}
 
@@ -20,6 +21,30 @@ USERNAME=${USERNAME:-"camunda"}
 JAVA_OPTS="${JAVA_OPTS:- -Xmx512m}" # Default Java options, required to run commands as remote user
 CAMUNDA_SNAPSHOT_VERSION=""
 CONNECTORS_SNAPSHOT_VERSION=""
+
+CAMUNDA_DISTRO_USER=${CAMUNDA_DISTRO_USER:-""}
+CAMUNDA_DISTRO_PASSWORD=${CAMUNDA_DISTRO_PASSWORD:-""}
+
+# Read credentials from temp file if present (written by all-in-one-install.sh)
+CAMUNDA_DISTRO_CRED_FILE="/tmp/.camunda-distro-credentials"
+if [[ -f "${CAMUNDA_DISTRO_CRED_FILE}" ]]; then
+    CAMUNDA_DISTRO_USER=$(sed -n '1p' "${CAMUNDA_DISTRO_CRED_FILE}")
+    CAMUNDA_DISTRO_PASSWORD=$(sed -n '2p' "${CAMUNDA_DISTRO_CRED_FILE}")
+    rm -f "${CAMUNDA_DISTRO_CRED_FILE}"
+fi
+
+CURL_AUTH_OPTS=()
+CURL_NETRC_FILE=""
+if [[ -n "${CAMUNDA_DISTRO_USER}" && -n "${CAMUNDA_DISTRO_PASSWORD}" ]]; then
+    echo "[INFO] Artifactory authentication credentials are configured."
+    CURL_NETRC_FILE=$(mktemp)
+    chmod 600 "${CURL_NETRC_FILE}"
+    printf 'machine artifacts.camunda.com login %s password %s\n' "${CAMUNDA_DISTRO_USER}" "${CAMUNDA_DISTRO_PASSWORD}" > "${CURL_NETRC_FILE}"
+    CURL_AUTH_OPTS=(--netrc-file "${CURL_NETRC_FILE}")
+    trap 'rm -f "${CURL_NETRC_FILE}"' EXIT
+else
+    echo "[WARN] No Artifactory authentication credentials configured. Downloads may fail for Enterprise artifacts."
+fi
 
 # Check that the operating system is Debian-based
 if ! grep -qE "ID=(debian|ubuntu)" /etc/os-release && ! grep -q "ID_LIKE=.*debian" /etc/os-release; then
@@ -65,7 +90,7 @@ sudo chown -R "${USERNAME}:${USERNAME}" "${MNT_DIR}/"
 
 if [[ "${CAMUNDA_VERSION}" =~ "SNAPSHOT" ]]; then
     echo "[INFO] Fetching the latest snapshot version of Camunda ${CAMUNDA_VERSION}."
-    CAMUNDA_SNAPSHOT_VERSION=$(curl -s "https://artifacts.camunda.com/artifactory/zeebe/io/camunda/camunda-zeebe/${CAMUNDA_VERSION}/maven-metadata.xml" | grep -A 1 "<extension>tar.gz</extension>" | \
+    CAMUNDA_SNAPSHOT_VERSION=$(curl -sfL "${CURL_AUTH_OPTS[@]}" "https://artifacts.camunda.com/artifactory/zeebe/io/camunda/camunda-zeebe/${CAMUNDA_VERSION}/maven-metadata.xml" | grep -A 1 "<extension>tar.gz</extension>" | \
         grep "<value>" | \
         sed -e 's/<[^>]*>//g' -e 's/^[ \t]*//')
     echo "[INFO] Latest snapshot version is ${CAMUNDA_SNAPSHOT_VERSION}."
@@ -73,10 +98,18 @@ fi
 
 if [[ "${CAMUNDA_CONNECTORS_VERSION}" =~ "SNAPSHOT" ]]; then
     echo "[INFO] Fetching the latest snapshot version of Camunda Connectors ${CAMUNDA_CONNECTORS_VERSION}."
-    CONNECTORS_SNAPSHOT_VERSION=$(curl -s "https://artifacts.camunda.com/artifactory/connectors-snapshots/io/camunda/connector/connector-runtime-bundle/${CAMUNDA_CONNECTORS_VERSION}/maven-metadata.xml" | grep -A 1 "<extension>pom</extension>" | \
+    CONNECTORS_SNAPSHOT_VERSION=$(curl -sfL "${CURL_AUTH_OPTS[@]}" "https://artifacts.camunda.com/artifactory/connectors-snapshots/io/camunda/connector/connector-runtime-bundle/${CAMUNDA_CONNECTORS_VERSION}/maven-metadata.xml" | grep -A 1 "<extension>pom</extension>" | \
         grep "<value>" | \
         sed -e 's/<[^>]*>//g' -e 's/^[ \t]*//')
     echo "[INFO] Latest snapshot version is ${CONNECTORS_SNAPSHOT_VERSION}."
+fi
+
+CURL_NETRC_OPT=""
+if [[ -n "${CURL_NETRC_FILE}" ]]; then
+    # Ensure netrc file is accessible by the camunda user in the sudo heredoc below
+    sudo chown "${USERNAME}" "${CURL_NETRC_FILE}"
+    sudo chmod 600 "${CURL_NETRC_FILE}"
+    CURL_NETRC_OPT="--netrc-file ${CURL_NETRC_FILE}"
 fi
 
 sudo -u "${USERNAME}" bash <<EOF
@@ -93,9 +126,11 @@ fi
 # Install Camunda 8
 
 if [[ "${CAMUNDA_VERSION}" =~ "SNAPSHOT" ]]; then
-    curl -L "https://artifacts.camunda.com/artifactory/zeebe/io/camunda/camunda-zeebe/${CAMUNDA_VERSION}/camunda-zeebe-${CAMUNDA_SNAPSHOT_VERSION}.tar.gz" -o "${MNT_DIR}/camunda.tar.gz"
+    # shellcheck disable=SC2086
+    curl -fL ${CURL_NETRC_OPT} "https://artifacts.camunda.com/artifactory/zeebe/io/camunda/camunda-zeebe/${CAMUNDA_VERSION}/camunda-zeebe-${CAMUNDA_SNAPSHOT_VERSION}.tar.gz" -o "${MNT_DIR}/camunda.tar.gz"
 else
-    curl -L "https://artifacts.camunda.com/artifactory/zeebe/io/camunda/camunda-zeebe/${CAMUNDA_VERSION}/camunda-zeebe-${CAMUNDA_VERSION}.tar.gz" -o "${MNT_DIR}/camunda.tar.gz"
+    # shellcheck disable=SC2086
+    curl -fL ${CURL_NETRC_OPT} "https://artifacts.camunda.com/artifactory/zeebe/io/camunda/camunda-zeebe/${CAMUNDA_VERSION}/camunda-zeebe-${CAMUNDA_VERSION}.tar.gz" -o "${MNT_DIR}/camunda.tar.gz"
 fi
 
 mkdir -p "${MNT_DIR}/camunda"
@@ -107,12 +142,14 @@ rm -rf "${MNT_DIR}/camunda.tar.gz"
 mkdir -p "${MNT_DIR}/connectors/"
 
 if [[ "${CAMUNDA_CONNECTORS_VERSION}" =~ "SNAPSHOT" ]]; then
-    curl -L "https://artifacts.camunda.com/artifactory/connectors-snapshots/io/camunda/connector/connector-runtime-bundle/${CAMUNDA_CONNECTORS_VERSION}/connector-runtime-bundle-${CONNECTORS_SNAPSHOT_VERSION}-with-dependencies.jar" -o "${MNT_DIR}/connectors/connectors.jar"
+    # shellcheck disable=SC2086
+    curl -fL ${CURL_NETRC_OPT} "https://artifacts.camunda.com/artifactory/connectors-snapshots/io/camunda/connector/connector-runtime-bundle/${CAMUNDA_CONNECTORS_VERSION}/connector-runtime-bundle-${CONNECTORS_SNAPSHOT_VERSION}-with-dependencies.jar" -o "${MNT_DIR}/connectors/connectors.jar"
 else
-    curl -L "https://artifacts.camunda.com/artifactory/connectors/io/camunda/connector/connector-runtime-bundle/${CAMUNDA_CONNECTORS_VERSION}/connector-runtime-bundle-${CAMUNDA_CONNECTORS_VERSION}-with-dependencies.jar" -o "${MNT_DIR}/connectors/connectors.jar"
+    # shellcheck disable=SC2086
+    curl -fL ${CURL_NETRC_OPT} "https://artifacts.camunda.com/artifactory/connectors/io/camunda/connector/connector-runtime-bundle/${CAMUNDA_CONNECTORS_VERSION}/connector-runtime-bundle-${CAMUNDA_CONNECTORS_VERSION}-with-dependencies.jar" -o "${MNT_DIR}/connectors/connectors.jar"
 fi
 
-curl -L https://raw.githubusercontent.com/camunda/connectors/main/bundle/default-bundle/start.sh -o "${MNT_DIR}/connectors/start.sh"
+curl -fL https://raw.githubusercontent.com/camunda/connectors/main/bundle/default-bundle/start.sh -o "${MNT_DIR}/connectors/start.sh"
 chmod +x "${MNT_DIR}/connectors/start.sh"
 
 # shellcheck disable=SC2016

--- a/generic/compute/debian/procedure/camunda-install.sh
+++ b/generic/compute/debian/procedure/camunda-install.sh
@@ -41,7 +41,10 @@ if [[ -n "${CAMUNDA_DISTRO_USER}" && -n "${CAMUNDA_DISTRO_PASSWORD}" ]]; then
     chmod 600 "${CURL_NETRC_FILE}"
     printf 'machine artifacts.camunda.com login %s password %s\n' "${CAMUNDA_DISTRO_USER}" "${CAMUNDA_DISTRO_PASSWORD}" > "${CURL_NETRC_FILE}"
     CURL_AUTH_OPTS=(--netrc-file "${CURL_NETRC_FILE}")
-    trap 'rm -f "${CURL_NETRC_FILE}"' EXIT
+    # Use sudo because ownership of the netrc file is later transferred to the
+    # camunda user (see chown below); without sudo, rm would fail due to the
+    # /tmp sticky bit and the EXIT trap would propagate a non-zero exit code.
+    trap 'sudo rm -f "${CURL_NETRC_FILE}" || true' EXIT
 else
     echo "[WARN] No Artifactory authentication credentials configured. Downloads may fail for Enterprise artifacts."
 fi
@@ -141,12 +144,14 @@ rm -rf "${MNT_DIR}/camunda.tar.gz"
 
 mkdir -p "${MNT_DIR}/connectors/"
 
+# --fail-with-body (instead of -f) keeps the response body on HTTP error so the
+# Artifactory error message (e.g. 401/403 JSON) is visible in CI logs.
 if [[ "${CAMUNDA_CONNECTORS_VERSION}" =~ "SNAPSHOT" ]]; then
     # shellcheck disable=SC2086
-    curl -fL ${CURL_NETRC_OPT} "https://artifacts.camunda.com/artifactory/connectors-snapshots/io/camunda/connector/connector-runtime-bundle/${CAMUNDA_CONNECTORS_VERSION}/connector-runtime-bundle-${CONNECTORS_SNAPSHOT_VERSION}-with-dependencies.jar" -o "${MNT_DIR}/connectors/connectors.jar"
+    curl -L --fail-with-body --show-error -w "[INFO] connectors download: HTTP %{http_code} (%{size_download} bytes)\n" ${CURL_NETRC_OPT} "https://artifacts.camunda.com/artifactory/connectors-snapshots/io/camunda/connector/connector-runtime-bundle/${CAMUNDA_CONNECTORS_VERSION}/connector-runtime-bundle-${CONNECTORS_SNAPSHOT_VERSION}-with-dependencies.jar" -o "${MNT_DIR}/connectors/connectors.jar" || { echo "[FAIL] connectors download failed; response body:"; cat "${MNT_DIR}/connectors/connectors.jar" 2>/dev/null | head -c 4096; echo; exit 1; }
 else
     # shellcheck disable=SC2086
-    curl -fL ${CURL_NETRC_OPT} "https://artifacts.camunda.com/artifactory/connectors/io/camunda/connector/connector-runtime-bundle/${CAMUNDA_CONNECTORS_VERSION}/connector-runtime-bundle-${CAMUNDA_CONNECTORS_VERSION}-with-dependencies.jar" -o "${MNT_DIR}/connectors/connectors.jar"
+    curl -L --fail-with-body --show-error -w "[INFO] connectors download: HTTP %{http_code} (%{size_download} bytes)\n" ${CURL_NETRC_OPT} "https://artifacts.camunda.com/artifactory/connectors/io/camunda/connector/connector-runtime-bundle/${CAMUNDA_CONNECTORS_VERSION}/connector-runtime-bundle-${CAMUNDA_CONNECTORS_VERSION}-with-dependencies.jar" -o "${MNT_DIR}/connectors/connectors.jar" || { echo "[FAIL] connectors download failed; response body:"; cat "${MNT_DIR}/connectors/connectors.jar" 2>/dev/null | head -c 4096; echo; exit 1; }
 fi
 
 curl -fL https://raw.githubusercontent.com/camunda/connectors/main/bundle/default-bundle/start.sh -o "${MNT_DIR}/connectors/start.sh"


### PR DESCRIPTION
This pull request enhances the Camunda installation process to support authenticated downloads of enterprise artifacts from Artifactory, particularly in CI environments. It introduces secure handling of credentials, integrates Vault-based secret retrieval in GitHub Actions, and updates installation scripts to use these credentials for authenticated `curl` requests. Additionally, it improves error handling and logging for artifact downloads.

**CI/CD pipeline enhancements:**

* Added a GitHub Actions step to fetch Artifactory credentials from Vault and expose them as outputs, which are then passed as environment variables to the installation process (`.github/workflows/aws_compute_ec2_single_region_tests.yml`). [[1]](diffhunk://#diff-98dfacd717ad0b252b5c9fa6b989f65f2f45a4579cfe626c1f4c9607cb26265eR201-R213) [[2]](diffhunk://#diff-98dfacd717ad0b252b5c9fa6b989f65f2f45a4579cfe626c1f4c9607cb26265eR260-R261)

**Secure credential handling:**

* Updated `all-in-one-install.sh` to accept and securely transfer Artifactory credentials to remote hosts, writing them to a temporary file with restricted permissions for use during installation (`aws/compute/ec2-single-region/procedure/all-in-one-install.sh`). [[1]](diffhunk://#diff-13442ef59b7e9acd001cdb66de50207b493b9d3187700059fca2706ab4fd6d89R15-R17) [[2]](diffhunk://#diff-13442ef59b7e9acd001cdb66de50207b493b9d3187700059fca2706ab4fd6d89R77-R86)

**Installation script improvements:**

* Modified `camunda-install.sh` to read credentials from the temporary file, configure `curl` to use a `.netrc` file for authentication, and clean up sensitive files after use. Added warnings when credentials are missing and improved download commands to show HTTP status and error bodies for easier troubleshooting (`generic/compute/debian/procedure/camunda-install.sh`). [[1]](diffhunk://#diff-43abb95fe70d3ec7faf40933f6512e88ad8749bf79429aa88478fea9a5b555c9R25-R51) [[2]](diffhunk://#diff-43abb95fe70d3ec7faf40933f6512e88ad8749bf79429aa88478fea9a5b555c9L68-R117) [[3]](diffhunk://#diff-43abb95fe70d3ec7faf40933f6512e88ad8749bf79429aa88478fea9a5b555c9L96-R136) [[4]](diffhunk://#diff-43abb95fe70d3ec7faf40933f6512e88ad8749bf79429aa88478fea9a5b555c9R147-R157)

**Other changes:**

* Downgraded the default `CAMUNDA_VERSION` to `8.8.21` with a note to update for future releases (`generic/compute/debian/procedure/camunda-install.sh`).