### PR TITLE
fix(eks): default node group AMI to AL2023 on stable/8.7 (CVE-2026-43284)

### DIFF
--- a/aws/kubernetes/eks-single-region-irsa/test/golden/tfplan-golden.json
+++ b/aws/kubernetes/eks-single-region-irsa/test/golden/tfplan-golden.json
@@ -282,7 +282,7 @@
                   },
                   "type": "aws_eks_node_group",
                   "values": {
-                    "ami_type": "AL2_x86_64",
+                    "ami_type": "AL2023_x86_64_STANDARD",
                     "capacity_type": "ON_DEMAND",
                     "disk_size": 20,
                     "force_update_version": null,

--- a/aws/kubernetes/eks-single-region/test/golden/tfplan-golden.json
+++ b/aws/kubernetes/eks-single-region/test/golden/tfplan-golden.json
@@ -282,7 +282,7 @@
                   },
                   "type": "aws_eks_node_group",
                   "values": {
-                    "ami_type": "AL2_x86_64",
+                    "ami_type": "AL2023_x86_64_STANDARD",
                     "capacity_type": "ON_DEMAND",
                     "disk_size": 20,
                     "force_update_version": null,

--- a/aws/modules/eks-cluster/README.md
+++ b/aws/modules/eks-cluster/README.md
@@ -64,7 +64,7 @@ module "eks_cluster" {
 | <a name="input_kms_key_tags"></a> [kms\_key\_tags](#input\_kms\_key\_tags) | The tags to associate with the KMS key. | `map(string)` | `{}` | no |
 | <a name="input_kubernetes_version"></a> [kubernetes\_version](#input\_kubernetes\_version) | Kubernetes version to be used by EKS | `string` | `"1.32"` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name being used for relevant resources - including EKS cluster name | `string` | n/a | yes |
-| <a name="input_np_ami_type"></a> [np\_ami\_type](#input\_np\_ami\_type) | Amazon Machine Image | `string` | `"AL2_x86_64"` | no |
+| <a name="input_np_ami_type"></a> [np\_ami\_type](#input\_np\_ami\_type) | Amazon Machine Image | `string` | `"AL2023_x86_64_STANDARD"` | no |
 | <a name="input_np_capacity_type"></a> [np\_capacity\_type](#input\_np\_capacity\_type) | Allows setting the capacity type to ON\_DEMAND or SPOT to determine stable nodes | `string` | `"ON_DEMAND"` | no |
 | <a name="input_np_desired_node_count"></a> [np\_desired\_node\_count](#input\_np\_desired\_node\_count) | Actual number of nodes for the default node pool. Min-Max will be used for autoscaling | `number` | `4` | no |
 | <a name="input_np_disk_size"></a> [np\_disk\_size](#input\_np\_disk\_size) | Disk size of the nodes on the default node pool | `number` | `20` | no |

--- a/aws/modules/eks-cluster/variables.tf
+++ b/aws/modules/eks-cluster/variables.tf
@@ -62,7 +62,7 @@ variable "np_disk_size" {
 variable "np_ami_type" {
   description = "Amazon Machine Image"
   type        = string
-  default     = "AL2_x86_64"
+  default     = "AL2023_x86_64_STANDARD"
 }
 
 variable "np_capacity_type" {


### PR DESCRIPTION
## Summary

Related to INC-5489

- Switches the EKS managed node group AMI default from `AL2_x86_64` to `AL2023_x86_64_STANDARD` in `aws/modules/eks-cluster` on `stable/8.7`.
- Updates the module README row and the two `tfplan-golden.json` files that asserted the AL2 default.

## Why

A Wiz scan on 2026-05-12 flagged **CVE-2026-43284** on a freshly-created CI EKS node group (`eks-services-…` ASG, `eu-west-2`, Infra-Experience account, m6i.xlarge). The affected kernel range is `>= 5.10.0 && < 5.10.253-252.1015.amzn2` — i.e. Amazon Linux 2 only.

Root cause: `main`, `stable/8.8`, and `stable/8.9` were moved to `AL2023_x86_64_STANDARD` by PR #568 (`94d3eda1`, 2025-06-10), but that change was never backported to `stable/8.7`. Every CI cluster spun up from `stable/8.7` (or its backport/renovate branches) therefore still creates an AL2 node group on each run.

PR #568 also bumped Kubernetes 1.32 → 1.33. That bump is intentionally **not** included here — `stable/8.7` stays on 1.32.

## Test plan

- [ ] CI green on this PR, in particular the terraform plan / golden-file tests for `eks-single-region` and `eks-single-region-irsa`.
- [ ] After merge, the next CI cluster spin-up from `stable/8.7` shows `ami_type = AL2023_x86_64_STANDARD`:
  - `aws eks describe-nodegroup --cluster-name <c> --nodegroup-name services --region eu-west-2 --query 'nodegroup.amiType'`
- [ ] Re-run the vulnerability scanner against the new nodes — CVE-2026-43284 should no longer match (AL2023 is on a 6.x kernel, outside the affected range).

🤖 Generated with [Claude Code](https://claude.com/claude-code)