### PR TITLE
ci(slack-alerts): skip report-failure job when run is triage-skipped (8.8)

### DIFF
--- a/.github/workflows/aws_common_procedure_s3_bucket.yml
+++ b/.github/workflows/aws_common_procedure_s3_bucket.yml
@@ -151,8 +151,9 @@ jobs:
     report-failure:
         name: Report failure
         runs-on: ubuntu-latest
-        if: failure()
+        if: needs.triage.outputs.should_skip == 'false' && (failure())
         needs:
+            - triage
             - report-success
         steps:
             - name: Notify in Slack in case of failure

--- a/.github/workflows/aws_compute_ec2_single_region_daily_cleanup.yml
+++ b/.github/workflows/aws_compute_ec2_single_region_daily_cleanup.yml
@@ -116,9 +116,10 @@ jobs:
 
     report-failure:
         name: Report failures
-        if: failure()
+        if: needs.triage.outputs.should_skip == 'false' && (failure())
         runs-on: ubuntu-latest
         needs:
+            - triage
             - cleanup-clusters
         steps:
             - name: Notify in Slack in case of failure

--- a/.github/workflows/aws_compute_ec2_single_region_tests.yml
+++ b/.github/workflows/aws_compute_ec2_single_region_tests.yml
@@ -389,8 +389,9 @@ jobs:
     report-failure:
         name: Report failure
         runs-on: ubuntu-latest
-        if: failure()
+        if: needs.triage.outputs.should_skip == 'false' && (failure())
         needs:
+            - triage
             - report-success
             - test-report
         steps:

--- a/.github/workflows/aws_eks_single_region_daily_cleanup.yml
+++ b/.github/workflows/aws_eks_single_region_daily_cleanup.yml
@@ -128,9 +128,10 @@ jobs:
 
     report-failure:
         name: Report failures
-        if: failure()
+        if: needs.triage.outputs.should_skip == 'false' && (failure())
         runs-on: ubuntu-latest
         needs:
+            - triage
             - cleanup-clusters
         steps:
             - name: Notify in Slack in case of failure

--- a/.github/workflows/aws_kubernetes_eks_single_region_tests.yml
+++ b/.github/workflows/aws_kubernetes_eks_single_region_tests.yml
@@ -873,9 +873,10 @@ jobs:
 
     report-failure:
         name: Report failures
-        if: failure()
+        if: needs.triage.outputs.should_skip == 'false' && (failure())
         runs-on: ubuntu-latest
         needs:
+            - triage
             - report-success
         steps:
             - name: Notify in Slack in case of failure

--- a/.github/workflows/aws_modules_eks_rds_os_tests.yml
+++ b/.github/workflows/aws_modules_eks_rds_os_tests.yml
@@ -306,8 +306,9 @@ jobs:
     report-failure:
         name: Report failure
         runs-on: ubuntu-latest
-        if: failure()
+        if: needs.triage.outputs.should_skip == 'false' && (failure())
         needs:
+            - triage
             - report-success
         steps:
             - name: Notify in Slack in case of failure

--- a/.github/workflows/aws_openshift_rosa_hcp_dual_region_tests.yml
+++ b/.github/workflows/aws_openshift_rosa_hcp_dual_region_tests.yml
@@ -806,9 +806,11 @@ jobs:
 
     report-failure:
         name: Report failures
-        if: failure() && (needs.integration-tests-retry.result != 'success' || fromJSON(github.run_attempt) >= 3)
+        if: needs.triage.outputs.should_skip == 'false' && (failure() && (needs.integration-tests-retry.result != 'success' || fromJSON(github.run_attempt)
+            >= 3))
         runs-on: ubuntu-latest
         needs:
+            - triage
             - integration-tests-retry
             - report-success
         steps:

--- a/.github/workflows/aws_openshift_rosa_hcp_single_region_tests.yml
+++ b/.github/workflows/aws_openshift_rosa_hcp_single_region_tests.yml
@@ -664,9 +664,10 @@ jobs:
 
     report-failures:
         name: Report failures
-        if: failure()
+        if: needs.triage.outputs.should_skip == 'false' && (failure())
         runs-on: ubuntu-latest
         needs:
+            - triage
             - report-success
         steps:
             - name: Notify in Slack in case of failure

--- a/.github/workflows/azure_aks_single_region_daily_cleanup.yml
+++ b/.github/workflows/azure_aks_single_region_daily_cleanup.yml
@@ -158,9 +158,10 @@ jobs:
 
     report-failure:
         name: Report failures
-        if: failure()
+        if: needs.triage.outputs.should_skip == 'false' && (failure())
         runs-on: ubuntu-latest
         needs:
+            - triage
             - cleanup-clusters
         steps:
             - name: Notify in Slack in case of failure

--- a/.github/workflows/azure_common_procedure_storageaccount_test.yml
+++ b/.github/workflows/azure_common_procedure_storageaccount_test.yml
@@ -149,8 +149,9 @@ jobs:
     report-failure:
         name: Report failure
         runs-on: ubuntu-latest
-        if: failure()
+        if: needs.triage.outputs.should_skip == 'false' && (failure())
         needs:
+            - triage
             - report-success
         steps:
             - name: Notify in Slack in case of failure

--- a/.github/workflows/azure_kubernetes_aks_single_region_tests.yml
+++ b/.github/workflows/azure_kubernetes_aks_single_region_tests.yml
@@ -807,9 +807,10 @@ jobs:
 
     report-failure:
         name: Report failures
-        if: failure()
+        if: needs.triage.outputs.should_skip == 'false' && (failure())
         runs-on: ubuntu-latest
         needs:
+            - triage
             - report-success
         steps:
             - name: Notify in Slack in case of failure

--- a/.github/workflows/generic_kubernetes_operator_based_test.yml
+++ b/.github/workflows/generic_kubernetes_operator_based_test.yml
@@ -908,9 +908,10 @@ jobs:
 
     report-failures:
         name: Report failures
-        if: failure()
+        if: needs.triage.outputs.should_skip == 'false' && (failure())
         runs-on: ubuntu-latest
         needs:
+            - triage
             - report-success
         steps:
             - name: Notify in Slack in case of failure

--- a/.github/workflows/local_kubernetes_kind_single_region_tests.yml
+++ b/.github/workflows/local_kubernetes_kind_single_region_tests.yml
@@ -433,9 +433,10 @@ jobs:
 
     report-failure:
         name: Report failures
-        if: failure()
+        if: needs.triage.outputs.should_skip == 'false' && (failure())
         runs-on: ubuntu-latest
         needs:
+            - triage
             - report-success
         steps:
             - name: Notify in Slack in case of failure


### PR DESCRIPTION
## Summary

Backport of #2484 to `stable/8.8`.

When a workflow run is skipped via a skip label (`skip_<workflow_name>`, `skip_all`, or `testing-ci-not-necessary`), the dedicated `report-failure(s)` job ended up running anyway and failing inside `report-failure-on-slack` with:

```
gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable.
```

The regression slipped in with the slack-alerts routing change (#2471 on this branch), which removed the `IS_SCHEDULE` gate around the slack-report step.

## Fix

For every workflow that has a dedicated `report-failure(s)` job and a `triage` job, add `triage` to its `needs` and gate the `if` with `needs.triage.outputs.should_skip == 'false' && (...)`. Intentionally skipped runs no longer attempt to send a Slack failure report.

## Test plan

- [ ] Workflow on a PR that carries a `skip_*` label completes without the `Report failures` job erroring
- [ ] A real failure on a non-skipped run still reports to Slack as before