### PR TITLE
ci(slack-alerts): backport branch-aware routing + 1.6.1 to stable/8.8

### DIFF
--- a/.github/workflows/aws_common_procedure_s3_bucket.yml
+++ b/.github/workflows/aws_common_procedure_s3_bucket.yml
@@ -157,9 +157,11 @@ jobs:
         steps:
             - name: Notify in Slack in case of failure
               id: slack-notification
-              if: ${{ env.IS_SCHEDULE == 'true' }}
-              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@193a21e1e56c9a65517a822224ac3b4ffa4d6ae4 # 1.5.9
+              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@6d3ddc1bbae80d4c7bb42541ba7f0e95a2ef9787 # 1.6.1
               with:
                   vault_addr: ${{ secrets.VAULT_ADDR }}
                   vault_role_id: ${{ secrets.VAULT_ROLE_ID }}
                   vault_secret_id: ${{ secrets.VAULT_SECRET_ID }}
+                  slack_channel_id: ${{ env.IS_SCHEDULE == 'true' && 'C076N4G1162' || 'C07E4FF6YMB' }}
+                  slack_mention_people: ${{ env.IS_SCHEDULE == 'true' && '@infraex-medic' || '' }}
+                  disable_silence_check: ${{ env.IS_SCHEDULE == 'true' && 'false' || 'true' }}

--- a/.github/workflows/aws_compute_ec2_single_region_daily_cleanup.yml
+++ b/.github/workflows/aws_compute_ec2_single_region_daily_cleanup.yml
@@ -123,9 +123,11 @@ jobs:
         steps:
             - name: Notify in Slack in case of failure
               id: slack-notification
-              if: ${{ env.IS_SCHEDULE == 'true' }}
-              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@193a21e1e56c9a65517a822224ac3b4ffa4d6ae4 # 1.5.9
+              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@6d3ddc1bbae80d4c7bb42541ba7f0e95a2ef9787 # 1.6.1
               with:
                   vault_addr: ${{ secrets.VAULT_ADDR }}
                   vault_role_id: ${{ secrets.VAULT_ROLE_ID }}
                   vault_secret_id: ${{ secrets.VAULT_SECRET_ID }}
+                  slack_channel_id: ${{ env.IS_SCHEDULE == 'true' && 'C076N4G1162' || 'C07E4FF6YMB' }}
+                  slack_mention_people: ${{ env.IS_SCHEDULE == 'true' && '@infraex-medic' || '' }}
+                  disable_silence_check: ${{ env.IS_SCHEDULE == 'true' && 'false' || 'true' }}

--- a/.github/workflows/aws_compute_ec2_single_region_tests.yml
+++ b/.github/workflows/aws_compute_ec2_single_region_tests.yml
@@ -396,9 +396,11 @@ jobs:
         steps:
             - name: Notify in Slack in case of failure
               id: slack-notification
-              if: ${{ env.IS_SCHEDULE == 'true' }}
-              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@193a21e1e56c9a65517a822224ac3b4ffa4d6ae4 # 1.5.9
+              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@6d3ddc1bbae80d4c7bb42541ba7f0e95a2ef9787 # 1.6.1
               with:
                   vault_addr: ${{ secrets.VAULT_ADDR }}
                   vault_role_id: ${{ secrets.VAULT_ROLE_ID }}
                   vault_secret_id: ${{ secrets.VAULT_SECRET_ID }}
+                  slack_channel_id: ${{ env.IS_SCHEDULE == 'true' && 'C076N4G1162' || 'C07E4FF6YMB' }}
+                  slack_mention_people: ${{ env.IS_SCHEDULE == 'true' && '@infraex-medic' || '' }}
+                  disable_silence_check: ${{ env.IS_SCHEDULE == 'true' && 'false' || 'true' }}

--- a/.github/workflows/aws_eks_single_region_daily_cleanup.yml
+++ b/.github/workflows/aws_eks_single_region_daily_cleanup.yml
@@ -135,9 +135,11 @@ jobs:
         steps:
             - name: Notify in Slack in case of failure
               id: slack-notification
-              if: ${{ env.IS_SCHEDULE == 'true' }}
-              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@193a21e1e56c9a65517a822224ac3b4ffa4d6ae4 # 1.5.9
+              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@6d3ddc1bbae80d4c7bb42541ba7f0e95a2ef9787 # 1.6.1
               with:
                   vault_addr: ${{ secrets.VAULT_ADDR }}
                   vault_role_id: ${{ secrets.VAULT_ROLE_ID }}
                   vault_secret_id: ${{ secrets.VAULT_SECRET_ID }}
+                  slack_channel_id: ${{ env.IS_SCHEDULE == 'true' && 'C076N4G1162' || 'C07E4FF6YMB' }}
+                  slack_mention_people: ${{ env.IS_SCHEDULE == 'true' && '@infraex-medic' || '' }}
+                  disable_silence_check: ${{ env.IS_SCHEDULE == 'true' && 'false' || 'true' }}

--- a/.github/workflows/aws_kubernetes_eks_single_region_tests.yml
+++ b/.github/workflows/aws_kubernetes_eks_single_region_tests.yml
@@ -880,9 +880,11 @@ jobs:
         steps:
             - name: Notify in Slack in case of failure
               id: slack-notification
-              if: ${{ env.IS_SCHEDULE == 'true' }}
-              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@193a21e1e56c9a65517a822224ac3b4ffa4d6ae4 # 1.5.9
+              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@6d3ddc1bbae80d4c7bb42541ba7f0e95a2ef9787 # 1.6.1
               with:
                   vault_addr: ${{ secrets.VAULT_ADDR }}
                   vault_role_id: ${{ secrets.VAULT_ROLE_ID }}
                   vault_secret_id: ${{ secrets.VAULT_SECRET_ID }}
+                  slack_channel_id: ${{ env.IS_SCHEDULE == 'true' && 'C076N4G1162' || 'C07E4FF6YMB' }}
+                  slack_mention_people: ${{ env.IS_SCHEDULE == 'true' && '@infraex-medic' || '' }}
+                  disable_silence_check: ${{ env.IS_SCHEDULE == 'true' && 'false' || 'true' }}

--- a/.github/workflows/aws_modules_eks_rds_os_create_destruct_tests.yml
+++ b/.github/workflows/aws_modules_eks_rds_os_create_destruct_tests.yml
@@ -310,9 +310,12 @@ jobs:
 
             - name: Notify in Slack in case of failure
               id: slack-notification
-              if: failure() && env.IS_SCHEDULE == 'true'
-              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@193a21e1e56c9a65517a822224ac3b4ffa4d6ae4 # 1.5.9
+              if: failure()
+              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@6d3ddc1bbae80d4c7bb42541ba7f0e95a2ef9787 # 1.6.1
               with:
                   vault_addr: ${{ secrets.VAULT_ADDR }}
                   vault_role_id: ${{ secrets.VAULT_ROLE_ID }}
                   vault_secret_id: ${{ secrets.VAULT_SECRET_ID }}
+                  slack_channel_id: ${{ env.IS_SCHEDULE == 'true' && 'C076N4G1162' || 'C07E4FF6YMB' }}
+                  slack_mention_people: ${{ env.IS_SCHEDULE == 'true' && '@infraex-medic' || '' }}
+                  disable_silence_check: ${{ env.IS_SCHEDULE == 'true' && 'false' || 'true' }}

--- a/.github/workflows/aws_modules_eks_rds_os_daily_cleanup.yml
+++ b/.github/workflows/aws_modules_eks_rds_os_daily_cleanup.yml
@@ -116,9 +116,12 @@ jobs:
 
             - name: Notify in Slack in case of failure
               id: slack-notification
-              if: failure() && env.IS_SCHEDULE == 'true' && steps.retry-delete-orphaned-resources.outcome == 'failure'
-              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@193a21e1e56c9a65517a822224ac3b4ffa4d6ae4 # 1.5.9
+              if: failure() && steps.retry-delete-orphaned-resources.outcome == 'failure'
+              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@6d3ddc1bbae80d4c7bb42541ba7f0e95a2ef9787 # 1.6.1
               with:
                   vault_addr: ${{ secrets.VAULT_ADDR }}
                   vault_role_id: ${{ secrets.VAULT_ROLE_ID }}
                   vault_secret_id: ${{ secrets.VAULT_SECRET_ID }}
+                  slack_channel_id: ${{ env.IS_SCHEDULE == 'true' && 'C076N4G1162' || 'C07E4FF6YMB' }}
+                  slack_mention_people: ${{ env.IS_SCHEDULE == 'true' && '@infraex-medic' || '' }}
+                  disable_silence_check: ${{ env.IS_SCHEDULE == 'true' && 'false' || 'true' }}

--- a/.github/workflows/aws_modules_eks_rds_os_tests.yml
+++ b/.github/workflows/aws_modules_eks_rds_os_tests.yml
@@ -312,9 +312,11 @@ jobs:
         steps:
             - name: Notify in Slack in case of failure
               id: slack-notification
-              if: env.IS_SCHEDULE == 'true'
-              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@193a21e1e56c9a65517a822224ac3b4ffa4d6ae4 # 1.5.9
+              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@6d3ddc1bbae80d4c7bb42541ba7f0e95a2ef9787 # 1.6.1
               with:
                   vault_addr: ${{ secrets.VAULT_ADDR }}
                   vault_role_id: ${{ secrets.VAULT_ROLE_ID }}
                   vault_secret_id: ${{ secrets.VAULT_SECRET_ID }}
+                  slack_channel_id: ${{ env.IS_SCHEDULE == 'true' && 'C076N4G1162' || 'C07E4FF6YMB' }}
+                  slack_mention_people: ${{ env.IS_SCHEDULE == 'true' && '@infraex-medic' || '' }}
+                  disable_silence_check: ${{ env.IS_SCHEDULE == 'true' && 'false' || 'true' }}

--- a/.github/workflows/aws_openshift_rosa_hcp_dual_region_tests.yml
+++ b/.github/workflows/aws_openshift_rosa_hcp_dual_region_tests.yml
@@ -814,9 +814,11 @@ jobs:
         steps:
             - name: Notify in Slack in case of failure
               id: slack-notification
-              if: ${{ env.IS_SCHEDULE == 'true' }}
-              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@193a21e1e56c9a65517a822224ac3b4ffa4d6ae4 # 1.5.9
+              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@6d3ddc1bbae80d4c7bb42541ba7f0e95a2ef9787 # 1.6.1
               with:
                   vault_addr: ${{ secrets.VAULT_ADDR }}
                   vault_role_id: ${{ secrets.VAULT_ROLE_ID }}
                   vault_secret_id: ${{ secrets.VAULT_SECRET_ID }}
+                  slack_channel_id: ${{ env.IS_SCHEDULE == 'true' && 'C076N4G1162' || 'C07E4FF6YMB' }}
+                  slack_mention_people: ${{ env.IS_SCHEDULE == 'true' && '@infraex-medic' || '' }}
+                  disable_silence_check: ${{ env.IS_SCHEDULE == 'true' && 'false' || 'true' }}

--- a/.github/workflows/aws_openshift_rosa_hcp_single_region_tests.yml
+++ b/.github/workflows/aws_openshift_rosa_hcp_single_region_tests.yml
@@ -671,9 +671,11 @@ jobs:
         steps:
             - name: Notify in Slack in case of failure
               id: slack-notification
-              if: ${{ env.IS_SCHEDULE == 'true' }}
-              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@193a21e1e56c9a65517a822224ac3b4ffa4d6ae4 # 1.5.9
+              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@6d3ddc1bbae80d4c7bb42541ba7f0e95a2ef9787 # 1.6.1
               with:
                   vault_addr: ${{ secrets.VAULT_ADDR }}
                   vault_role_id: ${{ secrets.VAULT_ROLE_ID }}
                   vault_secret_id: ${{ secrets.VAULT_SECRET_ID }}
+                  slack_channel_id: ${{ env.IS_SCHEDULE == 'true' && 'C076N4G1162' || 'C07E4FF6YMB' }}
+                  slack_mention_people: ${{ env.IS_SCHEDULE == 'true' && '@infraex-medic' || '' }}
+                  disable_silence_check: ${{ env.IS_SCHEDULE == 'true' && 'false' || 'true' }}

--- a/.github/workflows/aws_rosa_hcp_dual_region_daily_cleanup.yml
+++ b/.github/workflows/aws_rosa_hcp_dual_region_daily_cleanup.yml
@@ -137,9 +137,12 @@ jobs:
 
             - name: Notify in Slack in case of failure
               id: slack-notification
-              if: ${{ failure() && env.IS_SCHEDULE == 'true' && steps.retry_delete_clusters.outcome == 'failure' }}
-              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@193a21e1e56c9a65517a822224ac3b4ffa4d6ae4 # 1.5.9
+              if: ${{ failure() && steps.retry_delete_clusters.outcome == 'failure' }}
+              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@6d3ddc1bbae80d4c7bb42541ba7f0e95a2ef9787 # 1.6.1
               with:
                   vault_addr: ${{ secrets.VAULT_ADDR }}
                   vault_role_id: ${{ secrets.VAULT_ROLE_ID }}
                   vault_secret_id: ${{ secrets.VAULT_SECRET_ID }}
+                  slack_channel_id: ${{ env.IS_SCHEDULE == 'true' && 'C076N4G1162' || 'C07E4FF6YMB' }}
+                  slack_mention_people: ${{ env.IS_SCHEDULE == 'true' && '@infraex-medic' || '' }}
+                  disable_silence_check: ${{ env.IS_SCHEDULE == 'true' && 'false' || 'true' }}

--- a/.github/workflows/aws_rosa_hcp_single_region_daily_cleanup.yml
+++ b/.github/workflows/aws_rosa_hcp_single_region_daily_cleanup.yml
@@ -137,9 +137,12 @@ jobs:
 
             - name: Notify in Slack in case of failure
               id: slack-notification
-              if: ${{ failure() && env.IS_SCHEDULE == 'true' && steps.retry_delete_clusters.outcome == 'failure' }}
-              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@193a21e1e56c9a65517a822224ac3b4ffa4d6ae4 # 1.5.9
+              if: ${{ failure() && steps.retry_delete_clusters.outcome == 'failure' }}
+              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@6d3ddc1bbae80d4c7bb42541ba7f0e95a2ef9787 # 1.6.1
               with:
                   vault_addr: ${{ secrets.VAULT_ADDR }}
                   vault_role_id: ${{ secrets.VAULT_ROLE_ID }}
                   vault_secret_id: ${{ secrets.VAULT_SECRET_ID }}
+                  slack_channel_id: ${{ env.IS_SCHEDULE == 'true' && 'C076N4G1162' || 'C07E4FF6YMB' }}
+                  slack_mention_people: ${{ env.IS_SCHEDULE == 'true' && '@infraex-medic' || '' }}
+                  disable_silence_check: ${{ env.IS_SCHEDULE == 'true' && 'false' || 'true' }}

--- a/.github/workflows/azure_aks_single_region_daily_cleanup.yml
+++ b/.github/workflows/azure_aks_single_region_daily_cleanup.yml
@@ -165,9 +165,11 @@ jobs:
         steps:
             - name: Notify in Slack in case of failure
               id: slack-notification
-              if: ${{ env.IS_SCHEDULE == 'true' }}
-              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@193a21e1e56c9a65517a822224ac3b4ffa4d6ae4 # 1.5.9
+              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@6d3ddc1bbae80d4c7bb42541ba7f0e95a2ef9787 # 1.6.1
               with:
                   vault_addr: ${{ secrets.VAULT_ADDR }}
                   vault_role_id: ${{ secrets.VAULT_ROLE_ID }}
                   vault_secret_id: ${{ secrets.VAULT_SECRET_ID }}
+                  slack_channel_id: ${{ env.IS_SCHEDULE == 'true' && 'C076N4G1162' || 'C07E4FF6YMB' }}
+                  slack_mention_people: ${{ env.IS_SCHEDULE == 'true' && '@infraex-medic' || '' }}
+                  disable_silence_check: ${{ env.IS_SCHEDULE == 'true' && 'false' || 'true' }}

--- a/.github/workflows/azure_common_procedure_storageaccount_test.yml
+++ b/.github/workflows/azure_common_procedure_storageaccount_test.yml
@@ -155,9 +155,11 @@ jobs:
         steps:
             - name: Notify in Slack in case of failure
               id: slack-notification
-              if: ${{ env.IS_SCHEDULE == 'true' }}
-              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@193a21e1e56c9a65517a822224ac3b4ffa4d6ae4 # 1.5.9
+              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@6d3ddc1bbae80d4c7bb42541ba7f0e95a2ef9787 # 1.6.1
               with:
                   vault_addr: ${{ secrets.VAULT_ADDR }}
                   vault_role_id: ${{ secrets.VAULT_ROLE_ID }}
                   vault_secret_id: ${{ secrets.VAULT_SECRET_ID }}
+                  slack_channel_id: ${{ env.IS_SCHEDULE == 'true' && 'C076N4G1162' || 'C07E4FF6YMB' }}
+                  slack_mention_people: ${{ env.IS_SCHEDULE == 'true' && '@infraex-medic' || '' }}
+                  disable_silence_check: ${{ env.IS_SCHEDULE == 'true' && 'false' || 'true' }}

--- a/.github/workflows/azure_kubernetes_aks_single_region_tests.yml
+++ b/.github/workflows/azure_kubernetes_aks_single_region_tests.yml
@@ -814,9 +814,11 @@ jobs:
         steps:
             - name: Notify in Slack in case of failure
               id: slack-notification
-              if: ${{ env.IS_SCHEDULE == 'true' }}
-              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@193a21e1e56c9a65517a822224ac3b4ffa4d6ae4 # 1.5.9
+              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@6d3ddc1bbae80d4c7bb42541ba7f0e95a2ef9787 # 1.6.1
               with:
                   vault_addr: ${{ secrets.VAULT_ADDR }}
                   vault_role_id: ${{ secrets.VAULT_ROLE_ID }}
                   vault_secret_id: ${{ secrets.VAULT_SECRET_ID }}
+                  slack_channel_id: ${{ env.IS_SCHEDULE == 'true' && 'C076N4G1162' || 'C07E4FF6YMB' }}
+                  slack_mention_people: ${{ env.IS_SCHEDULE == 'true' && '@infraex-medic' || '' }}
+                  disable_silence_check: ${{ env.IS_SCHEDULE == 'true' && 'false' || 'true' }}

--- a/.github/workflows/generic_kubernetes_operator_based_test.yml
+++ b/.github/workflows/generic_kubernetes_operator_based_test.yml
@@ -915,9 +915,11 @@ jobs:
         steps:
             - name: Notify in Slack in case of failure
               id: slack-notification
-              if: ${{ env.IS_SCHEDULE == 'true' }}
-              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@193a21e1e56c9a65517a822224ac3b4ffa4d6ae4 # 1.5.9
+              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@6d3ddc1bbae80d4c7bb42541ba7f0e95a2ef9787 # 1.6.1
               with:
                   vault_addr: ${{ secrets.VAULT_ADDR }}
                   vault_role_id: ${{ secrets.VAULT_ROLE_ID }}
                   vault_secret_id: ${{ secrets.VAULT_SECRET_ID }}
+                  slack_channel_id: ${{ env.IS_SCHEDULE == 'true' && 'C076N4G1162' || 'C07E4FF6YMB' }}
+                  slack_mention_people: ${{ env.IS_SCHEDULE == 'true' && '@infraex-medic' || '' }}
+                  disable_silence_check: ${{ env.IS_SCHEDULE == 'true' && 'false' || 'true' }}

--- a/.github/workflows/internal_aws_artifact_aurora_versions.yml
+++ b/.github/workflows/internal_aws_artifact_aurora_versions.yml
@@ -67,9 +67,12 @@ jobs:
 
             - name: Notify in Slack in case of failure
               id: slack-notification
-              if: failure() && github.event_name == 'schedule'
-              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@193a21e1e56c9a65517a822224ac3b4ffa4d6ae4 # 1.5.9
+              if: failure()
+              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@6d3ddc1bbae80d4c7bb42541ba7f0e95a2ef9787 # 1.6.1
               with:
                   vault_addr: ${{ secrets.VAULT_ADDR }}
                   vault_role_id: ${{ secrets.VAULT_ROLE_ID }}
                   vault_secret_id: ${{ secrets.VAULT_SECRET_ID }}
+                  slack_channel_id: ${{ github.event_name == 'schedule' && 'C076N4G1162' || 'C07E4FF6YMB' }}
+                  slack_mention_people: ${{ github.event_name == 'schedule' && '@infraex-medic' || '' }}
+                  disable_silence_check: ${{ github.event_name == 'schedule' && 'false' || 'true' }}

--- a/.github/workflows/internal_aws_artifact_opensearch_versions.yml
+++ b/.github/workflows/internal_aws_artifact_opensearch_versions.yml
@@ -64,9 +64,12 @@ jobs:
 
             - name: Notify in Slack in case of failure
               id: slack-notification
-              if: failure() && github.event_name == 'schedule'
-              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@193a21e1e56c9a65517a822224ac3b4ffa4d6ae4 # 1.5.9
+              if: failure()
+              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@6d3ddc1bbae80d4c7bb42541ba7f0e95a2ef9787 # 1.6.1
               with:
                   vault_addr: ${{ secrets.VAULT_ADDR }}
                   vault_role_id: ${{ secrets.VAULT_ROLE_ID }}
                   vault_secret_id: ${{ secrets.VAULT_SECRET_ID }}
+                  slack_channel_id: ${{ github.event_name == 'schedule' && 'C076N4G1162' || 'C07E4FF6YMB' }}
+                  slack_mention_people: ${{ github.event_name == 'schedule' && '@infraex-medic' || '' }}
+                  disable_silence_check: ${{ github.event_name == 'schedule' && 'false' || 'true' }}

--- a/.github/workflows/internal_global_branches_workflow_scheduler.yml
+++ b/.github/workflows/internal_global_branches_workflow_scheduler.yml
@@ -208,8 +208,11 @@ jobs:
         steps:
             - name: Notify in Slack in case of failure
               id: slack-notification
-              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@193a21e1e56c9a65517a822224ac3b4ffa4d6ae4 # 1.5.9
+              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@6d3ddc1bbae80d4c7bb42541ba7f0e95a2ef9787 # 1.6.1
               with:
                   vault_addr: ${{ secrets.VAULT_ADDR }}
                   vault_role_id: ${{ secrets.VAULT_ROLE_ID }}
                   vault_secret_id: ${{ secrets.VAULT_SECRET_ID }}
+                  slack_channel_id: ${{ github.event_name == 'schedule' && 'C076N4G1162' || 'C07E4FF6YMB' }}
+                  slack_mention_people: ${{ github.event_name == 'schedule' && '@infraex-medic' || '' }}
+                  disable_silence_check: ${{ github.event_name == 'schedule' && 'false' || 'true' }}

--- a/.github/workflows/internal_global_links.yml
+++ b/.github/workflows/internal_global_links.yml
@@ -54,9 +54,12 @@ jobs:
 
             - name: Notify in Slack in case of failure
               id: slack-notification
-              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@193a21e1e56c9a65517a822224ac3b4ffa4d6ae4 # 1.5.9
+              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@6d3ddc1bbae80d4c7bb42541ba7f0e95a2ef9787 # 1.6.1
               if: failure() && env.IS_SCHEDULE == 'true'
               with:
                   vault_addr: ${{ secrets.VAULT_ADDR }}
                   vault_role_id: ${{ secrets.VAULT_ROLE_ID }}
                   vault_secret_id: ${{ secrets.VAULT_SECRET_ID }}
+                  slack_channel_id: ${{ env.IS_SCHEDULE == 'true' && 'C076N4G1162' || 'C07E4FF6YMB' }}
+                  slack_mention_people: ${{ env.IS_SCHEDULE == 'true' && '@infraex-medic' || '' }}
+                  disable_silence_check: ${{ env.IS_SCHEDULE == 'true' && 'false' || 'true' }}

--- a/.github/workflows/internal_global_pr_labeler.yml
+++ b/.github/workflows/internal_global_pr_labeler.yml
@@ -19,9 +19,12 @@ jobs:
 
             - name: Notify in Slack in case of failure
               id: slack-notification
-              if: failure() && github.event_name == 'schedule'
-              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@193a21e1e56c9a65517a822224ac3b4ffa4d6ae4 # 1.5.9
+              if: failure()
+              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@6d3ddc1bbae80d4c7bb42541ba7f0e95a2ef9787 # 1.6.1
               with:
                   vault_addr: ${{ secrets.VAULT_ADDR }}
                   vault_role_id: ${{ secrets.VAULT_ROLE_ID }}
                   vault_secret_id: ${{ secrets.VAULT_SECRET_ID }}
+                  slack_channel_id: ${{ github.event_name == 'schedule' && 'C076N4G1162' || 'C07E4FF6YMB' }}
+                  slack_mention_people: ${{ github.event_name == 'schedule' && '@infraex-medic' || '' }}
+                  disable_silence_check: ${{ github.event_name == 'schedule' && 'false' || 'true' }}

--- a/.github/workflows/internal_openshift_artifact_acm_versions.yml
+++ b/.github/workflows/internal_openshift_artifact_acm_versions.yml
@@ -57,9 +57,12 @@ jobs:
 
             - name: Notify in Slack in case of failure
               id: slack-notification
-              if: failure() && github.event_name == 'schedule'
-              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@193a21e1e56c9a65517a822224ac3b4ffa4d6ae4 # 1.5.9
+              if: failure()
+              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@6d3ddc1bbae80d4c7bb42541ba7f0e95a2ef9787 # 1.6.1
               with:
                   vault_addr: ${{ secrets.VAULT_ADDR }}
                   vault_role_id: ${{ secrets.VAULT_ROLE_ID }}
                   vault_secret_id: ${{ secrets.VAULT_SECRET_ID }}
+                  slack_channel_id: ${{ github.event_name == 'schedule' && 'C076N4G1162' || 'C07E4FF6YMB' }}
+                  slack_mention_people: ${{ github.event_name == 'schedule' && '@infraex-medic' || '' }}
+                  disable_silence_check: ${{ github.event_name == 'schedule' && 'false' || 'true' }}

--- a/.github/workflows/internal_openshift_artifact_rosa_versions.yml
+++ b/.github/workflows/internal_openshift_artifact_rosa_versions.yml
@@ -70,9 +70,12 @@ jobs:
 
             - name: Notify in Slack in case of failure
               id: slack-notification
-              if: failure() && github.event_name == 'schedule'
-              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@193a21e1e56c9a65517a822224ac3b4ffa4d6ae4 # 1.5.9
+              if: failure()
+              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@6d3ddc1bbae80d4c7bb42541ba7f0e95a2ef9787 # 1.6.1
               with:
                   vault_addr: ${{ secrets.VAULT_ADDR }}
                   vault_role_id: ${{ secrets.VAULT_ROLE_ID }}
                   vault_secret_id: ${{ secrets.VAULT_SECRET_ID }}
+                  slack_channel_id: ${{ github.event_name == 'schedule' && 'C076N4G1162' || 'C07E4FF6YMB' }}
+                  slack_mention_people: ${{ github.event_name == 'schedule' && '@infraex-medic' || '' }}
+                  disable_silence_check: ${{ github.event_name == 'schedule' && 'false' || 'true' }}

--- a/.github/workflows/local_kubernetes_kind_single_region_tests.yml
+++ b/.github/workflows/local_kubernetes_kind_single_region_tests.yml
@@ -440,9 +440,11 @@ jobs:
         steps:
             - name: Notify in Slack in case of failure
               id: slack-notification
-              if: ${{ env.IS_SCHEDULE == 'true' }}
-              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@193a21e1e56c9a65517a822224ac3b4ffa4d6ae4 # 1.5.9
+              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@6d3ddc1bbae80d4c7bb42541ba7f0e95a2ef9787 # 1.6.1
               with:
                   vault_addr: ${{ secrets.VAULT_ADDR }}
                   vault_role_id: ${{ secrets.VAULT_ROLE_ID }}
                   vault_secret_id: ${{ secrets.VAULT_SECRET_ID }}
+                  slack_channel_id: ${{ env.IS_SCHEDULE == 'true' && 'C076N4G1162' || 'C07E4FF6YMB' }}
+                  slack_mention_people: ${{ env.IS_SCHEDULE == 'true' && '@infraex-medic' || '' }}
+                  disable_silence_check: ${{ env.IS_SCHEDULE == 'true' && 'false' || 'true' }}


### PR DESCRIPTION
## Summary

Backport of #2466 (branch-aware Slack alert routing) to **stable/8.8**.

* Repins `report-failure-on-slack` to **1.6.1** (`6d3ddc1bbae80d4c7bb42541ba7f0e95a2ef9787`) on every call site.
* Drops the schedule-only conjunct from each notify step's `if:` guard so the alert fires on PR/push too, while preserving any unrelated predicates such as `failure()` or step-outcome checks.
* Adds three routing inputs per call site:
  | Trigger | Channel | Mention | Silence check |
  |---|---|---|---|
  | Scheduled | `C076N4G1162` (infraex-alerts) | `@infraex-medic` | enabled |
  | PR / push / manual | `C07E4FF6YMB` (infraex-tests) | none | disabled |

The 1.6.1 bump also enables the stable-branch severity prefix introduced in 1.6.0 — production-relevant failures on this branch are now visually flagged in Slack with `:rotating_light: *STABLE BRANCH FAILURE* :rotating_light:`.

The change is mechanical and was generated by the same transformation script used for the three backport branches (`8.7`, `8.8`, `8.9`).

## Refs

- camunda/team-infrastructure-experience#1106
- camunda/camunda-deployment-references#2466 (main)
- camunda/infraex-common-config#487 (1.6.1 release)

## Test plan

- [ ] Verify Slack notify step still fires on the next scheduled run and lands in `infraex-alerts` with the `@infraex-medic` mention and the new stable-branch severity prefix.
- [ ] Force-trigger any workflow via PR push and confirm the alert lands in `infraex-tests` without a mention.