### PR TITLE
fix(helm): roll chart 15.0.0 key renames across aws/azure/generic

### DIFF
--- a/aws/kubernetes/eks-single-region-irsa/helm-values/values-domain.yml
+++ b/aws/kubernetes/eks-single-region-irsa/helm-values/values-domain.yml
@@ -26,13 +26,13 @@ global:
             host: ${OPENSEARCH_HOST}
             port: 443
 
+    host: ${CAMUNDA_DOMAIN}
     security:
         authentication:
             method: oidc
 
     ingress:
         enabled: true
-        host: ${CAMUNDA_DOMAIN}
         tls:
             enabled: true
             secretName: camunda-c8-tls
@@ -162,7 +162,7 @@ webModeler:
     restapi:
         externalDatabase:
             url: jdbc:aws-wrapper:postgresql://${DB_HOST}:${DB_PORT}/${DB_WEBMODELER_NAME}?wrapperPlugins=iam
-            user: ${DB_WEBMODELER_USERNAME}
+            username: ${DB_WEBMODELER_USERNAME}
             secret:
                 existingSecret: webmodeler-postgres-secret # fake password needed for chart (IRSA uses IAM auth)
                 existingSecretKey: password

--- a/aws/kubernetes/eks-single-region-irsa/helm-values/values-no-domain.yml
+++ b/aws/kubernetes/eks-single-region-irsa/helm-values/values-no-domain.yml
@@ -125,7 +125,7 @@ webModeler:
     restapi:
         externalDatabase:
             url: jdbc:aws-wrapper:postgresql://${DB_HOST}:${DB_PORT}/${DB_WEBMODELER_NAME}?wrapperPlugins=iam
-            user: ${DB_WEBMODELER_USERNAME}
+            username: ${DB_WEBMODELER_USERNAME}
             secret:
                 existingSecret: webmodeler-postgres-secret # fake password needed for chart (IRSA uses IAM auth)
                 existingSecretKey: password

--- a/aws/kubernetes/eks-single-region/helm-values/values-domain.yml
+++ b/aws/kubernetes/eks-single-region/helm-values/values-domain.yml
@@ -11,13 +11,13 @@
 #   - OPENSEARCH_HOST: OpenSearch endpoint
 
 global:
+    host: ${CAMUNDA_DOMAIN}
     security:
         authentication:
             method: oidc
 
     ingress:
         enabled: true
-        host: ${CAMUNDA_DOMAIN}
         tls:
             enabled: true
             secretName: camunda-c8-tls
@@ -124,7 +124,7 @@ webModeler:
     restapi:
         externalDatabase:
             url: jdbc:aws-wrapper:postgresql://${DB_HOST}:${DB_PORT}/${DB_WEBMODELER_NAME}
-            user: ${DB_WEBMODELER_USERNAME}
+            username: ${DB_WEBMODELER_USERNAME}
             secret:
                 existingSecret: webmodeler-postgres-secret
                 existingSecretKey: password

--- a/aws/kubernetes/eks-single-region/helm-values/values-no-domain.yml
+++ b/aws/kubernetes/eks-single-region/helm-values/values-no-domain.yml
@@ -70,7 +70,7 @@ webModeler:
     restapi:
         externalDatabase:
             url: jdbc:aws-wrapper:postgresql://${DB_HOST}:${DB_PORT}/${DB_WEBMODELER_NAME}
-            user: ${DB_WEBMODELER_USERNAME}
+            username: ${DB_WEBMODELER_USERNAME}
             secret:
                 existingSecret: webmodeler-postgres-secret
                 existingSecretKey: password

--- a/azure/kubernetes/aks-single-region-rdbms/helm-values/values-domain.yml
+++ b/azure/kubernetes/aks-single-region-rdbms/helm-values/values-domain.yml
@@ -15,9 +15,9 @@
 #
 
 global:
+    host: ${CAMUNDA_DOMAIN}
     ingress:
         enabled: true
-        host: ${CAMUNDA_DOMAIN}
         tls:
             enabled: true
             secretName: camunda-c8-tls
@@ -74,7 +74,7 @@ webModeler:
         externalDatabase:
             enabled: true
             url: jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_WEBMODELER_NAME}?sslmode=require
-            user: ${DB_WEBMODELER_USERNAME}
+            username: ${DB_WEBMODELER_USERNAME}
             secret:
                 existingSecret: webmodeler-postgres-secret
                 existingSecretKey: password

--- a/azure/kubernetes/aks-single-region-rdbms/helm-values/values-no-domain.yml
+++ b/azure/kubernetes/aks-single-region-rdbms/helm-values/values-no-domain.yml
@@ -84,7 +84,7 @@ webModeler:
         externalDatabase:
             enabled: true
             url: jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_WEBMODELER_NAME}?sslmode=require
-            user: ${DB_WEBMODELER_USERNAME}
+            username: ${DB_WEBMODELER_USERNAME}
             secret:
                 existingSecret: webmodeler-postgres-secret
                 existingSecretKey: password

--- a/azure/kubernetes/aks-single-region/helm-values/values-domain.yml
+++ b/azure/kubernetes/aks-single-region/helm-values/values-domain.yml
@@ -12,9 +12,9 @@
 #
 
 global:
+    host: ${CAMUNDA_DOMAIN}
     ingress:
         enabled: true
-        host: ${CAMUNDA_DOMAIN}
         tls:
             enabled: true
             secretName: camunda-c8-tls
@@ -73,7 +73,7 @@ webModeler:
         externalDatabase:
             enabled: true
             url: jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_WEBMODELER_NAME}?sslmode=require
-            user: ${DB_WEBMODELER_USERNAME}
+            username: ${DB_WEBMODELER_USERNAME}
             secret:
                 existingSecret: webmodeler-postgres-secret
                 existingSecretKey: password

--- a/azure/kubernetes/aks-single-region/helm-values/values-no-domain.yml
+++ b/azure/kubernetes/aks-single-region/helm-values/values-no-domain.yml
@@ -67,7 +67,7 @@ webModeler:
         externalDatabase:
             enabled: true
             url: jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_WEBMODELER_NAME}?sslmode=require
-            user: ${DB_WEBMODELER_USERNAME}
+            username: ${DB_WEBMODELER_USERNAME}
             secret:
                 existingSecret: webmodeler-postgres-secret
                 existingSecretKey: password

--- a/generic/kubernetes/operator-based/tests/utils/camunda-domain-values.yml
+++ b/generic/kubernetes/operator-based/tests/utils/camunda-domain-values.yml
@@ -7,11 +7,11 @@
 # - INGRESS_CLASS_NAME: Ingress controller class (nginx for EKS, openshift-default for OpenShift)
 
 global:
+    host: ${CAMUNDA_DOMAIN}
     # Ingress configuration for external access
     ingress:
         enabled: true
         className: ${INGRESS_CLASS_NAME}
-        host: ${CAMUNDA_DOMAIN}
         tls:
             # TLS/HTTPS configuration - behavior depends on platform:
             # - EKS/Kubernetes: Uses cert-manager + Let's Encrypt for automatic certificates

--- a/generic/kubernetes/operator-based/tests/utils/camunda-no-domain-values.yml
+++ b/generic/kubernetes/operator-based/tests/utils/camunda-no-domain-values.yml
@@ -7,11 +7,11 @@
 # - INGRESS_CLASS_NAME: Ingress controller class (nginx for EKS, openshift-default for OpenShift)
 
 global:
+    host: ${CAMUNDA_DOMAIN}
     # Ingress configuration for external access
     ingress:
         enabled: true
         className: ${INGRESS_CLASS_NAME}
-        host: ${CAMUNDA_DOMAIN}
         tls:
             # TLS/HTTPS configuration - behavior depends on platform:
             # - EKS/Kubernetes: Uses cert-manager + Let's Encrypt for automatic certificates

--- a/generic/openshift/single-region/helm-values/domain.yml
+++ b/generic/openshift/single-region/helm-values/domain.yml
@@ -4,6 +4,7 @@
 # This file contains OpenShift-specific ingress configuration.
 
 global:
+    host: ${CAMUNDA_DOMAIN}
     identity:
         auth:
             identity:
@@ -19,7 +20,6 @@ global:
     ingress:
         enabled: true
         className: openshift-default
-        host: ${CAMUNDA_DOMAIN}
         tls:
             enabled: true
             # explicitly '-' as secret name as we rely on the IngressOperator to handle the TLS secret


### PR DESCRIPTION
## Summary

Follow-up to #2418, which fixed only the **kind single-region** values. The
same removed keys still existed in cloud reference architectures and would
fail every workflow pinned to chart `15-dev-latest` with `[camunda][error]`
from `templates/common/constraints.tpl`.

Two renames applied across **11 files** (15 lines):

- **`global.ingress.host` → `global.host`** — key moves out of the `ingress:` block, directly under `global:`.
  - 2 operator-based test util files (`generic/.../tests/utils/camunda-{,no-}domain-values.yml`)
  - 4 cloud `values-domain.yml` files (aws eks, eks-irsa, azure aks, aks-rdbms)
  - 1 openshift single-region domain values
  - The 5 cloud/openshift files beyond the original kind PR set were surfaced by the **defensive grep** that the follow-up plan specifically asked us to rerun before opening the PR.

- **`webModeler.restapi.externalDatabase.user` → `username`**
  - All 8 cloud values files (aws eks + eks-irsa, azure aks + aks-rdbms, both `-domain` and `-no-domain` variants).

## Verification

Ran `helm template` against chart `15-dev-latest` for each modified file:

- **Pre-fix** (origin/main) — `aws/kubernetes/eks-single-region/helm-values/values-domain.yml` produced:
  > `[camunda][error] The Helm values file key "global.ingress.host" has been removed.`
- **Post-fix** — all 11 modified files render with **zero `[camunda][error]` or `[camunda][warning]` lines**.

Defensive grep on `^\s*user:\s` and `^\s*host:\s+\S` (with ingress context) across `aws/`, `azure/`, `generic/`, `gcp/`, `local/` returns clean — no further occurrences of the deprecated keys.

## Out of scope (tracked separately)

- `console.enabled` / `webModeler.enabled` → `camundaHub.enabled` topology migration. The chart's `[camunda][warning]` for these will continue to surface in the deprecation-check PR comment for cloud workflows that flip them to `true` at runtime, but as of #2419 the check no longer fails on warnings during PR runs.
- Missing `webModeler.image.tag` / `camundaHub.image.tag` in `bitnami-values.yml` causing `ImagePullBackOff` — needs registry/chart-team coordination.

## Test plan

- [ ] CI on this PR is green
- [ ] Watch next scheduled run of `aws_kubernetes_eks_single_region_tests.yml`, `azure_kubernetes_aks_single_region_tests.yml`, and `generic_kubernetes_operator_based_test.yml` — confirm no `[camunda][error]` for the renamed keys