### PR TITLE
fix(aws-eks-dual): raise Zeebe memory to fit chart 14.2.0 RocksDB defaults

### DIFF
--- a/aws/kubernetes/eks-dual-region/helm-values/camunda-values.yml
+++ b/aws/kubernetes/eks-dual-region/helm-values/camunda-values.yml
@@ -111,7 +111,7 @@ orchestration:
     resources:
         requests:
             cpu: 200m
-            memory: 1Gi
+            memory: 2Gi
         limits:
             cpu: 1512m
-            memory: 3Gi
+            memory: 5Gi


### PR DESCRIPTION
## Summary

Raise the orchestration container memory in `aws/kubernetes/eks-dual-region/helm-values/camunda-values.yml`:

- `requests.memory`: 1Gi → 2Gi
- `limits.memory`: 3Gi → 5Gi

## Background

After the Renovate bump to `camunda-platform` 14.2.0 (#2459), Zeebe computes per-partition RocksDB memory as `partitions × 512 MiB`. With `clusterSize: 8`, `partitionCount: 8`, RocksDB asks for ~4 GiB but the container limit was pinned at 3 GiB:

```
java.lang.IllegalArgumentException: Requested RocksDB memory
(4294967296 bytes / 4096 MB) exceeds total system memory
(3221225472 bytes / 3072 MB). Memory allocation strategy: PARTITION.
Partitions count: 8. Consider reducing the value of
CAMUNDA_DATA_PRIMARYSTORAGE_ROCKSDB_MEMORYLIMIT.
```

Every Zeebe pod CrashLoopBackOff'd, so port 26502 was never bound. In run [26194101600](https://github.com/camunda/camunda-deployment-references/actions/runs/26194101600) (stable/8.9) this surfaced as `Cross-cluster connectivity test (London → Paris zeebe:26502) ... TCP connection failed`. The network layer is healthy — DNS resolution and VPC peering work correctly (cross-region nslookup returned all 4 Paris pod IPs); the TCP failure is purely a downstream symptom of the crashing pods.

5 GiB leaves ~1 GiB headroom over RocksDB (4 GiB) for JVM heap/off-heap.

An alternative would be to cap RocksDB explicitly via `CAMUNDA_DATA_PRIMARYSTORAGE_ROCKSDB_MEMORYLIMIT=2147483648`, but raising the limit preserves the intended cluster topology and matches the chart's defaults.

## Test plan

- [x] Trigger `aws_kubernetes_eks_dual_region_tests.yml` and verify Zeebe pods reach `Ready` and the multi-region cross-cluster TCP probe to `zeebe:26502` succeeds.
- [x] Check pod memory usage post-startup to confirm the 5Gi limit isn't immediately maxed out.

## Backport

Required on `stable/8.9` (file identical). Will be included in a bundled backport PR after this lands.