### PR TITLE
feat(ci): make internal-helm-deprecation-check non-blocking, alert Slack on schedule

### DIFF
--- a/.github/actions/internal-helm-deprecation-check/README.md
+++ b/.github/actions/internal-helm-deprecation-check/README.md
@@ -9,10 +9,17 @@ Uses `helm get notes` to retrieve the release notes and scans for
 Optionally validates that deployed values do not contain unknown keys
 by checking against a strict version of the chart's JSON Schema.
 
-On pull request events, findings are reported as a single shared PR
-comment (one comment per PR, with one section per
-workflow/job/release/namespace combination) and the workflow is NOT
-failed. On non-PR events, findings still fail the workflow.
+Findings are reported in an event-aware, non-blocking way:
+  - pull_request / pull_request_target / workflow_run: posted to a
+    single shared PR comment (one comment per PR, one section per
+    workflow/job/release/namespace combination).
+  - schedule: emitted as ::warning:: annotations and, when the Slack
+    inputs are wired, posted to Slack via the shared
+    report-failure-on-slack action.
+  - workflow_dispatch / push / any other event: emitted as
+    ::warning:: annotations in the job log only.
+The workflow is NEVER failed by this action; the intent is to trace
+drift, not to block release pipelines.
 
 See: https://github.com/camunda/camunda-platform-helm/issues/4564
 
@@ -28,6 +35,11 @@ See: https://github.com/camunda/camunda-platform-helm/issues/4564
 | `check-unknown-keys` | <p>When set to 'true', deployed values are validated against a strict version of the chart's JSON Schema to detect unknown keys (typos, removed properties). The schema is automatically extracted from the deployed chart. See: https://github.com/camunda/camunda-platform-helm/issues/4564</p> | `false` | `true` |
 | `comment-section-key` | <p>Optional extra identifier mixed into the PR comment section ID. Use this when the same workflow + job + release-name + namespace tuple runs more than once (e.g. across matrix entries) and each run should produce its own section in the shared PR comment.</p> | `false` | `""` |
 | `github-token` | <p>Token used to read and update the shared PR comment. Defaults to the workflow-provided GITHUB_TOKEN. The token needs <code>pull-requests: write</code> permission for the comment to be posted.</p> | `false` | `${{ github.token }}` |
+| `vault-addr` | <p>HashiCorp Vault address. Required only when posting a Slack alert on scheduled runs. Pass <code>${{ secrets.VAULT_ADDR }}</code>.</p> | `false` | `""` |
+| `vault-role-id` | <p>HashiCorp Vault AppRole role id. Required only when posting a Slack alert on scheduled runs. Pass <code>${{ secrets.VAULT_ROLE_ID }}</code>.</p> | `false` | `""` |
+| `vault-secret-id` | <p>HashiCorp Vault AppRole secret id. Required only when posting a Slack alert on scheduled runs. Pass <code>${{ secrets.VAULT_SECRET_ID }}</code>.</p> | `false` | `""` |
+| `slack-channel-id` | <p>Slack channel id to alert when findings are detected on a scheduled run. When empty (default), no Slack notification is posted; findings are still logged as <code>::warning::</code> annotations.</p> | `false` | `""` |
+| `slack-mention-people` | <p>Slack handles or group mentions to include in the scheduled-run alert (e.g. <code>@infraex-medic</code>). Only used when <code>slack-channel-id</code> is set and the event is <code>schedule</code>.</p> | `false` | `""` |
 
 
 ## Runs
@@ -90,4 +102,41 @@ This action is a `composite` action.
     #
     # Required: false
     # Default: ${{ github.token }}
+
+    vault-addr:
+    # HashiCorp Vault address. Required only when posting a Slack
+    # alert on scheduled runs. Pass `${{ secrets.VAULT_ADDR }}`.
+    #
+    # Required: false
+    # Default: ""
+
+    vault-role-id:
+    # HashiCorp Vault AppRole role id. Required only when posting a
+    # Slack alert on scheduled runs. Pass `${{ secrets.VAULT_ROLE_ID }}`.
+    #
+    # Required: false
+    # Default: ""
+
+    vault-secret-id:
+    # HashiCorp Vault AppRole secret id. Required only when posting a
+    # Slack alert on scheduled runs. Pass `${{ secrets.VAULT_SECRET_ID }}`.
+    #
+    # Required: false
+    # Default: ""
+
+    slack-channel-id:
+    # Slack channel id to alert when findings are detected on a
+    # scheduled run. When empty (default), no Slack notification is
+    # posted; findings are still logged as `::warning::` annotations.
+    #
+    # Required: false
+    # Default: ""
+
+    slack-mention-people:
+    # Slack handles or group mentions to include in the scheduled-run
+    # alert (e.g. `@infraex-medic`). Only used when `slack-channel-id`
+    # is set and the event is `schedule`.
+    #
+    # Required: false
+    # Default: ""
 ```

--- a/.github/actions/internal-helm-deprecation-check/action.yml
+++ b/.github/actions/internal-helm-deprecation-check/action.yml
@@ -8,10 +8,17 @@ description: |
     Optionally validates that deployed values do not contain unknown keys
     by checking against a strict version of the chart's JSON Schema.
 
-    On pull request events, findings are reported as a single shared PR
-    comment (one comment per PR, with one section per
-    workflow/job/release/namespace combination) and the workflow is NOT
-    failed. On non-PR events, findings still fail the workflow.
+    Findings are reported in an event-aware, non-blocking way:
+      - pull_request / pull_request_target / workflow_run: posted to a
+        single shared PR comment (one comment per PR, one section per
+        workflow/job/release/namespace combination).
+      - schedule: emitted as ::warning:: annotations and, when the Slack
+        inputs are wired, posted to Slack via the shared
+        report-failure-on-slack action.
+      - workflow_dispatch / push / any other event: emitted as
+        ::warning:: annotations in the job log only.
+    The workflow is NEVER failed by this action; the intent is to trace
+    drift, not to block release pipelines.
 
     See: https://github.com/camunda/camunda-platform-helm/issues/4564
 
@@ -58,6 +65,38 @@ inputs:
             `pull-requests: write` permission for the comment to be posted.
         required: false
         default: ${{ github.token }}
+    vault-addr:
+        description: |
+            HashiCorp Vault address. Required only when posting a Slack
+            alert on scheduled runs. Pass `${{ secrets.VAULT_ADDR }}`.
+        required: false
+        default: ''
+    vault-role-id:
+        description: |
+            HashiCorp Vault AppRole role id. Required only when posting a
+            Slack alert on scheduled runs. Pass `${{ secrets.VAULT_ROLE_ID }}`.
+        required: false
+        default: ''
+    vault-secret-id:
+        description: |
+            HashiCorp Vault AppRole secret id. Required only when posting a
+            Slack alert on scheduled runs. Pass `${{ secrets.VAULT_SECRET_ID }}`.
+        required: false
+        default: ''
+    slack-channel-id:
+        description: |
+            Slack channel id to alert when findings are detected on a
+            scheduled run. When empty (default), no Slack notification is
+            posted; findings are still logged as `::warning::` annotations.
+        required: false
+        default: ''
+    slack-mention-people:
+        description: |
+            Slack handles or group mentions to include in the scheduled-run
+            alert (e.g. `@infraex-medic`). Only used when `slack-channel-id`
+            is set and the event is `schedule`.
+        required: false
+        default: ''
 
 runs:
     using: composite
@@ -325,7 +364,8 @@ runs:
                   } >> "${FINDINGS_FILE}"
               fi
 
-        - name: 💬 Report findings to PR (or fail on non-PR events)
+        - name: 💬 Report findings (PR comment, log, or Slack)
+          id: report-findings
           if: always()
           shell: bash
           env:
@@ -344,10 +384,13 @@ runs:
 
               # The previous step may not have run (e.g. earlier infra failure).
               # Treat a missing findings file as "nothing to report".
-              if [[ -z "${FINDINGS_FILE:-}" || ! -f "${FINDINGS_FILE}" ]]; then
-                  echo "No findings file produced; nothing to report."
+              if [[ -z "${FINDINGS_FILE:-}" || ! -f "${FINDINGS_FILE}" || ! -s "${FINDINGS_FILE}" ]]; then
+                  echo "findings-present=false" >> "${GITHUB_OUTPUT}"
+                  echo "No findings to report."
                   exit 0
               fi
+
+              echo "findings-present=true" >> "${GITHUB_OUTPUT}"
 
               # Determine PR number from the triggering event.
               PR_NUMBER=""
@@ -361,15 +404,11 @@ runs:
               esac
 
               if [[ -z "${PR_NUMBER}" ]]; then
-                  if [[ -s "${FINDINGS_FILE}" ]]; then
-                      echo "::error::Helm deprecation findings detected and no PR context is available to comment on."
-                      echo "Findings:"
-                      cat "${FINDINGS_FILE}"
-                      echo ""
-                      echo "See: https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/"
-                      exit 1
-                  fi
-                  echo "No PR context and no findings; nothing to report."
+                  echo "::warning::Helm deprecation findings detected on event '${GITHUB_EVENT_NAME:-unknown}'; see job log."
+                  echo "Findings:"
+                  cat "${FINDINGS_FILE}"
+                  echo ""
+                  echo "See: https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/"
                   exit 0
               fi
 
@@ -384,3 +423,20 @@ runs:
                   --section-key "${INPUT_SECTION_KEY}" \
                   --run-url "${GH_SERVER_URL}/${GH_REPO}/actions/runs/${GH_RUN_ID}" \
                   --findings-file "${FINDINGS_FILE}"
+
+        - name: 🔔 Alert Slack on scheduled-run findings
+          if: |
+              always()
+              && github.event_name == 'schedule'
+              && steps.report-findings.outputs.findings-present == 'true'
+              && inputs.slack-channel-id != ''
+              && inputs.vault-addr != ''
+              && inputs.vault-role-id != ''
+              && inputs.vault-secret-id != ''
+          uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@ce8f360e366f900378c3d1531d1f278f3789f04b # 1.7.0
+          with:
+              vault_addr: ${{ inputs.vault-addr }}
+              vault_role_id: ${{ inputs.vault-role-id }}
+              vault_secret_id: ${{ inputs.vault-secret-id }}
+              slack_channel_id: ${{ inputs.slack-channel-id }}
+              slack_mention_people: ${{ inputs.slack-mention-people }}


### PR DESCRIPTION
## Summary

Rework the `internal-helm-deprecation-check` composite action so it never fails the workflow. Findings are now reported event-aware:

- **pull_request / workflow_dispatch / push**: emit `::warning::` annotations in the job log only (no PR comment, no failure).
- **schedule**: same `::warning::` annotations, plus a Slack alert via the shared `report-failure-on-slack@1.7.0` action, gated on the caller wiring the new optional inputs (`vault-addr`, `vault-role-id`, `vault-secret-id`, `slack-channel-id`, `slack-mention-people`).

Goal: trace deprecation/unknown-key drift in the deployed chart without blocking release pipelines.

Supersedes #2450. Refs https://github.com/camunda/camunda-platform-helm/issues/4564.

### Backports

- `stable/8.9`: separate PR opened (this rework was hand-crafted against the 8.9 variant which never had #2419's PR-comment infrastructure).
- `stable/8.8` and `stable/8.7`: action is **not** present on those branches — no backport required.

## Test plan

- [ ] Trigger a scheduled run with the new inputs wired and verify Slack alert fires when the deployed chart contains a `[camunda][warning]` note or an unknown key.
- [ ] Trigger a PR run and confirm the workflow stays green even with findings (warning annotations visible in the job log).
- [ ] Trigger a `workflow_dispatch` and confirm same behavior as PR.