### PR TITLE
ci: stop burning Let's Encrypt quota on camunda.ie via Bitnami Keycloak

### DIFF
--- a/.github/actions/aws-kubernetes-ingress-setup/action.yml
+++ b/.github/actions/aws-kubernetes-ingress-setup/action.yml
@@ -129,10 +129,19 @@ runs:
                   echo "🩹 Wildcard cert in use — patching cert-manager to drop ingress-shim default issuer"
                   echo "   (keeps ClusterIssuer/letsencrypt installed but stops auto-Certificates from"
                   echo "    'kubernetes.io/tls-acme' annotations, so sub-charts cannot burn LE quota)"
-                  kubectl -n cert-manager get deployment cert-manager -o json | \
-                      jq '.spec.template.spec.containers[0].args |= map(select(test("^--default-issuer-(name|kind|group)=") | not))' | \
-                      kubectl apply -f -
-                  kubectl -n cert-manager rollout status deployment cert-manager --timeout=2m
+
+                  current_args=$(kubectl -n cert-manager get deployment cert-manager \
+                      -o json | jq -c '.spec.template.spec.containers[0].args // []')
+                  new_args=$(jq -cn --argjson a "$current_args" \
+                      '$a | map(select(test("^--default-issuer-(name|kind|group)=") | not))')
+
+                  if [[ "$current_args" == "$new_args" ]]; then
+                      echo "ℹ️  cert-manager controller already has no default-issuer args — nothing to patch"
+                  else
+                      kubectl -n cert-manager patch deployment cert-manager --type=json \
+                          -p "[{\"op\":\"replace\",\"path\":\"/spec/template/spec/containers/0/args\",\"value\":${new_args}}]"
+                      kubectl -n cert-manager rollout status deployment cert-manager --timeout=2m
+                  fi
               fi
 
               echo "✅ Ingress setup completed successfully for EKS cluster."

--- a/.github/actions/aws-kubernetes-ingress-setup/action.yml
+++ b/.github/actions/aws-kubernetes-ingress-setup/action.yml
@@ -125,6 +125,16 @@ runs:
               echo "Installing ACME/Let's Encrypt issuer..."
               ./aws/kubernetes/${{ inputs.ref-arch }}/procedure/install-cert-manager-issuer.sh
 
+              if [[ "${{ inputs.use-wildcard-cert }}" == "true" ]]; then
+                  echo "🩹 Wildcard cert in use — patching cert-manager to drop ingress-shim default issuer"
+                  echo "   (keeps ClusterIssuer/letsencrypt installed but stops auto-Certificates from"
+                  echo "    'kubernetes.io/tls-acme' annotations, so sub-charts cannot burn LE quota)"
+                  kubectl -n cert-manager get deployment cert-manager -o json | \
+                      jq '.spec.template.spec.containers[0].args |= map(select(test("^--default-issuer-(name|kind|group)=") | not))' | \
+                      kubectl apply -f -
+                  kubectl -n cert-manager rollout status deployment cert-manager --timeout=2m
+              fi
+
               echo "✅ Ingress setup completed successfully for EKS cluster."
 
         - name: 🔐 Setup wildcard TLS certificate from Vault

--- a/.github/actions/azure-kubernetes-ingress-setup/action.yml
+++ b/.github/actions/azure-kubernetes-ingress-setup/action.yml
@@ -116,6 +116,16 @@ runs:
               export AZURE_DNS_ZONE="${{ inputs.tld }}"
               ./azure/kubernetes/${{ inputs.scenario-name }}/procedure/install-cert-manager-issuer.sh
 
+              if [[ "${{ inputs.use-wildcard-cert }}" == "true" ]]; then
+                  echo "🩹 Wildcard cert in use — patching cert-manager to drop ingress-shim default issuer"
+                  echo "   (keeps ClusterIssuer/letsencrypt installed but stops auto-Certificates from"
+                  echo "    'kubernetes.io/tls-acme' annotations, so sub-charts cannot burn LE quota)"
+                  kubectl -n cert-manager get deployment cert-manager -o json | \
+                      jq '.spec.template.spec.containers[0].args |= map(select(test("^--default-issuer-(name|kind|group)=") | not))' | \
+                      kubectl apply -f -
+                  kubectl -n cert-manager rollout status deployment cert-manager --timeout=2m
+              fi
+
               echo "✅ Ingress setup completed successfully for AKS cluster."
 
         - name: Setup wildcard TLS certificate from Vault

--- a/.github/actions/azure-kubernetes-ingress-setup/action.yml
+++ b/.github/actions/azure-kubernetes-ingress-setup/action.yml
@@ -120,10 +120,19 @@ runs:
                   echo "🩹 Wildcard cert in use — patching cert-manager to drop ingress-shim default issuer"
                   echo "   (keeps ClusterIssuer/letsencrypt installed but stops auto-Certificates from"
                   echo "    'kubernetes.io/tls-acme' annotations, so sub-charts cannot burn LE quota)"
-                  kubectl -n cert-manager get deployment cert-manager -o json | \
-                      jq '.spec.template.spec.containers[0].args |= map(select(test("^--default-issuer-(name|kind|group)=") | not))' | \
-                      kubectl apply -f -
-                  kubectl -n cert-manager rollout status deployment cert-manager --timeout=2m
+
+                  current_args=$(kubectl -n cert-manager get deployment cert-manager \
+                      -o json | jq -c '.spec.template.spec.containers[0].args // []')
+                  new_args=$(jq -cn --argjson a "$current_args" \
+                      '$a | map(select(test("^--default-issuer-(name|kind|group)=") | not))')
+
+                  if [[ "$current_args" == "$new_args" ]]; then
+                      echo "ℹ️  cert-manager controller already has no default-issuer args — nothing to patch"
+                  else
+                      kubectl -n cert-manager patch deployment cert-manager --type=json \
+                          -p "[{\"op\":\"replace\",\"path\":\"/spec/template/spec/containers/0/args\",\"value\":${new_args}}]"
+                      kubectl -n cert-manager rollout status deployment cert-manager --timeout=2m
+                  fi
               fi
 
               echo "✅ Ingress setup completed successfully for AKS cluster."

--- a/.github/actions/kubernetes-wildcard-certificate/README.md
+++ b/.github/actions/kubernetes-wildcard-certificate/README.md
@@ -10,7 +10,7 @@ Setup wildcard TLS certificate from Vault for Kubernetes clusters
 | --- | --- | --- | --- |
 | `tld` | <p>Top-level domain for the wildcard certificate</p> | `false` | `camunda.ie` |
 | `namespace` | <p>Kubernetes namespace where the TLS secret will be created</p> | `false` | `camunda` |
-| `secret-name` | <p>Name of the TLS secret to create</p> | `false` | `camunda-tls` |
+| `secret-name` | <p>Name(s) of the TLS secret(s) to create from the same wildcard certificate. Accepts a single name or a newline-separated list to provision multiple identical TLS secrets (e.g. one for the Camunda ingress and one consumed by the Bitnami Keycloak sub-chart) without burning Let's Encrypt quota.</p> | `false` | `camunda-tls` |
 | `vault-addr` | <p>Vault server address</p> | `true` | `""` |
 | `vault-role-id` | <p>Vault AppRole role ID</p> | `true` | `""` |
 | `vault-secret-id` | <p>Vault AppRole secret ID</p> | `true` | `""` |
@@ -38,7 +38,10 @@ This action is a `composite` action.
     # Default: camunda
 
     secret-name:
-    # Name of the TLS secret to create
+    # Name(s) of the TLS secret(s) to create from the same wildcard certificate.
+    # Accepts a single name or a newline-separated list to provision multiple
+    # identical TLS secrets (e.g. one for the Camunda ingress and one consumed
+    # by the Bitnami Keycloak sub-chart) without burning Let's Encrypt quota.
     #
     # Required: false
     # Default: camunda-tls

--- a/.github/actions/kubernetes-wildcard-certificate/action.yml
+++ b/.github/actions/kubernetes-wildcard-certificate/action.yml
@@ -12,7 +12,11 @@ inputs:
         required: false
         default: camunda
     secret-name:
-        description: Name of the TLS secret to create
+        description: |
+            Name(s) of the TLS secret(s) to create from the same wildcard certificate.
+            Accepts a single name or a newline-separated list to provision multiple
+            identical TLS secrets (e.g. one for the Camunda ingress and one consumed
+            by the Bitnami Keycloak sub-chart) without burning Let's Encrypt quota.
         required: false
         default: camunda-tls
     vault-addr:
@@ -44,9 +48,10 @@ runs:
           run: |
               set -euo pipefail
 
-              echo "🌐 Creating TLS secret for wildcard certificate *.${{ inputs.tld }}"
+              echo "🌐 Creating TLS secret(s) for wildcard certificate *.${{ inputs.tld }}"
               echo "📍 Target namespace: ${{ inputs.namespace }}"
-              echo "🔑 Secret name: ${{ inputs.secret-name }}"
+              echo "🔑 Secret name(s):"
+              echo "${{ inputs.secret-name }}" | sed 's/^/    - /'
 
               # Mask sensitive certificate data in logs
               echo "::add-mask::$WILDCARD_CERT"
@@ -85,19 +90,29 @@ runs:
               echo "$WILDCARD_KEY" > "$KEY_FILE"
 
 
-              # Create or update the TLS secret
-              echo "🔐 Creating TLS secret '${{ inputs.secret-name }}'..."
-              kubectl create secret tls "${{ inputs.secret-name }}" \
-                  --cert="$CERT_FILE" \
-                  --key="$KEY_FILE" \
-                  --namespace="${{ inputs.namespace }}" \
-                  --dry-run=client -o yaml | \
-              kubectl apply -f -
+              # Create or update each requested TLS secret from the same wildcard cert.
+              # Trim surrounding whitespace and skip blank lines so the action accepts both
+              # a single secret name and a newline-separated list.
+              SECRET_NAMES_RAW="${{ inputs.secret-name }}"
+              while IFS= read -r raw_name; do
+                  secret_name="$(echo "$raw_name" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+                  [[ -z "$secret_name" ]] && continue
+
+                  echo "🔐 Creating TLS secret '$secret_name'..."
+                  kubectl create secret tls "$secret_name" \
+                      --cert="$CERT_FILE" \
+                      --key="$KEY_FILE" \
+                      --namespace="${{ inputs.namespace }}" \
+                      --dry-run=client -o yaml | \
+                  kubectl apply -f -
+              done <<< "$SECRET_NAMES_RAW"
 
               echo "✅ Wildcard certificate setup completed successfully"
               echo ""
               echo "📋 Created resources:"
-              echo "  - Secret: ${{ inputs.secret-name }} (namespace: ${{ inputs.namespace }})"
+              echo "  - Namespace: ${{ inputs.namespace }}"
               echo "  - Type: kubernetes.io/tls"
               echo "  - Certificate: *.${{ inputs.tld }}"
+              echo "  - Secret(s):"
+              echo "${{ inputs.secret-name }}" | sed 's/^/      - /'
               echo ""

--- a/.github/workflows/aws_kubernetes_eks_single_region_tests.yml
+++ b/.github/workflows/aws_kubernetes_eks_single_region_tests.yml
@@ -76,8 +76,10 @@ env:
     # Docker Hub auth to avoid image pull rate limit.
     # Vars with "TEST_" prefix are used in the test runner tool (Task).
     TESTS_ENABLED: ${{ github.event.inputs.enable_tests || 'true' }}
-    # renovate: datasource=github-tags depName=camunda/camunda-platform-helm
-    TESTS_CAMUNDA_HELM_CHART_REPO_REF: camunda-platform-8.7-12.10.0
+    # 12.8.5 is the last 8.7 tag that still ships test/integration/testsuites/vars/files/,
+    # which the internal-camunda-chart-tests action depends on. Newer tags (>=12.9.0) drop it,
+    # so do NOT bump this past 12.8.5 without updating the action.
+    TESTS_CAMUNDA_HELM_CHART_REPO_REF: camunda-platform-8.7-12.8.5
     TESTS_CAMUNDA_HELM_CHART_REPO_PATH: ./.camunda_helm_repo   # where to clone it
 
     # Optional components that are not enabled by default in the doc

--- a/.github/workflows/aws_kubernetes_eks_single_region_tests.yml
+++ b/.github/workflows/aws_kubernetes_eks_single_region_tests.yml
@@ -527,7 +527,9 @@ jobs:
                   ref-arch: ${{ matrix.scenario.name }}
                   use-wildcard-cert: ${{ steps.cert-config.outputs.use-wildcard-cert }}
                   wildcard-cert-namespace: ${{ env.CAMUNDA_NAMESPACE }}
-                  wildcard-cert-secret-name: ${{ env.WILDCARD_TLS_SECRET_NAME }}
+                  wildcard-cert-secret-name: |
+                      ${{ env.WILDCARD_TLS_SECRET_NAME }}
+                      camunda-keycloak-tls
                   vault-addr: ${{ secrets.VAULT_ADDR }}
                   vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
                   vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}

--- a/.github/workflows/azure_kubernetes_aks_single_region_tests.yml
+++ b/.github/workflows/azure_kubernetes_aks_single_region_tests.yml
@@ -477,7 +477,9 @@ jobs:
                   azure-subscription-id: ${{ steps.secrets.outputs.AZURE_SUBSCRIPTION_ID }}
                   use-wildcard-cert: ${{ steps.cert-config.outputs.use-wildcard-cert }}
                   wildcard-cert-namespace: ${{ env.CAMUNDA_NAMESPACE }}
-                  wildcard-cert-secret-name: ${{ env.WILDCARD_TLS_SECRET_NAME }}
+                  wildcard-cert-secret-name: |
+                      ${{ env.WILDCARD_TLS_SECRET_NAME }}
+                      camunda-keycloak-tls
                   vault-addr: ${{ secrets.VAULT_ADDR }}
                   vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
                   vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}


### PR DESCRIPTION
## Summary

Backport of the LE quota fix from PR #2400's branch.

The Bitnami Keycloak sub-chart auto-creates an Ingress with `kubernetes.io/tls-acme: true`, which makes cert-manager's ingress-shim auto-issue a `Certificate` against the `letsencrypt` ClusterIssuer. With one `camunda-keycloak-tls` Order per CI run on top of `camunda-c8-tls`, the 50-cert/168h LE rate limit on `camunda.ie` is exhausted regularly, cascading into PKIX failures on zeebe/connectors.

CI-only — no impact on the documented user procedure:
- `kubernetes-wildcard-certificate` action now accepts a newline-separated list of secret names; EKS/AKS callers pre-create both `camunda-c8-tls` and `camunda-keycloak-tls` from the same Vault wildcard.
- After cert-manager install, when `use-wildcard-cert=true`, the cert-manager controller deployment is patched to drop `--default-issuer-{name,kind,group}` args. The `ClusterIssuer/letsencrypt` resource stays installed (procedure still exercised), but the ingress-shim no longer auto-creates Certificates from `tls-acme` annotations, so sub-charts cannot trigger LE Orders.

On Renovate cert-manager PRs (`use-wildcard-cert=false`), the LE flow is unchanged and still fully tested.

## Test plan

- [ ] CI run on this branch shows no `camunda-keycloak-tls` LE Order, no `429 rateLimited` on `camunda.ie`
- [ ] `kubectl get clusterissuer letsencrypt` is still present after ingress setup
- [ ] Camunda + Keycloak ingresses serve TLS via the pre-created Vault wildcard secrets