### PR TITLE
ci: fix report-success skip cascade marking runs as failure

### DIFF
--- a/.github/workflows/aws_common_procedure_s3_bucket.yml
+++ b/.github/workflows/aws_common_procedure_s3_bucket.yml
@@ -136,6 +136,7 @@ jobs:
 
     report-success:
         name: Report success
+        if: ${{ !failure() && !cancelled() }}
         runs-on: ubuntu-latest
         needs:
             - s3-bucket-verification

--- a/.github/workflows/aws_compute_ec2_single_region_tests.yml
+++ b/.github/workflows/aws_compute_ec2_single_region_tests.yml
@@ -376,6 +376,7 @@ jobs:
 
     report-success:
         name: Report success
+        if: ${{ !failure() && !cancelled() }}
         runs-on: ubuntu-latest
         needs:
             - integration-tests

--- a/.github/workflows/aws_ecs_single_region_fargate_tests.yml
+++ b/.github/workflows/aws_ecs_single_region_fargate_tests.yml
@@ -385,6 +385,7 @@ jobs:
 
     report-success:
         name: Report success
+        if: ${{ !failure() && !cancelled() }}
         runs-on: ubuntu-slim
         needs:
             - integration-tests

--- a/.github/workflows/aws_kubernetes_eks_dual_region_teleport_tests.yml
+++ b/.github/workflows/aws_kubernetes_eks_dual_region_teleport_tests.yml
@@ -350,6 +350,7 @@ jobs:
 
     report-success:
         name: Report success
+        if: ${{ !failure() && !cancelled() }}
         runs-on: ubuntu-latest
         needs:
             - integration-tests

--- a/.github/workflows/aws_kubernetes_eks_dual_region_tests.yml
+++ b/.github/workflows/aws_kubernetes_eks_dual_region_tests.yml
@@ -585,6 +585,7 @@ jobs:
 
     report-success:
         name: Report success
+        if: ${{ !failure() && !cancelled() }}
         runs-on: ubuntu-latest
         needs:
             - integration-tests

--- a/.github/workflows/aws_kubernetes_eks_single_region_tests.yml
+++ b/.github/workflows/aws_kubernetes_eks_single_region_tests.yml
@@ -1052,6 +1052,7 @@ jobs:
 
     report-success:
         name: Report success
+        if: ${{ !failure() && !cancelled() }}
         runs-on: ubuntu-latest
         needs:
             - integration-tests

--- a/.github/workflows/aws_modules_eks_rds_os_tests.yml
+++ b/.github/workflows/aws_modules_eks_rds_os_tests.yml
@@ -288,6 +288,7 @@ jobs:
 
     report-success:
         name: Report success
+        if: ${{ !failure() && !cancelled() }}
         runs-on: ubuntu-latest
         needs:
             - configure-tests

--- a/.github/workflows/aws_openshift_rosa_hcp_dual_region_tests.yml
+++ b/.github/workflows/aws_openshift_rosa_hcp_dual_region_tests.yml
@@ -909,6 +909,7 @@ jobs:
                   modules-order: backup_bucket,peering,clusters
     report-success:
         name: Report success
+        if: ${{ !failure() && !cancelled() }}
         runs-on: ubuntu-latest
         needs:
             - integration-tests

--- a/.github/workflows/aws_openshift_rosa_hcp_single_region_tests.yml
+++ b/.github/workflows/aws_openshift_rosa_hcp_single_region_tests.yml
@@ -789,6 +789,7 @@ jobs:
 
     report-success:
         name: Report success
+        if: ${{ !failure() && !cancelled() }}
         runs-on: ubuntu-latest
         needs:
             - integration-tests

--- a/.github/workflows/azure_common_procedure_storageaccount_test.yml
+++ b/.github/workflows/azure_common_procedure_storageaccount_test.yml
@@ -134,6 +134,7 @@ jobs:
 
     report-success:
         name: Report success
+        if: ${{ !failure() && !cancelled() }}
         runs-on: ubuntu-latest
         needs:
             - test-storage-account-creation

--- a/.github/workflows/azure_kubernetes_aks_single_region_tests.yml
+++ b/.github/workflows/azure_kubernetes_aks_single_region_tests.yml
@@ -879,6 +879,7 @@ jobs:
 
     report-success:
         name: Report success
+        if: ${{ !failure() && !cancelled() }}
         runs-on: ubuntu-latest
         needs:
             - integration-tests

--- a/.github/workflows/generic_kubernetes_migration_test.yml
+++ b/.github/workflows/generic_kubernetes_migration_test.yml
@@ -150,6 +150,7 @@ jobs:
 
     report-success:
         name: Report success
+        if: ${{ !failure() && !cancelled() }}
         runs-on: ubuntu-latest
         needs:
             - migration-tests

--- a/.github/workflows/generic_kubernetes_operator_based_test.yml
+++ b/.github/workflows/generic_kubernetes_operator_based_test.yml
@@ -886,6 +886,7 @@ jobs:
 
     report-success:
         name: Report success
+        if: ${{ !failure() && !cancelled() }}
         runs-on: ubuntu-latest
         needs:
             - integration-tests

--- a/.github/workflows/local_kubernetes_kind_single_region_tests.yml
+++ b/.github/workflows/local_kubernetes_kind_single_region_tests.yml
@@ -377,6 +377,7 @@ jobs:
 
     report-success:
         name: Report success
+        if: ${{ !failure() && !cancelled() }}
         runs-on: ubuntu-latest
         needs:
             - integration-tests


### PR DESCRIPTION
## Summary

- When a workflow is skipped via a `skip_*` label, triage emits `should_skip=true` and the gating job is skipped. The skip cascades down `needs` chains, leaving `report-success` itself skipped (its default `if: success()` returns false when needs are skipped). With no terminal success job, the overall run is marked **failure** — even though nothing actually failed.
- Guard every `report-success` job with `if: ${{ !failure() && !cancelled() }}` so it runs when the chain is intentionally skipped, producing a green terminal job and a `success` run conclusion.
- Real failures still keep `report-success` skipped (because `failure()` is true), and `report-failure` continues to fire via its own `failure()` condition propagated from triage chain ancestors.

Touched 14 workflows on `main`. See e.g. https://github.com/camunda/camunda-deployment-references/actions/runs/26232291170 for the previously-failing-when-skipped behavior on PR #2400.

## Test plan

- [ ] Re-run a workflow with a `skip_*` label applied; verify the run is marked `success` instead of `failure`
- [ ] Confirm an actual failure still triggers Slack notification via `report-failure`