### PR TITLE
test(ci): probe OpenShift 4.21 compatibility on stable/8.8

### DIFF
--- a/.github/workflows-config/aws-openshift-rosa-hcp-single-region/test_matrix.yml
+++ b/.github/workflows-config/aws-openshift-rosa-hcp-single-region/test_matrix.yml
@@ -5,23 +5,14 @@ matrix:
         # /!\ Please keep this matrix synced with the official documentation:
         # https://github.com/camunda/camunda-docs/blob/main/docs/self-managed/setup/deploy/openshift/redhat-openshift.md?plain=1#L2
         # According to https://access.redhat.com/support/policy/updates/openshift, this matrix should reference the first and the last of the supported versions of OpenShift
-        - name: OpenShift 4.19
+        # TEMP: only OpenShift 4.21 to validate compatibility with stable/8.8.
+        # Do NOT merge — revert to the original 4.19 / 4.18 entries before merging.
+        - name: OpenShift 4.21
           schedule_only: false
           # ! Unlike EKS, 'private_vpc' is defined in 'distro' and not in 'scenario'.
           private_vpc: true # latest always use vpn, olders use public
-          # renovate: datasource=custom.rosa-camunda depName=red-hat-openshift versioning=regex:^4(\.(?<minor>\d+))?(\.(?<patch>\d+))?$
-          version: 4.19.7
-          # /!\ Warning: When a new minor version of OpenShift is released,
-          # you must update the N-3 versions in this matrix.
-          # rationale: Red Hat supports the last four minor versions of OpenShift.
-          # Therefore, to ensure compatibility and support, we test the latest and the older.
-          # For more details, refer to the official support policy at https://endoflife.date/red-hat-openshift.
-
-        - name: OpenShift 4.18
-          schedule_only: true
-          private_vpc: false
-          # renovate: datasource=custom.rosa-camunda depName=red-hat-openshift versioning=regex:^4.18(\.(?<patch>\d+))?$
-          version: 4.18.41
+          # renovate: datasource=custom.rosa-camunda depName=red-hat-openshift versioning=regex:^4.21(\.(?<patch>\d+))?$
+          version: 4.21.15
 
     scenario:
         - name: rosa-hcp-single-region


### PR DESCRIPTION
## Purpose

Validate whether \`stable/8.8\` is compatible with **OpenShift 4.21** by running the existing ROSA HCP single-region test workflow against a single 4.21 distro entry.

## Changes

\`.github/workflows-config/aws-openshift-rosa-hcp-single-region/test_matrix.yml\`:
- Replace the OpenShift 4.19 (\`4.19.7\`) and OpenShift 4.18 (\`4.18.41\`) distro entries with a single **OpenShift 4.21 (\`4.21.15\`)** entry.
- Keep \`private_vpc: true\` (VPN), matching the behavior used for the latest supported version.
- Only one distro is exercised on purpose: we don't need to re-spawn the other supported versions for this compatibility probe.

## Validation

The PR-triggered run of \`aws_openshift_rosa_hcp_single_region_tests.yml\` will provision a ROSA HCP cluster on 4.21.15 and run the standard \`no-domain\` and \`domain\` declinations. Result of that run answers the compatibility question.

## ⚠️ Do NOT merge

This PR is a one-off CI probe. Once the workflow result is known, the matrix must be reverted to its original 4.19 / 4.18 entries (or updated according to the official support policy). Close without merging.