### PR TITLE
fix(ci): unblock ROSA cleanup matrix by dropping rosa delete --watch

### DIFF
--- a/.github/actions/aws-generic-terraform-cleanup/scripts/cleanup-ghost-rosa-clusters.sh
+++ b/.github/actions/aws-generic-terraform-cleanup/scripts/cleanup-ghost-rosa-clusters.sh
@@ -122,20 +122,27 @@ echo "$raw_clusters" | jq -c '.[]' | while read -r cluster; do
   echo "⏳ Waiting for cluster $cluster_name to be fully deregistered..."
   cluster_deregistered=false
   for i in $(seq 1 60); do
-    # Distinguish "cluster not found" from transient errors by checking if the
-    # cluster still appears in the list of clusters. If it does not, we assume
-    # it is fully deregistered; otherwise, we keep waiting.
-    if rosa list clusters 2>/dev/null | grep -q "[[:space:]]${cluster_name}[[:space:]]"; then
-      if [ "$i" -lt 60 ]; then
-        echo "⏳ Cluster still registered, waiting 30s... (attempt $i/60)"
-        sleep 30
+    # Capture `rosa list clusters` separately so we can distinguish a
+    # transient failure (API/network hiccup) from a true "cluster not found".
+    # Treating a non-zero `rosa list` as deregistered would let role deletion
+    # race ahead of cluster teardown and fail with
+    # "clusters using Operator Roles Prefix".
+    if cluster_list=$(rosa list clusters 2>/dev/null); then
+      if echo "$cluster_list" | grep -q "[[:space:]]${cluster_name}[[:space:]]"; then
+        if [ "$i" -lt 60 ]; then
+          echo "⏳ Cluster still registered, waiting 30s... (attempt $i/60)"
+          sleep 30
+        else
+          echo "❌ Cluster $cluster_name is still registered after $i attempts"
+        fi
       else
-        echo "❌ Cluster $cluster_name is still registered after $i attempts"
+        echo "✅ Cluster $cluster_name is fully deregistered"
+        cluster_deregistered=true
+        break
       fi
     else
-      echo "✅ Cluster $cluster_name is fully deregistered"
-      cluster_deregistered=true
-      break
+      echo "⚠️ rosa list clusters failed transiently, retrying in 30s... (attempt $i/60)"
+      sleep 30
     fi
   done
 

--- a/.github/actions/aws-generic-terraform-cleanup/scripts/cleanup-ghost-rosa-clusters.sh
+++ b/.github/actions/aws-generic-terraform-cleanup/scripts/cleanup-ghost-rosa-clusters.sh
@@ -111,20 +111,23 @@ echo "$raw_clusters" | jq -c '.[]' | while read -r cluster; do
   AWS_REGION="$region_id" rosa create operator-roles --mode auto --yes --hosted-cp --prefix "${cluster_name}-operator" --oidc-config-id "${oidc_config_id}" --role-arn "${installer_role_arn}"
 
   echo "💣 Deleting cluster: $cluster_name"
-  AWS_REGION="$region_id" rosa delete cluster -c "$cluster_name" -y --best-effort --watch
+  # Do NOT pass --watch: it blocks for the full ~60 min AWS teardown and
+  # starves later clusters in the matrix. The polling loop below is the
+  # supported wait mechanism.
+  AWS_REGION="$region_id" rosa delete cluster -c "$cluster_name" -y --best-effort
 
   # Wait for the cluster to be fully deregistered from ROSA API
   # rosa delete cluster can return before the cluster is fully removed,
   # which causes operator-roles deletion to fail with "clusters using Operator Roles Prefix"
   echo "⏳ Waiting for cluster $cluster_name to be fully deregistered..."
   cluster_deregistered=false
-  for i in $(seq 1 30); do
+  for i in $(seq 1 60); do
     # Distinguish "cluster not found" from transient errors by checking if the
     # cluster still appears in the list of clusters. If it does not, we assume
     # it is fully deregistered; otherwise, we keep waiting.
     if rosa list clusters 2>/dev/null | grep -q "[[:space:]]${cluster_name}[[:space:]]"; then
-      if [ "$i" -lt 30 ]; then
-        echo "⏳ Cluster still registered, waiting 30s... (attempt $i/30)"
+      if [ "$i" -lt 60 ]; then
+        echo "⏳ Cluster still registered, waiting 30s... (attempt $i/60)"
         sleep 30
       else
         echo "❌ Cluster $cluster_name is still registered after $i attempts"

--- a/.github/workflows/aws_openshift_rosa_hcp_dual_region_tests.yml
+++ b/.github/workflows/aws_openshift_rosa_hcp_dual_region_tests.yml
@@ -886,7 +886,7 @@ jobs:
             - name: Delete on-demand ROSA HCP Cluster
               uses: ./.github/actions/aws-generic-terraform-cleanup
               if: always() && env.CLEANUP_CLUSTERS == 'true'
-              timeout-minutes: 125
+              timeout-minutes: 180
               env:
                   RHCS_TOKEN: ${{ steps.secrets.outputs.RH_OPENSHIFT_TOKEN }}
                   CLUSTER_0_AWS_REGION: ${{ env.CLUSTER_0_AWS_REGION }}

--- a/.github/workflows/aws_openshift_rosa_hcp_single_region_tests.yml
+++ b/.github/workflows/aws_openshift_rosa_hcp_single_region_tests.yml
@@ -824,7 +824,7 @@ jobs:
             - name: Delete on-demand ROSA HCP Cluster
               uses: ./.github/actions/aws-generic-terraform-cleanup
               if: always() && env.CLEANUP_CLUSTERS == 'true'
-              timeout-minutes: 125
+              timeout-minutes: 180
               env:
                   RHCS_TOKEN: ${{ steps.secrets.outputs.RH_OPENSHIFT_TOKEN }}
               with:


### PR DESCRIPTION
## Summary

- Drop `--watch` from `rosa delete cluster` in `cleanup-ghost-rosa-clusters.sh` — it blocked ~60 min on the first ghost cluster in run [26194101603](https://github.com/camunda/camunda-deployment-references/actions/runs/26194101603), starving the rest of the matrix before the 125 min step timeout fired.
- Extend the existing deregistration polling loop from 30 → 60 iterations (30 s each → 30 min total) so it outlasts the no-watch teardown.
- Bump the cleanup step `timeout-minutes` from 125 → 180 on both the dual- and single-region ROSA workflows to absorb the worst case (Terraform destroy ≈ 50 min + several ghost clusters at ≈ 20 min each).

## Background

The ROSA HCP dual-region scheduled run on `stable/8.9` (`26194101603`) hit `##[error]The action has timed out` after 125 min. Reconstructing the timeline from the cleanup log:

| Time | Event |
|------|-------|
| 23:51 → 00:42 | `destroy-resources.sh` (Terraform destroy, ~51 min) |
| 00:43:50 | `rosa delete cluster -y --best-effort --watch` starts on first ghost cluster |
| 01:43:49 | `--watch` finally returns (~60 min) |
| 01:43:50 → 01:56:08 | 25/30 polling attempts (30 s each) |
| 01:56:20 | step timeout fires; second ghost cluster never started |

`--watch` is redundant — the script already polls `rosa list clusters` to confirm deregistration before deleting operator/account roles.

The "ROSA HCP clusters must have default machine pools managed" provider error seen in the same run originates from the Terraform `rhcs` destroy phase and is what produces orphans in the first place. The ghost-cleanup uses the `rosa` CLI, which is not subject to that constraint, so no machine-pool teardown is needed here.

## Test plan

- [ ] Trigger `aws_openshift_rosa_hcp_dual_region_tests.yml` manually on this branch and confirm the cleanup step processes all matrix entries within 180 min.
- [ ] Re-run on `aws_openshift_rosa_hcp_single_region_tests.yml` to confirm the bumped timeout doesn't regress passing single-region runs.
- [ ] Sanity check: search the cleanup step logs for `attempt $i/60` strings to confirm the new polling cadence is in effect.

## Backport

Required on `stable/8.9` (files are byte-identical). Will be included in a bundled backport PR after this lands.