### PR TITLE
fix(ci): write rosa_versions.txt into the repo, not /tmp/docs

### DIFF
--- a/.github/workflows/internal_openshift_artifact_rosa_versions.yml
+++ b/.github/workflows/internal_openshift_artifact_rosa_versions.yml
@@ -51,7 +51,13 @@ jobs:
                   rosa version
                   rosa login --token=${{ steps.secrets.outputs.RH_OPENSHIFT_TOKEN }}
                   mkdir -p docs
-                  rosa list versions --output json | jq '.[].raw_id' --raw-output > docs/rosa_versions.txt
+                  # We deploy ROSA HCP (Hosted Control Planes) — the `--hosted-cp` flag is required,
+                  # otherwise `rosa list versions` returns ROSA classic versions, which lag behind HCP.
+                  # Merge classic + HCP, dedup, and sort descending so Renovate sees all supported versions.
+                  {
+                    rosa list versions --hosted-cp --output json | jq '.[].raw_id' --raw-output
+                    rosa list versions --output json              | jq '.[].raw_id' --raw-output
+                  } | sort -V -u -r > docs/rosa_versions.txt
 
             - name: Commit and push ROSA versions file to gh-pages
               shell: bash

--- a/.github/workflows/internal_openshift_artifact_rosa_versions.yml
+++ b/.github/workflows/internal_openshift_artifact_rosa_versions.yml
@@ -39,17 +39,22 @@ jobs:
 
             - name: Install ROSA CLI and output rosa versions
               shell: bash
-              working-directory: /tmp
               run: |
                   set -euo pipefail
 
+                  # Download and install rosa CLI in /tmp (we don't need it in the repo).
+                  pushd /tmp >/dev/null
                   curl -LO "https://mirror.openshift.com/pub/openshift-v4/clients/rosa/latest/rosa-linux.tar.gz"
                   tar -xvf rosa-linux.tar.gz
                   sudo mv rosa /usr/local/bin/rosa
                   chmod +x /usr/local/bin/rosa
                   rm -f rosa-linux.tar.gz
+                  popd >/dev/null
+
                   rosa version
                   rosa login --token=${{ steps.secrets.outputs.RH_OPENSHIFT_TOKEN }}
+
+                  # Write the artifact into the repo working tree (gh-pages branch is currently checked out).
                   mkdir -p docs
                   # We deploy ROSA HCP (Hosted Control Planes) — the `--hosted-cp` flag is required,
                   # otherwise `rosa list versions` returns ROSA classic versions, which lag behind HCP.

--- a/.github/workflows/internal_openshift_artifact_rosa_versions.yml
+++ b/.github/workflows/internal_openshift_artifact_rosa_versions.yml
@@ -59,10 +59,26 @@ jobs:
                     rosa list versions --output json              | jq '.[].raw_id' --raw-output
                   } | sort -V -u -r > docs/rosa_versions.txt
 
+                  echo "::group::Raw HCP versions returned by rosa CLI"
+                  rosa list versions --hosted-cp --output json | jq '.[].raw_id' --raw-output || true
+                  echo "::endgroup::"
+
+                  echo "::group::Raw classic versions returned by rosa CLI"
+                  rosa list versions --output json | jq '.[].raw_id' --raw-output || true
+                  echo "::endgroup::"
+
+                  echo "::group::Generated docs/rosa_versions.txt ($(wc -l < docs/rosa_versions.txt) lines)"
+                  cat docs/rosa_versions.txt
+                  echo "::endgroup::"
+
             - name: Commit and push ROSA versions file to gh-pages
               shell: bash
               run: |
                   set -euo pipefail
+
+                  echo "::group::Diff against gh-pages"
+                  git --no-pager diff -- docs/rosa_versions.txt || true
+                  echo "::endgroup::"
 
                   git diff --exit-code docs/rosa_versions.txt || {
                     git config --local user.name "github-actions[bot]"


### PR DESCRIPTION
## Root cause

The `internal_openshift_artifact_rosa_versions` workflow had `working-directory: /tmp` set on the rosa CLI step. That value was convenient for unpacking the tarball, but it also caused the artifact write to land in the wrong place:

```yaml
- name: Install ROSA CLI and output rosa versions
  working-directory: /tmp    # ← applies to the whole step
  run: |
      ...
      mkdir -p docs
      ... > docs/rosa_versions.txt   # → /tmp/docs/rosa_versions.txt
```

The next step ("Commit and push") runs in the default `$GITHUB_WORKSPACE`. It then executes:

```bash
git diff --exit-code docs/rosa_versions.txt
```

which compares the **untouched** `gh-pages` copy against itself — diff is always empty, no commit is ever made, and the published artifact at <https://camunda.github.io/camunda-deployment-references/rosa_versions.txt> remained frozen at its last manual state (`4.20.3`, last-modified `2026-05-12`).

That is why, even though `rosa list versions` (with or without `--hosted-cp`) has been returning the full 4.21.x range for a while, Renovate never saw any new version and **no upgrade PR was opened for ROSA HCP 4.21**.

Confirmed via the debug logs added in this PR (workflow run [#26100311368](https://github.com/camunda/camunda-deployment-references/actions/runs/26100311368)):

```text
##[group]Raw HCP versions returned by rosa CLI
4.21.15
4.21.14
...
4.21.0
4.20.22
...
```

…yet `git diff` against `gh-pages` was empty.

## Changes

1. **Move only the rosa CLI install into `/tmp`** via `pushd`/`popd`. The rest of the step now runs in the default working directory (the repo with `gh-pages` checked out), so `docs/rosa_versions.txt` is written in the correct place.
2. Keep `rosa list versions --hosted-cp` merged with classic via `sort -V -u -r` (introduced in #2467) so HCP-only versions are included.
3. Add log groups dumping the raw HCP versions, raw classic versions, the generated file (with line count), and the diff against `gh-pages`. These groups make any future regression obvious from the logs.

## Plan

1. Merge this PR.
2. Trigger the workflow manually (`workflow_dispatch`) to regenerate `docs/rosa_versions.txt` on `gh-pages` immediately.
3. Renovate will detect the new 4.21.x HCP versions on its next cycle and open the corresponding **major** upgrade PR (draft, label `upgrade:major`, per the `default.json5` policy of `camunda/infraex-common-config`).
4. Optionally open a follow-up to remove the temporary debug log groups once we have a few successful daily runs on record.

## Context

- Supersedes the diagnostic intent of this branch — the debug output ended up surfacing the real bug.
- Builds on top of [#2467](https://github.com/camunda/camunda-deployment-references/pull/2467).
- Customer request: (OpenShift 4.20 → 4.21 compatibility on Camunda 8.7/8.8).
- AWS announcement: *Red Hat OpenShift Service on AWS version 4.21 is now available for new clusters.*
