### PR TITLE
backport(stable/8.9): vendor EC2 connectors launcher + schema-manager pre-release bypass

### DIFF
--- a/aws/compute/ec2-single-region/test/src/default_ec2_test.go
+++ b/aws/compute/ec2-single-region/test/src/default_ec2_test.go
@@ -344,11 +344,17 @@ func TestCamundaUpgrade(t *testing.T) {
 		t.Fatalf("Error writing file: %v", err)
 	}
 
-	// Zeebe has a prerelease protection that results in unhealthy clusters if not disabled
+	// Both Zeebe broker and the search-engine SchemaManager refuse upgrades from/to a
+	// pre-release version (see io.camunda.zeebe.util.migration.VersionCompatibilityCheck —
+	// UseOfPreReleaseVersion). Disable both gates so the upgrade test can run against
+	// SNAPSHOT/alpha builds.
 	if strings.Contains(camundaCurrentVersionFull, "SNAPSHOT") || strings.Contains(camundaCurrentVersionFull, "alpha") {
 		cmd = shell.Command{
 			Command: "bash",
-			Args:    []string{"-c", "echo ZEEBE_BROKER_EXPERIMENTAL_VERSIONCHECKRESTRICTIONENABLED=false >> ../../configs/camunda-environment"},
+			Args: []string{"-c", `cat >> ../../configs/camunda-environment <<'EOF'
+ZEEBE_BROKER_EXPERIMENTAL_VERSIONCHECKRESTRICTIONENABLED=false
+CAMUNDA_DATABASE_SCHEMA_MANAGER_VERSION_CHECK_RESTRICTION_ENABLED=false
+EOF`},
 		}
 		shell.RunCommand(t, cmd)
 	}

--- a/aws/compute/ec2-single-region/test/src/default_ec2_test.go
+++ b/aws/compute/ec2-single-region/test/src/default_ec2_test.go
@@ -259,6 +259,12 @@ func TestCloudWatchFeature(t *testing.T) {
 	}
 }
 
+// TestCamundaUpgrade exercises the in-place upgrade path. When the target
+// version is a SNAPSHOT (default on main / stable branches between releases),
+// the broker may legitimately fail to start because the daily artifact at
+// https://artifacts.camunda.com/artifactory/zeebe/io/camunda/camunda-zeebe/
+// can be broken upstream — independent of anything in this repo. If this test
+// is the only failure on a green PR, re-run later or check upstream Zeebe CI.
 func TestCamundaUpgrade(t *testing.T) {
 	t.Log("Test Camunda upgrade")
 

--- a/aws/compute/ec2-single-region/test/src/default_ec2_test.go
+++ b/aws/compute/ec2-single-region/test/src/default_ec2_test.go
@@ -359,7 +359,7 @@ func TestCamundaUpgrade(t *testing.T) {
 			Command: "bash",
 			Args: []string{"-c", `cat >> ../../configs/camunda-environment <<'EOF'
 ZEEBE_BROKER_EXPERIMENTAL_VERSIONCHECKRESTRICTIONENABLED=false
-CAMUNDA_DATABASE_SCHEMA_MANAGER_VERSION_CHECK_RESTRICTION_ENABLED=false
+CAMUNDA_DATABASE_SCHEMAMANAGER_VERSIONCHECKRESTRICTIONENABLED=false
 EOF`},
 		}
 		shell.RunCommand(t, cmd)

--- a/generic/compute/debian/procedure/camunda-checks.sh
+++ b/generic/compute/debian/procedure/camunda-checks.sh
@@ -44,6 +44,10 @@ check_service_running() {
         echo "[OK] The service '$service_name' is running."
     else
         echo "[FAIL] The service '$service_name' is not running."
+        echo "[INFO] systemctl status (last 50 lines):"
+        sudo systemctl status --no-pager -n 50 "$service_name" || true
+        echo "[INFO] journalctl (last 200 lines):"
+        sudo journalctl -u "$service_name" --no-pager -n 200 || true
         SCRIPT_STATUS_OUTPUT=2
     fi
 }

--- a/generic/compute/debian/procedure/camunda-checks.sh
+++ b/generic/compute/debian/procedure/camunda-checks.sh
@@ -40,7 +40,7 @@ check_service() {
 check_service_running() {
     local service_name=$1
 
-    if systemctl is-active --quiet "$service_name"; then
+    if sudo systemctl is-active --quiet "$service_name"; then
         echo "[OK] The service '$service_name' is running."
     else
         echo "[FAIL] The service '$service_name' is not running."

--- a/generic/compute/debian/procedure/camunda-install.sh
+++ b/generic/compute/debian/procedure/camunda-install.sh
@@ -153,18 +153,26 @@ else
     curl -L --fail-with-body --show-error -w "[INFO] connectors download: HTTP %{http_code} (%{size_download} bytes)\n" ${CURL_NETRC_OPT} "https://artifacts.camunda.com/artifactory/connectors/io/camunda/connector/connector-runtime-bundle/${CAMUNDA_CONNECTORS_VERSION}/connector-runtime-bundle-${CAMUNDA_CONNECTORS_VERSION}-with-dependencies.jar" -o "${MNT_DIR}/connectors/connectors.jar" || { echo "[FAIL] connectors download failed; response body:"; cat "${MNT_DIR}/connectors/connectors.jar" 2>/dev/null | head -c 4096; echo; exit 1; }
 fi
 
+# Connectors JAR is downloaded above (inside the camunda-user heredoc).
+# The launcher is written from the OUTER script on purpose: the surrounding
+# sudo-user heredoc is unquoted, so it would otherwise expand every dollar
+# sign inside the nested quoted LAUNCH body before piping to bash --
+# turning the launcher's $0 into the outer shell's $0 (-bash over SSH) and
+# breaking 'readlink -f' with 'invalid option -- b', plus tripping set -u
+# on SCRIPT_DIR. Writing the file here keeps the launcher body 100% literal.
+EOF
+
 # The connector-runtime-bundle is a Spring Boot uber-jar with its dependencies
 # under BOOT-INF/lib/, so it can only be launched via "java -jar". The upstream
 # start.sh from camunda/connectors@main is unpinned and historically used a
 # flat-classpath invocation that broke whenever the bundle layout changed
 # (e.g. the 8.9.4 release), making every fresh install fail with a JVM
-# class-resolution error. Vendor a minimal self-contained launcher instead.
-cat > "${MNT_DIR}/connectors/start.sh" <<'LAUNCH'
+# class-resolution error. Vendor a minimal self-contained launcher.
+sudo -u "${USERNAME}" tee "${MNT_DIR}/connectors/start.sh" > /dev/null <<'LAUNCH'
 #!/bin/bash
 set -eu
 SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
 # shellcheck disable=SC2086
 exec java ${JAVA_OPTS:-} -jar "${SCRIPT_DIR}/connectors.jar"
 LAUNCH
-chmod +x "${MNT_DIR}/connectors/start.sh"
-EOF
+sudo chmod +x "${MNT_DIR}/connectors/start.sh"

--- a/generic/compute/debian/procedure/camunda-install.sh
+++ b/generic/compute/debian/procedure/camunda-install.sh
@@ -162,8 +162,9 @@ fi
 cat > "${MNT_DIR}/connectors/start.sh" <<'LAUNCH'
 #!/bin/bash
 set -eu
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
 # shellcheck disable=SC2086
-exec java ${JAVA_OPTS:-} -jar "/opt/camunda/connectors/connectors.jar"
+exec java ${JAVA_OPTS:-} -jar "${SCRIPT_DIR}/connectors.jar"
 LAUNCH
 chmod +x "${MNT_DIR}/connectors/start.sh"
 EOF

--- a/generic/compute/debian/procedure/camunda-install.sh
+++ b/generic/compute/debian/procedure/camunda-install.sh
@@ -153,9 +153,17 @@ else
     curl -L --fail-with-body --show-error -w "[INFO] connectors download: HTTP %{http_code} (%{size_download} bytes)\n" ${CURL_NETRC_OPT} "https://artifacts.camunda.com/artifactory/connectors/io/camunda/connector/connector-runtime-bundle/${CAMUNDA_CONNECTORS_VERSION}/connector-runtime-bundle-${CAMUNDA_CONNECTORS_VERSION}-with-dependencies.jar" -o "${MNT_DIR}/connectors/connectors.jar" || { echo "[FAIL] connectors download failed; response body:"; cat "${MNT_DIR}/connectors/connectors.jar" 2>/dev/null | head -c 4096; echo; exit 1; }
 fi
 
-curl -fL https://raw.githubusercontent.com/camunda/connectors/main/bundle/default-bundle/start.sh -o "${MNT_DIR}/connectors/start.sh"
+# The connector-runtime-bundle is a Spring Boot uber-jar with its dependencies
+# under BOOT-INF/lib/, so it can only be launched via "java -jar". The upstream
+# start.sh from camunda/connectors@main is unpinned and historically used a
+# flat-classpath invocation that broke whenever the bundle layout changed
+# (e.g. the 8.9.4 release), making every fresh install fail with a JVM
+# class-resolution error. Vendor a minimal self-contained launcher instead.
+cat > "${MNT_DIR}/connectors/start.sh" <<'LAUNCH'
+#!/bin/bash
+set -eu
+# shellcheck disable=SC2086
+exec java ${JAVA_OPTS:-} -jar "/opt/camunda/connectors/connectors.jar"
+LAUNCH
 chmod +x "${MNT_DIR}/connectors/start.sh"
-
-# shellcheck disable=SC2016
-sed -i '$ s@.*@java ${JAVA_OPTS} -cp "'"${MNT_DIR}/connectors/*"'" "io.camunda.connector.runtime.app.ConnectorRuntimeApplication"@' "${MNT_DIR}/connectors/start.sh"
 EOF


### PR DESCRIPTION
## Summary

Backport of [#2505](https://github.com/camunda/camunda-deployment-references/pull/2505) to `stable/8.9`. Two cherry-picks:

- `ac9129ec` — vendor a minimal connectors `start.sh` (`exec java -jar connectors.jar`) instead of downloading the unpinned upstream `start.sh` and `sed`-rewriting it into a flat `java -cp ...` launcher. The flat-classpath approach broke from connectors `8.9.4` onward because the bundle ships as a Spring Boot uber-jar (`BOOT-INF/lib/`), causing `camunda-connectors.service` to fail on every fresh install (root cause of the recurring EC2 scheduled run failures — see `./debug/ci-failures-report.md`).
- `665120cf` — add `CAMUNDA_DATABASE_SCHEMA_MANAGER_VERSION_CHECK_RESTRICTION_ENABLED=false` alongside the existing Zeebe broker flag in `TestCamundaUpgrade`'s SNAPSHOT/alpha branch. No-op on `stable/8.9` (pinned to `8.9.5`), kept for symmetry with `main`.

Also adds richer service-down diagnostics to `camunda-checks.sh` (`systemctl status` + `journalctl` dump).

## Docs

Verified: no docs in `generic/compute/debian/**`, `aws/compute/ec2-single-region/**` or repo-root `docs/` reference `start.sh`, `JAVA_OPTS`, `ConnectorRuntimeApplication` or the upstream `camunda/connectors` repo. No internal doc change needed.

External `camunda/camunda-docs` follow-up: not required for this fix — the user-facing procedure is unchanged.

## Test plan

- [ ] Next scheduled EC2 Single Region run on `stable/8.9` passes `TestCamundaUpgrade`, `TestAllInOneScript`, `TestCloudWatchFeature` on both x86_64 and arm64
- [ ] `camunda-connectors.service` reaches `Active: running` on fresh install with `CAMUNDA_CONNECTORS_VERSION=8.9.4`