### PR TITLE
fix(cleanup): sweep orphan ELBv2 target groups to relieve quota

### DIFF
--- a/.github/actions/aws-generic-terraform-cleanup/action.yml
+++ b/.github/actions/aws-generic-terraform-cleanup/action.yml
@@ -58,19 +58,7 @@ runs:
           uses: camunda/infraex-common-config/./.github/actions/asdf-install-tooling@18718a9ca7599dc71ef3624230ad624720e85ee9 # 1.6.0
 
         - name: Install Cloud Nuke for retry
-          shell: bash
-          working-directory: /tmp
-          env:
-              # renovate: datasource=github-tags depName=gruntwork-io/cloud-nuke
-              CLOUD_NUKE_VERSION: v0.49.0
-          run: |
-              curl -LO \
-                  --retry 5 \
-                  --max-time 15 \
-                  --retry-delay 30 \
-                  https://github.com/gruntwork-io/cloud-nuke/releases/download/${{ env.CLOUD_NUKE_VERSION }}/cloud-nuke_linux_amd64
-              chmod +x cloud-nuke_linux_amd64
-              mv cloud-nuke_linux_amd64 /usr/local/bin/cloud-nuke
+          uses: ./.github/actions/install-cloud-nuke
 
         - name: Install ROSA CLI
           if: ${{ inputs.openshift == 'true' }}
@@ -127,6 +115,25 @@ runs:
               if [ "${{ inputs.delete-ghost-rosa-clusters }}" == "true" ]; then
                 ${{ github.action_path }}/scripts/cleanup-ghost-rosa-clusters.sh ${{ inputs.max-age-hours }}
               fi
+
+        # Region-wide safety net: sweep ELBv2 target groups not attached to any LB.
+        # Per-VPC cleanup in destroy-resources.sh handles TGs in the cluster's VPC,
+        # but operator-managed TGs (e.g. OpenShift IngressController) can outlive
+        # the VPC and exhaust the per-region TooManyTargetGroups quota. Runs after
+        # destroy (success or failure) and is idempotent. Failures are non-fatal —
+        # orphans that survive will be caught the next day.
+        - name: Sweep orphan ELBv2 target groups
+          if: always()
+          shell: bash
+          run: |
+              set -euo pipefail
+              declare -A regions=()
+              [[ -n "${AWS_REGION:-}" ]] && regions["$AWS_REGION"]=1
+              [[ -n "${CLUSTER_0_AWS_REGION:-}" ]] && regions["$CLUSTER_0_AWS_REGION"]=1
+              [[ -n "${CLUSTER_1_AWS_REGION:-}" ]] && regions["$CLUSTER_1_AWS_REGION"]=1
+              for region in "${!regions[@]}"; do
+                ${{ github.action_path }}/scripts/nuke-orphan-target-groups.sh "$region" || true
+              done
 
         # Required for matrix jobs
         - name: Convert key prefix into slug

--- a/.github/actions/aws-generic-terraform-cleanup/action.yml
+++ b/.github/actions/aws-generic-terraform-cleanup/action.yml
@@ -127,13 +127,17 @@ runs:
           shell: bash
           run: |
               set -euo pipefail
-              declare -A regions=()
-              [[ -n "${AWS_REGION:-}" ]] && regions["$AWS_REGION"]=1
-              [[ -n "${CLUSTER_0_AWS_REGION:-}" ]] && regions["$CLUSTER_0_AWS_REGION"]=1
-              [[ -n "${CLUSTER_1_AWS_REGION:-}" ]] && regions["$CLUSTER_1_AWS_REGION"]=1
-              for region in "${!regions[@]}"; do
+              regions=$(
+                printf '%s\n%s\n%s\n' \
+                  "${AWS_REGION:-}" \
+                  "${CLUSTER_0_AWS_REGION:-}" \
+                  "${CLUSTER_1_AWS_REGION:-}" \
+                  | grep -v '^$' | sort -u
+              )
+              while IFS= read -r region; do
+                [[ -z "$region" ]] && continue
                 ${{ github.action_path }}/scripts/nuke-orphan-target-groups.sh "$region" || true
-              done
+              done <<< "$regions"
 
         # Required for matrix jobs
         - name: Convert key prefix into slug

--- a/.github/actions/aws-generic-terraform-cleanup/scripts/destroy-resources.sh
+++ b/.github/actions/aws-generic-terraform-cleanup/scripts/destroy-resources.sh
@@ -83,6 +83,21 @@ cleanup_vpc_dependencies() {
     sleep 30
   fi
 
+  # 1b. Delete ELBv2 Target Groups in this VPC.
+  # AWS does not cascade-delete TGs when their LB is removed, so they pile up
+  # and eventually exhaust the per-region TooManyTargetGroups quota.
+  # TGs still attached to a live LB return ResourceInUse and are silently skipped.
+  local tg_arns
+  tg_arns=$(aws elbv2 describe-target-groups \
+    --query "TargetGroups[?VpcId=='${vpc_id}'].TargetGroupArn" \
+    --output text --region "$region" 2>/dev/null)
+  if [[ -n "$tg_arns" && "$tg_arns" != "None" ]]; then
+    for tg_arn in $tg_arns; do
+      echo "  Deleting Target Group: $tg_arn"
+      aws elbv2 delete-target-group --target-group-arn "$tg_arn" --region "$region" 2>/dev/null || true
+    done
+  fi
+
   # 2. Delete Classic Load Balancers
   local clb_names
   clb_names=$(aws elb describe-load-balancers \

--- a/.github/actions/aws-generic-terraform-cleanup/scripts/nuke-orphan-target-groups.sh
+++ b/.github/actions/aws-generic-terraform-cleanup/scripts/nuke-orphan-target-groups.sh
@@ -47,8 +47,9 @@ list_orphans() {
 }
 
 echo "Listing ELBv2 target groups in ${REGION} (pass 1)..."
-mapfile -t pass1 < <(list_orphans)
-pass1_count=${#pass1[@]}
+pass1="$(list_orphans)"
+pass1_count=0
+[[ -n "$pass1" ]] && pass1_count=$(printf '%s\n' "$pass1" | wc -l | tr -d ' ')
 echo "Pass 1: ${pass1_count} orphan target group(s)."
 
 if [[ $pass1_count -eq 0 ]]; then
@@ -59,22 +60,40 @@ echo "Waiting ${SETTLE_SECONDS}s before re-checking to avoid deleting TGs mid-at
 sleep "$SETTLE_SECONDS"
 
 echo "Listing ELBv2 target groups in ${REGION} (pass 2)..."
-mapfile -t pass2 < <(list_orphans)
-declare -A still_orphan=()
-for arn in "${pass2[@]}"; do
-    still_orphan["$arn"]=1
-done
+pass2="$(list_orphans)"
 
-confirmed=()
-for arn in "${pass1[@]}"; do
-    if [[ -n "${still_orphan[$arn]:-}" ]]; then
-        confirmed+=("$arn")
-    else
-        echo "Skipping ${arn} — attached to an LB during the settle window."
+# Confirmed = intersection of pass1 and pass2 (newline-separated lists).
+# Avoids bash 4-only features (mapfile, associative arrays) so the script
+# runs on macOS bash 3.2 as well as the Linux runners used by CI.
+confirmed="$(
+    if [[ -n "$pass1" && -n "$pass2" ]]; then
+        comm -12 \
+            <(printf '%s\n' "$pass1" | sort -u) \
+            <(printf '%s\n' "$pass2" | sort -u)
     fi
-done
+)"
 
-total=${#confirmed[@]}
+# Log TGs that recovered (in pass1 but not in pass2).
+if [[ -n "$pass1" ]]; then
+    healed="$(
+        if [[ -n "$pass2" ]]; then
+            comm -23 \
+                <(printf '%s\n' "$pass1" | sort -u) \
+                <(printf '%s\n' "$pass2" | sort -u)
+        else
+            printf '%s\n' "$pass1" | sort -u
+        fi
+    )"
+    if [[ -n "$healed" ]]; then
+        while IFS= read -r arn; do
+            [[ -z "$arn" ]] && continue
+            echo "Skipping ${arn} — attached to an LB during the settle window."
+        done <<< "$healed"
+    fi
+fi
+
+total=0
+[[ -n "$confirmed" ]] && total=$(printf '%s\n' "$confirmed" | wc -l | tr -d ' ')
 echo "Confirmed orphan target group(s) in ${REGION}: ${total}"
 
 if [[ $total -eq 0 ]]; then
@@ -83,7 +102,8 @@ fi
 
 deleted=0
 skipped=0
-for tg_arn in "${confirmed[@]}"; do
+while IFS= read -r tg_arn; do
+    [[ -z "$tg_arn" ]] && continue
     if [[ "$DRY_RUN" == "true" ]]; then
         echo "[DRY RUN] Would delete: $tg_arn"
         continue
@@ -97,6 +117,6 @@ for tg_arn in "${confirmed[@]}"; do
         echo "Skipped (delete failed): $tg_arn — $(cat /tmp/tg-delete-err)"
         skipped=$((skipped + 1))
     fi
-done
+done <<< "$confirmed"
 
 echo "Done in ${REGION}: deleted=${deleted}, skipped=${skipped}, total=${total}"

--- a/.github/actions/aws-generic-terraform-cleanup/scripts/nuke-orphan-target-groups.sh
+++ b/.github/actions/aws-generic-terraform-cleanup/scripts/nuke-orphan-target-groups.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+# Sweep orphan ELBv2 target groups in a region.
+#
+# A target group is "orphan" when it is not attached to any load balancer.
+# AWS does not cascade-delete target groups when their parent load balancer
+# is removed, so they accumulate until they exhaust the per-region quota
+# (TooManyTargetGroups). cloud-nuke does not natively support standalone
+# ELBv2 target groups (only the LBs themselves), so this script does the
+# sweep directly via the AWS CLI.
+#
+# Race-safety:
+#   AWS does not expose a creation time on target groups via DescribeTargetGroups,
+#   so we cannot filter by age. Instead, a TG is only deleted if it appears as
+#   orphan in TWO snapshots taken SETTLE_SECONDS apart. A TG that is mid-attach
+#   (created but not yet wired to an LB by Terraform / ingress controller / AWS
+#   Load Balancer Controller) will gain a LoadBalancerArns entry inside the wait
+#   window and drop out of the second snapshot, so we will not delete it.
+#
+# Other safety:
+#   - If AWS rejects a delete (e.g. a listener rule still references it), the
+#     error is logged but does not abort the script.
+#   - DRY_RUN=true logs candidates and exits without deleting.
+#
+# Usage:
+#   ./nuke-orphan-target-groups.sh <region>
+#
+# Arguments:
+#   region  AWS region to sweep (e.g. eu-west-2).
+#
+# Environment:
+#   DRY_RUN         If "true", list candidates and exit without deleting.
+#   SETTLE_SECONDS  Seconds to wait between the two orphan snapshots.
+#                   Defaults to 120 (covers typical Terraform/ingress LB
+#                   provisioning windows of 2–3 minutes).
+
+set -euo pipefail
+
+REGION="${1:?region required (e.g. eu-west-2)}"
+DRY_RUN="${DRY_RUN:-false}"
+SETTLE_SECONDS="${SETTLE_SECONDS:-120}"
+
+list_orphans() {
+    aws elbv2 describe-target-groups \
+        --region "$REGION" \
+        --query "TargetGroups[?length(LoadBalancerArns)==\`0\`].TargetGroupArn" \
+        --output text 2>/dev/null | tr '\t' '\n' | grep -v '^$' || true
+}
+
+echo "Listing ELBv2 target groups in ${REGION} (pass 1)..."
+mapfile -t pass1 < <(list_orphans)
+pass1_count=${#pass1[@]}
+echo "Pass 1: ${pass1_count} orphan target group(s)."
+
+if [[ $pass1_count -eq 0 ]]; then
+    exit 0
+fi
+
+echo "Waiting ${SETTLE_SECONDS}s before re-checking to avoid deleting TGs mid-attach..."
+sleep "$SETTLE_SECONDS"
+
+echo "Listing ELBv2 target groups in ${REGION} (pass 2)..."
+mapfile -t pass2 < <(list_orphans)
+declare -A still_orphan=()
+for arn in "${pass2[@]}"; do
+    still_orphan["$arn"]=1
+done
+
+confirmed=()
+for arn in "${pass1[@]}"; do
+    if [[ -n "${still_orphan[$arn]:-}" ]]; then
+        confirmed+=("$arn")
+    else
+        echo "Skipping ${arn} — attached to an LB during the settle window."
+    fi
+done
+
+total=${#confirmed[@]}
+echo "Confirmed orphan target group(s) in ${REGION}: ${total}"
+
+if [[ $total -eq 0 ]]; then
+    exit 0
+fi
+
+deleted=0
+skipped=0
+for tg_arn in "${confirmed[@]}"; do
+    if [[ "$DRY_RUN" == "true" ]]; then
+        echo "[DRY RUN] Would delete: $tg_arn"
+        continue
+    fi
+    if aws elbv2 delete-target-group \
+            --target-group-arn "$tg_arn" \
+            --region "$REGION" 2>/tmp/tg-delete-err; then
+        echo "Deleted: $tg_arn"
+        deleted=$((deleted + 1))
+    else
+        echo "Skipped (delete failed): $tg_arn — $(cat /tmp/tg-delete-err)"
+        skipped=$((skipped + 1))
+    fi
+done
+
+echo "Done in ${REGION}: deleted=${deleted}, skipped=${skipped}, total=${total}"

--- a/.github/actions/install-cloud-nuke/README.md
+++ b/.github/actions/install-cloud-nuke/README.md
@@ -1,0 +1,30 @@
+# Install cloud-nuke
+
+## Description
+
+Install the gruntwork-io/cloud-nuke binary at a pinned version onto the runner.
+Used by cleanup workflows to delete AWS resources outside of Terraform state.
+
+
+## Inputs
+
+| name | description | required | default |
+| --- | --- | --- | --- |
+| `version` | <p>cloud-nuke release tag (e.g. v0.49.0)</p> | `false` | `v0.49.0` |
+
+
+## Runs
+
+This action is a `composite` action.
+
+## Usage
+
+```yaml
+- uses: camunda/camunda-deployment-references/.github/actions/install-cloud-nuke@main
+  with:
+    version:
+    # cloud-nuke release tag (e.g. v0.49.0)
+    #
+    # Required: false
+    # Default: v0.49.0
+```

--- a/.github/actions/install-cloud-nuke/action.yml
+++ b/.github/actions/install-cloud-nuke/action.yml
@@ -1,0 +1,31 @@
+---
+name: Install cloud-nuke
+
+description: |
+    Install the gruntwork-io/cloud-nuke binary at a pinned version onto the runner.
+    Used by cleanup workflows to delete AWS resources outside of Terraform state.
+
+inputs:
+    version:
+        description: cloud-nuke release tag (e.g. v0.49.0)
+        # renovate: datasource=github-tags depName=gruntwork-io/cloud-nuke
+        default: v0.49.0
+
+runs:
+    using: composite
+    steps:
+        - name: Install cloud-nuke
+          shell: bash
+          working-directory: /tmp
+          env:
+              CLOUD_NUKE_VERSION: ${{ inputs.version }}
+          run: |
+              set -euo pipefail
+              curl -LO \
+                  --retry 5 \
+                  --max-time 15 \
+                  --retry-delay 30 \
+                  "https://github.com/gruntwork-io/cloud-nuke/releases/download/${CLOUD_NUKE_VERSION}/cloud-nuke_linux_amd64"
+              chmod +x cloud-nuke_linux_amd64
+              sudo mv cloud-nuke_linux_amd64 /usr/local/bin/cloud-nuke
+              cloud-nuke --version


### PR DESCRIPTION
## Why

Daily cleanup runs were failing with `TooManyTargetGroups: The maximum number of target groups has been reached` in `eu-west-2` (see run [25778877598](https://github.com/camunda/camunda-deployment-references/actions/runs/25778877598)). The failure surfaced on the ECS Fargate matrix but the cause is account-wide: AWS does **not** cascade-delete target groups when their parent load balancer is removed, and the existing cleanup path never touched standalone TGs, so they accumulated until the per-region quota was exhausted.

## What changes

Two complementary sweeps inside `aws-generic-terraform-cleanup`:

- **Per-VPC** — `destroy-resources.sh::cleanup_vpc_dependencies()` now deletes TGs in the VPC right after deleting its load balancers, alongside the existing SG / ENI / NAT cleanup.
- **Region-wide safety net** — a new step at the end of the composite action runs `scripts/nuke-orphan-target-groups.sh` against `AWS_REGION` (and `CLUSTER_0_AWS_REGION` / `CLUSTER_1_AWS_REGION` if set, deduped). The script deletes TGs not attached to any LB, using a two-pass settle window (default `120s`) to avoid racing with TGs that are mid-attach during a Terraform or ingress-controller deploy.

`cloud-nuke` v0.49.0 does not support standalone ELBv2 target groups (only LBs and VPC-Lattice TGs), so the sweep is implemented with the AWS CLI directly. The inline `cloud-nuke` install was also extracted into a reusable composite action so the renovate pin lives in one place.

A follow-up PR will address the root cause for OpenShift specifically — waiting for `IngressController` cleanup before `terraform destroy` runs.

## Verification

- `pre-commit run` passes (shellcheck, yamllint, action-lint, format-yaml).
- New step runs `if: always()`, so orphans created when destroy itself fails still get swept.
- `DRY_RUN=true ./nuke-orphan-target-groups.sh <region>` can be used to inspect candidates without deleting.
