### PR TITLE
fix(aws-eks-dual): raise Zeebe memory to fit chart 14.2.0 RocksDB defaults [stable/8.9]

### DIFF
--- a/aws/kubernetes/eks-dual-region/helm-values/camunda-values.yml
+++ b/aws/kubernetes/eks-dual-region/helm-values/camunda-values.yml
@@ -111,7 +111,7 @@ orchestration:
     resources:
         requests:
             cpu: 200m
-            memory: 1Gi
+            memory: 2Gi
         limits:
             cpu: 1512m
-            memory: 3Gi
+            memory: 5Gi


### PR DESCRIPTION
Backport of #2504 to `stable/8.9`.

## Summary

Raise the orchestration container memory in `aws/kubernetes/eks-dual-region/helm-values/camunda-values.yml`:

- `requests.memory`: 1Gi → 2Gi
- `limits.memory`: 3Gi → 5Gi

File is identical to `main`; clean cherry-equivalent change.

## Background

After the camunda-platform 14.2.0 bump, Zeebe sizes per-partition RocksDB as `partitions × 512 MiB`. With `clusterSize=8` / `partitionCount=8`, RocksDB needs ~4 GiB but the container limit was 3 GiB, so every Zeebe pod CrashLoopBackOff'd and the multi-region TCP probe to `zeebe:26502` failed as a downstream symptom (network layer healthy — DNS and VPC peering verified).

Original failing run on stable/8.9: https://github.com/camunda/camunda-deployment-references/actions/runs/26194101600

## Test plan

- [ ] Trigger `aws_kubernetes_eks_dual_region_tests.yml` on this branch and verify Zeebe pods reach `Ready`.
- [ ] Cross-cluster TCP probe to `zeebe:26502` succeeds.

## Note on 8.8

`aws/kubernetes/eks-dual-region/` does not exist on `stable/8.8` — no backport needed there.