### PR TITLE
fix(ec2): disable schema-manager pre-release check in upgrade test

### DIFF
--- a/aws/compute/ec2-single-region/test/src/default_ec2_test.go
+++ b/aws/compute/ec2-single-region/test/src/default_ec2_test.go
@@ -344,11 +344,17 @@ func TestCamundaUpgrade(t *testing.T) {
 		t.Fatalf("Error writing file: %v", err)
 	}
 
-	// Zeebe has a prerelease protection that results in unhealthy clusters if not disabled
+	// Both Zeebe broker and the search-engine SchemaManager refuse upgrades from/to a
+	// pre-release version (see io.camunda.zeebe.util.migration.VersionCompatibilityCheck —
+	// UseOfPreReleaseVersion). Disable both gates so the upgrade test can run against
+	// SNAPSHOT/alpha builds.
 	if strings.Contains(camundaCurrentVersionFull, "SNAPSHOT") || strings.Contains(camundaCurrentVersionFull, "alpha") {
 		cmd = shell.Command{
 			Command: "bash",
-			Args:    []string{"-c", "echo ZEEBE_BROKER_EXPERIMENTAL_VERSIONCHECKRESTRICTIONENABLED=false >> ../../configs/camunda-environment"},
+			Args: []string{"-c", `cat >> ../../configs/camunda-environment <<'EOF'
+ZEEBE_BROKER_EXPERIMENTAL_VERSIONCHECKRESTRICTIONENABLED=false
+CAMUNDA_DATABASE_SCHEMA_MANAGER_VERSION_CHECK_RESTRICTION_ENABLED=false
+EOF`},
 		}
 		shell.RunCommand(t, cmd)
 	}


### PR DESCRIPTION
## Summary

`TestCamundaUpgrade` (`aws/compute/ec2-single-region/test/src/default_ec2_test.go`) was failing on `main` with:

```
io.camunda.search.schema.exceptions.IncompatibleVersionException:
Cannot upgrade to or from a pre-release version:
UseOfPreReleaseVersion[from=8.9.0, to=8.10.0-SNAPSHOT]
```

The test already disables the Zeebe broker pre-release guard via `ZEEBE_BROKER_EXPERIMENTAL_VERSIONCHECKRESTRICTIONENABLED=false`. Camunda 8.10 adds a **second** identical guard in the search-engine `SchemaManager` (`io.camunda.search.schema.SchemaManager#checkUpgrade`), which fails independently with `IncompatibleVersionException` when the target is a SNAPSHOT/alpha.

This PR sets the analogous Spring Boot property for the SchemaManager side: `CAMUNDA_DATABASE_SCHEMA_MANAGER_VERSION_CHECK_RESTRICTION_ENABLED=false`, gated to the same SNAPSHOT/alpha branch.

Observed on PR #2505 run [26280964750](https://github.com/camunda/camunda-deployment-references/actions/runs/26280964750) — the PR's own fix (connectors launcher) works (`camunda-connectors.service` is running), but `TestCamundaUpgrade` masks it with this unrelated failure.

## Test plan

- [ ] EC2 integration tests pass on this PR
- [ ] When 8.10 GA is released, this guard naturally becomes a no-op (the `SNAPSHOT/alpha` branch is no longer taken)