### PR TITLE
fix(openshift-dual): raise Zeebe memory to fit chart 14.2.0 RocksDB defaults

### DIFF
--- a/generic/openshift/dual-region/helm-values/values-base.yml
+++ b/generic/openshift/dual-region/helm-values/values-base.yml
@@ -104,10 +104,10 @@ orchestration:
     resources:
         requests:
             cpu: 200m
-            memory: 1Gi
+            memory: 2Gi
         limits:
             cpu: 1512m
-            memory: 3Gi
+            memory: 5Gi
 
 identity:
     enabled: false


### PR DESCRIPTION
## Summary

Mirror of #2504 (EKS dual-region) for the OpenShift dual-region reference.

Chart 14.2.0 sizes the per-partition RocksDB block cache at 512 MiB, so with `clusterSize=8` and `partitionCount=8` RocksDB needs ~4 GiB while the container limit was capped at 3 GiB. Every Zeebe pod aborts at startup with:

```
IllegalArgumentException: Requested RocksDB memory (4096 MB) exceeds
total system memory (3072 MB). Memory allocation strategy: PARTITION.
```

Raise `limits.memory` to `5Gi` (and `requests` to `2Gi`) in `generic/openshift/dual-region/helm-values/values-base.yml` so RocksDB plus JVM headroom fits, matching the EKS dual fix.

## Test plan

- [ ] Next OpenShift dual-region scheduled run is green (Zeebe pods stay up, cross-region connectivity test passes).