### PR TITLE
ci(slack-alerts): run report-success when upstream jobs are skipped via triage (stable/8.7)

### DIFF
--- a/.github/workflows/aws_common_procedure_s3_bucket.yml
+++ b/.github/workflows/aws_common_procedure_s3_bucket.yml
@@ -132,6 +132,7 @@ jobs:
 
     report-success:
         name: Report success
+        if: ${{ !failure() && !cancelled() }}
         runs-on: ubuntu-latest
         needs:
             - s3-bucket-verification

--- a/.github/workflows/aws_kubernetes_eks_single_region_tests.yml
+++ b/.github/workflows/aws_kubernetes_eks_single_region_tests.yml
@@ -826,6 +826,7 @@ jobs:
 
     report-success:
         name: Report success
+        if: ${{ !failure() && !cancelled() }}
         runs-on: ubuntu-latest
         needs:
             - integration-tests

--- a/.github/workflows/aws_modules_eks_rds_os_tests.yml
+++ b/.github/workflows/aws_modules_eks_rds_os_tests.yml
@@ -283,6 +283,7 @@ jobs:
 
     report-success:
         name: Report success
+        if: ${{ !failure() && !cancelled() }}
         runs-on: ubuntu-latest
         needs:
             - configure-tests

--- a/.github/workflows/aws_openshift_rosa_hcp_dual_region_tests.yml
+++ b/.github/workflows/aws_openshift_rosa_hcp_dual_region_tests.yml
@@ -753,8 +753,8 @@ jobs:
 
     report-success:
         name: Report success
+        if: ${{ !failure() && !cancelled() }}
         runs-on: ubuntu-latest
-        if: success()
         needs:
             - integration-tests
             - cleanup-clusters

--- a/.github/workflows/aws_openshift_rosa_hcp_single_region_tests.yml
+++ b/.github/workflows/aws_openshift_rosa_hcp_single_region_tests.yml
@@ -635,6 +635,7 @@ jobs:
 
     report-success:
         name: Report success
+        if: ${{ !failure() && !cancelled() }}
         runs-on: ubuntu-latest
         needs:
             - integration-tests

--- a/.github/workflows/azure_common_procedure_storageaccount_test.yml
+++ b/.github/workflows/azure_common_procedure_storageaccount_test.yml
@@ -118,6 +118,7 @@ jobs:
 
     report-success:
         name: Report success
+        if: ${{ !failure() && !cancelled() }}
         runs-on: ubuntu-latest
         needs:
             - test-storage-account-creation

--- a/.github/workflows/azure_kubernetes_aks_single_region_tests.yml
+++ b/.github/workflows/azure_kubernetes_aks_single_region_tests.yml
@@ -782,6 +782,7 @@ jobs:
 
     report-success:
         name: Report success
+        if: ${{ !failure() && !cancelled() }}
         runs-on: ubuntu-latest
         needs:
             - integration-tests


### PR DESCRIPTION
## Summary

Backport of #2497 to `stable/8.7`.

When a workflow run is skipped through a skip label (`skip_<workflow_name>`, `skip_all`, `testing-ci-not-necessary`), upstream jobs are marked as skipped and the default `if: success()` on `report-success` causes it to be skipped too. The run then has no terminal success job and is reported as **failure** by GitHub even though nothing actually failed.

Replace the implicit `if: success()` with `if: ${{ !failure() && !cancelled() }}` so `report-success` runs (and reports success) when upstream jobs were skipped, while still being skipped on real failures (handled by `report-failure`, fixed separately in #2487).

## Test plan
- [ ] CI on this PR ends with a green run conclusion
- [ ] Verify on a future run with skip labels that workflow conclusion is `success` instead of `failure`