### PR TITLE
fix(ci): backport ROSA cleanup --watch drop + transient list retry to stable/8.9

### DIFF
--- a/.github/actions/aws-generic-terraform-cleanup/scripts/cleanup-ghost-rosa-clusters.sh
+++ b/.github/actions/aws-generic-terraform-cleanup/scripts/cleanup-ghost-rosa-clusters.sh
@@ -122,20 +122,27 @@ echo "$raw_clusters" | jq -c '.[]' | while read -r cluster; do
   echo "⏳ Waiting for cluster $cluster_name to be fully deregistered..."
   cluster_deregistered=false
   for i in $(seq 1 60); do
-    # Distinguish "cluster not found" from transient errors by checking if the
-    # cluster still appears in the list of clusters. If it does not, we assume
-    # it is fully deregistered; otherwise, we keep waiting.
-    if rosa list clusters 2>/dev/null | grep -q "[[:space:]]${cluster_name}[[:space:]]"; then
-      if [ "$i" -lt 60 ]; then
-        echo "⏳ Cluster still registered, waiting 30s... (attempt $i/60)"
-        sleep 30
+    # Capture `rosa list clusters` separately so we can distinguish a
+    # transient failure (API/network hiccup) from a true "cluster not found".
+    # Treating a non-zero `rosa list` as deregistered would let role deletion
+    # race ahead of cluster teardown and fail with
+    # "clusters using Operator Roles Prefix".
+    if cluster_list=$(rosa list clusters 2>/dev/null); then
+      if echo "$cluster_list" | grep -q "[[:space:]]${cluster_name}[[:space:]]"; then
+        if [ "$i" -lt 60 ]; then
+          echo "⏳ Cluster still registered, waiting 30s... (attempt $i/60)"
+          sleep 30
+        else
+          echo "❌ Cluster $cluster_name is still registered after $i attempts"
+        fi
       else
-        echo "❌ Cluster $cluster_name is still registered after $i attempts"
+        echo "✅ Cluster $cluster_name is fully deregistered"
+        cluster_deregistered=true
+        break
       fi
     else
-      echo "✅ Cluster $cluster_name is fully deregistered"
-      cluster_deregistered=true
-      break
+      echo "⚠️ rosa list clusters failed transiently, retrying in 30s... (attempt $i/60)"
+      sleep 30
     fi
   done
 

--- a/.github/actions/aws-generic-terraform-cleanup/scripts/cleanup-ghost-rosa-clusters.sh
+++ b/.github/actions/aws-generic-terraform-cleanup/scripts/cleanup-ghost-rosa-clusters.sh
@@ -111,20 +111,23 @@ echo "$raw_clusters" | jq -c '.[]' | while read -r cluster; do
   AWS_REGION="$region_id" rosa create operator-roles --mode auto --yes --hosted-cp --prefix "${cluster_name}-operator" --oidc-config-id "${oidc_config_id}" --role-arn "${installer_role_arn}"
 
   echo "💣 Deleting cluster: $cluster_name"
-  AWS_REGION="$region_id" rosa delete cluster -c "$cluster_name" -y --best-effort --watch
+  # Do NOT pass --watch: it blocks for the full ~60 min AWS teardown and
+  # starves later clusters in the matrix. The polling loop below is the
+  # supported wait mechanism.
+  AWS_REGION="$region_id" rosa delete cluster -c "$cluster_name" -y --best-effort
 
   # Wait for the cluster to be fully deregistered from ROSA API
   # rosa delete cluster can return before the cluster is fully removed,
   # which causes operator-roles deletion to fail with "clusters using Operator Roles Prefix"
   echo "⏳ Waiting for cluster $cluster_name to be fully deregistered..."
   cluster_deregistered=false
-  for i in $(seq 1 30); do
+  for i in $(seq 1 60); do
     # Distinguish "cluster not found" from transient errors by checking if the
     # cluster still appears in the list of clusters. If it does not, we assume
     # it is fully deregistered; otherwise, we keep waiting.
     if rosa list clusters 2>/dev/null | grep -q "[[:space:]]${cluster_name}[[:space:]]"; then
-      if [ "$i" -lt 30 ]; then
-        echo "⏳ Cluster still registered, waiting 30s... (attempt $i/30)"
+      if [ "$i" -lt 60 ]; then
+        echo "⏳ Cluster still registered, waiting 30s... (attempt $i/60)"
         sleep 30
       else
         echo "❌ Cluster $cluster_name is still registered after $i attempts"

--- a/.github/workflows/aws_openshift_rosa_hcp_dual_region_tests.yml
+++ b/.github/workflows/aws_openshift_rosa_hcp_dual_region_tests.yml
@@ -886,7 +886,7 @@ jobs:
             - name: Delete on-demand ROSA HCP Cluster
               uses: ./.github/actions/aws-generic-terraform-cleanup
               if: always() && env.CLEANUP_CLUSTERS == 'true'
-              timeout-minutes: 125
+              timeout-minutes: 180
               env:
                   RHCS_TOKEN: ${{ steps.secrets.outputs.RH_OPENSHIFT_TOKEN }}
                   CLUSTER_0_AWS_REGION: ${{ env.CLUSTER_0_AWS_REGION }}

--- a/.github/workflows/aws_openshift_rosa_hcp_single_region_tests.yml
+++ b/.github/workflows/aws_openshift_rosa_hcp_single_region_tests.yml
@@ -821,7 +821,7 @@ jobs:
             - name: Delete on-demand ROSA HCP Cluster
               uses: ./.github/actions/aws-generic-terraform-cleanup
               if: always() && env.CLEANUP_CLUSTERS == 'true'
-              timeout-minutes: 125
+              timeout-minutes: 180
               env:
                   RHCS_TOKEN: ${{ steps.secrets.outputs.RH_OPENSHIFT_TOKEN }}
               with:


### PR DESCRIPTION
## Summary

Backports two fixes from `main` (branch `fix/rosa-cleanup-watch-timeout`) to unblock the ROSA HCP Dual Region cleanup matrix on `stable/8.9`.

- `cab1c085` — drop `rosa delete cluster --watch` (which serialised matrix cleanup for ~60 min/cluster), extend the polling loop to 60×30s, bump cleanup workflow `timeout-minutes` to 180.
- `a13ecaf2` — distinguish transient `rosa list clusters` API failures from true deregistration, so role deletion does not race ahead of cluster teardown.

Observed on scheduled run [26194101603](https://github.com/camunda/camunda-deployment-references/actions/runs/26194101603): cleanup job hit `The action has timed out` at attempt 25/30 after `rosa delete cluster --best-effort`.

## Test plan

- [ ] Next scheduled ROSA HCP Dual Region run on `stable/8.9` succeeds at cleanup
- [ ] No regression on ROSA HCP Single Region cleanup