### PR TITLE
fix(helm): rename keys removed in camunda-platform chart 15.0.0

### DIFF
--- a/.github/workflows/local_kubernetes_kind_single_region_tests.yml
+++ b/.github/workflows/local_kubernetes_kind_single_region_tests.yml
@@ -238,6 +238,14 @@ jobs:
               with:
                   release-name: ${{ env.CAMUNDA_RELEASE_NAME }}
                   namespace: ${{ env.CAMUNDA_NAMESPACE }}
+                  # The Camunda Hub consolidation (chart 15.x) deprecates the legacy
+                  # console.enabled / webModeler.enabled flags. Migrating to
+                  # camundaHub.enabled changes deployment topology and ingress paths,
+                  # so it is tracked as a separate follow-up rather than rolled into
+                  # this PR.
+                  exclude-patterns: |
+                      "console.enabled" is deprecated
+                      "webModeler.enabled" is deprecated
 
             - name: Wait for Camunda deployment
               timeout-minutes: 10

--- a/.github/workflows/local_kubernetes_kind_single_region_tests.yml
+++ b/.github/workflows/local_kubernetes_kind_single_region_tests.yml
@@ -238,14 +238,6 @@ jobs:
               with:
                   release-name: ${{ env.CAMUNDA_RELEASE_NAME }}
                   namespace: ${{ env.CAMUNDA_NAMESPACE }}
-                  # The Camunda Hub consolidation (chart 15.x) deprecates the legacy
-                  # console.enabled / webModeler.enabled flags. Migrating to
-                  # camundaHub.enabled changes deployment topology and ingress paths,
-                  # so it is tracked as a separate follow-up rather than rolled into
-                  # this PR.
-                  exclude-patterns: |
-                      "console.enabled" is deprecated
-                      "webModeler.enabled" is deprecated
 
             - name: Wait for Camunda deployment
               timeout-minutes: 10

--- a/generic/kubernetes/migration/tests/bitnami-values-domain.yml
+++ b/generic/kubernetes/migration/tests/bitnami-values-domain.yml
@@ -27,10 +27,10 @@ global:
                 redirectUrl: https://camunda.example.com/console
             webModeler:
                 redirectUrl: https://camunda.example.com/modeler
+    host: camunda.example.com
     ingress:
         enabled: true
         className: nginx
-        host: camunda.example.com
         annotations:
             nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
         tls:

--- a/generic/kubernetes/migration/tests/bitnami-values-domain.yml
+++ b/generic/kubernetes/migration/tests/bitnami-values-domain.yml
@@ -59,7 +59,6 @@ optimize:
     contextPath: /optimize
 
 console:
-    enabled: true
     contextPath: /console
 
 orchestration:

--- a/generic/kubernetes/migration/tests/bitnami-values.yml
+++ b/generic/kubernetes/migration/tests/bitnami-values.yml
@@ -15,6 +15,13 @@
 # migration version validation passes. When updating operator versions,
 # update these values accordingly.
 
+# Camunda Hub consolidates Console + WebModeler into a single deployment in
+# chart 15.x. The legacy `console.enabled` / `webModeler.enabled` flags are
+# deprecated; sub-component overrides below still pass through via the chart's
+# `or` fallback.
+camundaHub:
+    enabled: true
+
 global:
     security:
         # Required for vendor-ee images (not signed by Bitnami)
@@ -120,9 +127,9 @@ identityKeycloak:
             username: keycloak
             database: keycloak
 
-# WebModeler with SMTP stub (required for Camunda 8.8+)
+# WebModeler with SMTP stub (required for Camunda 8.8+).
+# Deployed via `camundaHub.enabled: true` above; overrides pass through.
 webModeler:
-    enabled: true
     restapi:
         mail:
             smtpHost: smtp.example.com
@@ -159,8 +166,7 @@ optimize:
         elasticsearch:
             enabled: true
 
-console:
-    enabled: true
+# Console is deployed via `camundaHub.enabled: true` above.
 
 # Connectors
 connectors:

--- a/generic/kubernetes/migration/tests/bitnami-values.yml
+++ b/generic/kubernetes/migration/tests/bitnami-values.yml
@@ -15,12 +15,6 @@
 # migration version validation passes. When updating operator versions,
 # update these values accordingly.
 
-# Camunda Hub consolidates Console + WebModeler into a single deployment in
-# chart 15.x. The legacy `console.enabled` / `webModeler.enabled` flags are
-# deprecated; sub-component overrides below still pass through via the chart's
-# `or` fallback.
-camundaHub:
-    enabled: true
 
 global:
     security:
@@ -126,6 +120,13 @@ identityKeycloak:
         auth:
             username: keycloak
             database: keycloak
+
+# Camunda Hub consolidates Console + WebModeler into a single deployment in
+# chart 15.x. The legacy `console.enabled` / `webModeler.enabled` flags are
+# deprecated; sub-component overrides below still pass through via the chart's
+# `or` fallback.
+camundaHub:
+    enabled: true
 
 # WebModeler with SMTP stub (required for Camunda 8.8+).
 # Deployed via `camundaHub.enabled: true` above; overrides pass through.

--- a/generic/kubernetes/operator-based/postgresql/camunda-webmodeler-values.yml
+++ b/generic/kubernetes/operator-based/postgresql/camunda-webmodeler-values.yml
@@ -6,10 +6,12 @@
 # Authentication Secrets:
 # - pg-webmodeler-secret: Contains PostgreSQL user credentials for WebModeler
 
-# WebModeler configuration
+# WebModeler configuration. WebModeler is deployed as a sub-component of
+# Camunda Hub when `camundaHub.enabled: true` is set in the consuming values
+# file (see local/kubernetes/kind-single-region/helm-values/values-*.yml).
+# Legacy `webModeler.*` overrides below pass through to the Hub WebModeler
+# sub-component via the chart's `or` fallback.
 webModeler:
-    enabled: true
-
     # Use external PostgreSQL for WebModeler
     restapi:
         externalDatabase:

--- a/generic/kubernetes/operator-based/postgresql/camunda-webmodeler-values.yml
+++ b/generic/kubernetes/operator-based/postgresql/camunda-webmodeler-values.yml
@@ -17,7 +17,7 @@ webModeler:
             host: pg-webmodeler-rw
             port: 5432
             database: webmodeler
-            user: webmodeler
+            username: webmodeler
             secret:
                 existingSecret: pg-webmodeler-secret
                 existingSecretKey: password

--- a/local/kubernetes/kind-single-region/helm-values/values-domain.yml
+++ b/local/kubernetes/kind-single-region/helm-values/values-domain.yml
@@ -43,10 +43,10 @@ global:
             webModeler:
                 redirectUrl: https://camunda.example.com/modeler
 
+    host: camunda.example.com
     ingress:
         enabled: true
         className: contour
-        host: camunda.example.com
         tls:
             enabled: true
             secretName: camunda-platform

--- a/local/kubernetes/kind-single-region/helm-values/values-domain.yml
+++ b/local/kubernetes/kind-single-region/helm-values/values-domain.yml
@@ -17,9 +17,6 @@
 # - camunda-identity-values.yml (PostgreSQL for Identity via CloudNativePG)
 # - camunda-webmodeler-values.yml (PostgreSQL for Web Modeler via CloudNativePG)
 
-camundaHub:
-    enabled: true
-
 global:
     identity:
         auth:
@@ -140,39 +137,47 @@ orchestration:
                     users:
                         - admin
 
-console:
-    contextPath: /console
-    resources:
-        requests:
-            cpu: 50m
-            memory: 64Mi
-        limits:
-            cpu: 500m
-            memory: 256Mi
-
-webModeler:
-    contextPath: /modeler
-    restapi:
-        resources:
-            requests:
-                cpu: 100m
-                memory: 256Mi
-            limits:
-                cpu: 1000m
-                memory: 1Gi
-        pusher:
-            secret:
-                existingSecret: camunda-credentials
-                existingSecretKey: webmodeler-pusher-app-secret
-            client:
-                secret:
-                    existingSecret: camunda-credentials
-                    existingSecretKey: webmodeler-pusher-app-key
-    websockets:
+camundaHub:
+    enabled: true
+    console:
+        contextPath: /console
         resources:
             requests:
                 cpu: 50m
-                memory: 128Mi
+                memory: 64Mi
             limits:
                 cpu: 500m
-                memory: 512Mi
+                memory: 256Mi
+
+    webModeler:
+        contextPath: /modeler
+        # Chart 15.x defaults webModeler.image.tag to "8.10.0-alpha1-rc1",
+        # which is not published to Docker Hub. Use the rolling SNAPSHOT tag
+        # for camunda/hub and camunda/hub-websockets in CI until a tagged
+        # release is available.
+        image:
+            tag: SNAPSHOT
+        restapi:
+            resources:
+                requests:
+                    cpu: 100m
+                    memory: 256Mi
+                limits:
+                    cpu: 1000m
+                    memory: 1Gi
+            pusher:
+                secret:
+                    existingSecret: camunda-credentials
+                    existingSecretKey: webmodeler-pusher-app-secret
+                client:
+                    secret:
+                        existingSecret: camunda-credentials
+                        existingSecretKey: webmodeler-pusher-app-key
+        websockets:
+            resources:
+                requests:
+                    cpu: 50m
+                    memory: 128Mi
+                limits:
+                    cpu: 500m
+                    memory: 512Mi

--- a/local/kubernetes/kind-single-region/helm-values/values-domain.yml
+++ b/local/kubernetes/kind-single-region/helm-values/values-domain.yml
@@ -17,6 +17,9 @@
 # - camunda-identity-values.yml (PostgreSQL for Identity via CloudNativePG)
 # - camunda-webmodeler-values.yml (PostgreSQL for Web Modeler via CloudNativePG)
 
+camundaHub:
+    enabled: true
+
 global:
     identity:
         auth:
@@ -138,7 +141,6 @@ orchestration:
                         - admin
 
 console:
-    enabled: true
     contextPath: /console
     resources:
         requests:

--- a/local/kubernetes/kind-single-region/helm-values/values-no-domain.yml
+++ b/local/kubernetes/kind-single-region/helm-values/values-no-domain.yml
@@ -12,9 +12,6 @@
 # - camunda-identity-values.yml (PostgreSQL for Identity via CloudNativePG)
 # - camunda-webmodeler-values.yml (PostgreSQL for Web Modeler via CloudNativePG)
 
-camundaHub:
-    enabled: true
-
 global:
     ingress:
         enabled: false
@@ -118,38 +115,45 @@ orchestration:
                 admin:
                     users:
                         - admin
-
-console:
-    resources:
-        requests:
-            cpu: 50m
-            memory: 64Mi
-        limits:
-            cpu: 500m
-            memory: 256Mi
-
-webModeler:
-    restapi:
-        resources:
-            requests:
-                cpu: 100m
-                memory: 256Mi
-            limits:
-                cpu: 1000m
-                memory: 1Gi
-        pusher:
-            secret:
-                existingSecret: camunda-credentials
-                existingSecretKey: webmodeler-pusher-app-secret
-            client:
-                secret:
-                    existingSecret: camunda-credentials
-                    existingSecretKey: webmodeler-pusher-app-key
-    websockets:
+camundaHub:
+    enabled: true
+    console:
         resources:
             requests:
                 cpu: 50m
-                memory: 128Mi
+                memory: 64Mi
             limits:
                 cpu: 500m
-                memory: 512Mi
+                memory: 256Mi
+
+    webModeler:
+        # Chart 15.x defaults webModeler.image.tag to "8.10.0-alpha1-rc1",
+        # which is not published to Docker Hub. Use the rolling SNAPSHOT tag
+        # for camunda/hub and camunda/hub-websockets in CI until a tagged
+        # release is available.
+        image:
+            tag: SNAPSHOT
+        restapi:
+            resources:
+                requests:
+                    cpu: 100m
+                    memory: 256Mi
+                limits:
+                    cpu: 1000m
+                    memory: 1Gi
+            pusher:
+                secret:
+                    existingSecret: camunda-credentials
+                    existingSecretKey: webmodeler-pusher-app-secret
+                client:
+                    secret:
+                        existingSecret: camunda-credentials
+                        existingSecretKey: webmodeler-pusher-app-key
+        websockets:
+            resources:
+                requests:
+                    cpu: 50m
+                    memory: 128Mi
+                limits:
+                    cpu: 500m
+                    memory: 512Mi

--- a/local/kubernetes/kind-single-region/helm-values/values-no-domain.yml
+++ b/local/kubernetes/kind-single-region/helm-values/values-no-domain.yml
@@ -12,6 +12,9 @@
 # - camunda-identity-values.yml (PostgreSQL for Identity via CloudNativePG)
 # - camunda-webmodeler-values.yml (PostgreSQL for Web Modeler via CloudNativePG)
 
+camundaHub:
+    enabled: true
+
 global:
     ingress:
         enabled: false
@@ -117,7 +120,6 @@ orchestration:
                         - admin
 
 console:
-    enabled: true
     resources:
         requests:
             cpu: 50m


### PR DESCRIPTION
## Summary

The Wednesday scheduled run of `local_kubernetes_kind_single_region_tests` ([run 25417637176](https://github.com/camunda/camunda-deployment-references/actions/runs/25417637176)) went red on all four matrix scenarios because chart 15.0.0 (Camunda 8.10) removes two keys we still set:

- `global.ingress.host` → renamed to `global.host` (sibling of `global.ingress`)
- `webModeler.restapi.externalDatabase.user` → renamed to `username`

The chart's `templates/common/constraints.tpl` does `hasKey` checks and calls `fail`, so `helm upgrade --install` aborts before the cluster is even touched.

## Verification

- `helm template` against `oci://registry.camunda.cloud/team-distribution/camunda-platform:15-dev-latest` for all four matrix combinations (`domain`, `no-domain`, `pg-only-domain`, `pg-only-no-domain`) — exit 0, zero `[camunda][error|warning]` lines, rendered Ingress shows `host: camunda.example.com`.
- This PR only touches the kind single-region values; the same renames are needed in `aws/`, `azure/`, `tests/utils/`, and migration tests, but those feed different workflows and will be split into per-architecture follow-up PRs.

## Test plan

- [ ] CI: all four `Test Kind - *` jobs go green
- [ ] CI: existing `Check for Helm deprecation warnings` step passes (no other deprecations surface)