### PR TITLE
fix(openshift-dual): raise Zeebe memory to fit chart 14.2.0 RocksDB defaults (backport #2511 to stable/8.9)

### DIFF
--- a/generic/openshift/dual-region/helm-values/values-base.yml
+++ b/generic/openshift/dual-region/helm-values/values-base.yml
@@ -104,10 +104,10 @@ orchestration:
     resources:
         requests:
             cpu: 200m
-            memory: 1Gi
+            memory: 2Gi
         limits:
             cpu: 1512m
-            memory: 3Gi
+            memory: 5Gi
 
 identity:
     enabled: false


### PR DESCRIPTION
## Summary

Backport of #2511 to `stable/8.9`. Same root cause and fix as the EKS dual backport #2507.

Chart 14.2.0 sizes RocksDB at `partitions * 512 MiB`; with `partitionCount=8` and a 3 GiB container limit, every Zeebe pod aborts at startup. Raise `limits.memory` to `5Gi` (and `requests.memory` to `2Gi`).

## Test plan

- [ ] Next OpenShift dual-region scheduled run on `stable/8.9` is green.
- [ ] Land after the deprecation-check rework so the schema check doesn't pre-empt the multi-region test.