### PR TITLE
fix(ci): include ROSA HCP versions in renovate artifact

### DIFF
--- a/.github/workflows/internal_openshift_artifact_rosa_versions.yml
+++ b/.github/workflows/internal_openshift_artifact_rosa_versions.yml
@@ -51,7 +51,13 @@ jobs:
                   rosa version
                   rosa login --token=${{ steps.secrets.outputs.RH_OPENSHIFT_TOKEN }}
                   mkdir -p docs
-                  rosa list versions --output json | jq '.[].raw_id' --raw-output > docs/rosa_versions.txt
+                  # We deploy ROSA HCP (Hosted Control Planes) — the `--hosted-cp` flag is required,
+                  # otherwise `rosa list versions` returns ROSA classic versions, which lag behind HCP.
+                  # Merge classic + HCP, dedup, and sort descending so Renovate sees all supported versions.
+                  {
+                    rosa list versions --hosted-cp --output json | jq '.[].raw_id' --raw-output
+                    rosa list versions --output json              | jq '.[].raw_id' --raw-output
+                  } | sort -V -u -r > docs/rosa_versions.txt
 
             - name: Commit and push ROSA versions file to gh-pages
               shell: bash


### PR DESCRIPTION
## Summary

The `internal_openshift_artifact_rosa_versions` workflow generates the [`rosa_versions.txt`](https://camunda.github.io/camunda-deployment-references/rosa_versions.txt) artifact consumed by Renovate (via the `custom.rosa-camunda` datasource defined in `camunda/infraex-common-config`) to bump `openshift_version` across this repository.

Until now the workflow ran:

```bash
rosa list versions --output json
```

which returns only **ROSA classic** versions. However, this repository **exclusively deploys ROSA HCP** (Hosted Control Planes, see `aws/modules/rosa-hcp/` and `aws/openshift/rosa-hcp-*`). HCP versions are published on a different track that is often **ahead** of classic.

For example, OpenShift 4.21 became available on ROSA HCP first, but the artifact still tops out at `4.20.3`:

```text
curl -s https://camunda.github.io/camunda-deployment-references/rosa_versions.txt | head -5
4.20.3
4.20.2
4.20.1
4.20.0
4.19.19
```

As a result, Renovate never sees the new HCP versions and **no upgrade PR is opened for ROSA HCP 4.21**, even though customers are already running on it.

## Changes

- Add `rosa list versions --hosted-cp` so HCP versions are collected.
- Keep the classic list to avoid losing any version.
- Merge, deduplicate and reverse-sort the union with `sort -V -u -r` so the file format consumed by Renovate is preserved (newest first, one version per line).

## Verification

After this is merged:

1. Either wait for the next scheduled run (cron `0 0 * * *`) or trigger the workflow manually via `workflow_dispatch`.
2. The next commit on the `gh-pages` branch will include the new HCP versions.
3. Renovate will detect 4.21.x on its next cycle and open the corresponding **major** upgrade PR (draft, label `upgrade:major`, per the `default.json5` policy of `camunda/infraex-common-config`).

## Context

- OpenShift 4.20 → 4.21 compatibility on Camunda 8.7/8.8).
- AWS announcement: *Red Hat OpenShift Service on AWS version 4.21 is now available for new clusters.*
- Related Slack thread: https://camunda.slack.com/archives/C03UR0V2R2M/p1763984628081739

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
