### PR TITLE
backport(stable/8.7): never deploy CI clusters with default demo:demo admin (INC-5340)

### DIFF
--- a/.github/actions/internal-camunda-ci-credentials/README.md
+++ b/.github/actions/internal-camunda-ci-credentials/README.md
@@ -1,0 +1,75 @@
+# Internal — Camunda CI basic-auth credentials
+
+## Description
+
+Fetches a shared Camunda basic-auth user/password from Vault and exposes
+them to the workflow so that publicly reachable CI deployments never run
+with the chart/config default `demo:demo` credentials (see incident
+INC-5340).
+
+Outputs:
+- The credentials are exported to `$GITHUB_ENV` as `CAMUNDA_BASIC_AUTH_USER`
+  and `CAMUNDA_BASIC_AUTH_PASSWORD`.
+- A Helm overlay values file is written at `${{ runner.temp }}/ci-camunda-basic-auth.yml`
+  with init-user overrides for the `camunda-platform` chart. Its path is
+  exported as `CAMUNDA_BASIC_AUTH_VALUES_FILE` env var and as the
+  `values-file` step output, so callers can append it to their `helm`
+  / `--values` invocation (or to a multi-region tests `extra-values-yaml`
+  input) to make the deployed chart use the Vault credentials.
+
+
+## Inputs
+
+| name | description | required | default |
+| --- | --- | --- | --- |
+| `vault-addr` | <p>Vault address (typically secrets.VAULT_ADDR).</p> | `true` | `""` |
+| `vault-role-id` | <p>Vault AppRole role id (typically secrets.VAULT<em>ROLE</em>ID).</p> | `true` | `""` |
+| `vault-secret-id` | <p>Vault AppRole secret id (typically secrets.VAULT<em>SECRET</em>ID).</p> | `true` | `""` |
+| `vault-secret-path` | <p>Vault KV v2 data path holding the basic-auth credentials. Defaults to the shared <code>ci/common</code> secret already used by other workflows: its <code>CI_CAMUNDA_USER_TEST_CLIENT_ID</code> / <code>CI_CAMUNDA_USER_TEST_CLIENT_SECRET</code> keys are reused here as the Camunda basic-auth username/password (the chart provisions a local user matching them via the generated overlay values).</p> | `false` | `secret/data/products/infrastructure-experience/ci/common` |
+
+
+## Outputs
+
+| name | description |
+| --- | --- |
+| `values-file` | <p>Path of the generated Helm overlay values file.</p> |
+
+
+## Runs
+
+This action is a `composite` action.
+
+## Usage
+
+```yaml
+- uses: camunda/camunda-deployment-references/.github/actions/internal-camunda-ci-credentials@main
+  with:
+    vault-addr:
+    # Vault address (typically secrets.VAULT_ADDR).
+    #
+    # Required: true
+    # Default: ""
+
+    vault-role-id:
+    # Vault AppRole role id (typically secrets.VAULT_ROLE_ID).
+    #
+    # Required: true
+    # Default: ""
+
+    vault-secret-id:
+    # Vault AppRole secret id (typically secrets.VAULT_SECRET_ID).
+    #
+    # Required: true
+    # Default: ""
+
+    vault-secret-path:
+    # Vault KV v2 data path holding the basic-auth credentials.
+    # Defaults to the shared `ci/common` secret already used by other
+    # workflows: its `CI_CAMUNDA_USER_TEST_CLIENT_ID` /
+    # `CI_CAMUNDA_USER_TEST_CLIENT_SECRET` keys are reused here as the
+    # Camunda basic-auth username/password (the chart provisions a local
+    # user matching them via the generated overlay values).
+    #
+    # Required: false
+    # Default: secret/data/products/infrastructure-experience/ci/common
+```

--- a/.github/actions/internal-camunda-ci-credentials/README.md
+++ b/.github/actions/internal-camunda-ci-credentials/README.md
@@ -9,13 +9,15 @@ INC-5340).
 
 Outputs:
 - The credentials are exported to `$GITHUB_ENV` as `CAMUNDA_BASIC_AUTH_USER`
-  and `CAMUNDA_BASIC_AUTH_PASSWORD`.
-- A Helm overlay values file is written at `${{ runner.temp }}/ci-camunda-basic-auth.yml`
-  with init-user overrides for the `camunda-platform` chart. Its path is
-  exported as `CAMUNDA_BASIC_AUTH_VALUES_FILE` env var and as the
-  `values-file` step output, so callers can append it to their `helm`
-  / `--values` invocation (or to a multi-region tests `extra-values-yaml`
-  input) to make the deployed chart use the Vault credentials.
+  and `CAMUNDA_BASIC_AUTH_PASSWORD` (written via the GITHUB_ENV heredoc
+  form so the values are never interpolated into the shell source).
+- A Helm overlay values file (JSON, which is valid YAML for helm) is
+  written at `${{ runner.temp }}/ci-camunda-basic-auth.json` with
+  init-user overrides for the `camunda-platform` chart, with `0600`
+  perms. Its path is exposed as the `values-file` step output, so
+  callers can append it to their `helm -f` invocation (or to a
+  multi-region tests `extra-values-yaml` input) to make the deployed
+  chart use the Vault credentials.
 
 
 ## Inputs

--- a/.github/actions/internal-camunda-ci-credentials/README.md
+++ b/.github/actions/internal-camunda-ci-credentials/README.md
@@ -12,7 +12,7 @@ Outputs:
   and `CAMUNDA_BASIC_AUTH_PASSWORD` (written via the GITHUB_ENV heredoc
   form so the values are never interpolated into the shell source).
 - A Helm overlay values file (JSON, which is valid YAML for helm) is
-  written at `${{ runner.temp }}/ci-camunda-basic-auth.json` with
+  written at `$RUNNER_TEMP/ci-camunda-basic-auth.json` with
   init-user overrides for the `camunda-platform` chart, with `0600`
   perms. Its path is exposed as the `values-file` step output, so
   callers can append it to their `helm -f` invocation (or to a

--- a/.github/actions/internal-camunda-ci-credentials/action.yml
+++ b/.github/actions/internal-camunda-ci-credentials/action.yml
@@ -1,0 +1,112 @@
+---
+name: Internal — Camunda CI basic-auth credentials
+description: |
+    Fetches a shared Camunda basic-auth user/password from Vault and exposes
+    them to the workflow so that publicly reachable CI deployments never run
+    with the chart/config default `demo:demo` credentials (see incident
+    INC-5340).
+
+    Outputs:
+    - The credentials are exported to `$GITHUB_ENV` as `CAMUNDA_BASIC_AUTH_USER`
+      and `CAMUNDA_BASIC_AUTH_PASSWORD`.
+    - A Helm overlay values file is written at `${{ runner.temp }}/ci-camunda-basic-auth.yml`
+      with init-user overrides for the `camunda-platform` chart. Its path is
+      exported as `CAMUNDA_BASIC_AUTH_VALUES_FILE` env var and as the
+      `values-file` step output, so callers can append it to their `helm`
+      / `--values` invocation (or to a multi-region tests `extra-values-yaml`
+      input) to make the deployed chart use the Vault credentials.
+
+inputs:
+    vault-addr:
+        description: Vault address (typically secrets.VAULT_ADDR).
+        required: true
+    vault-role-id:
+        description: Vault AppRole role id (typically secrets.VAULT_ROLE_ID).
+        required: true
+    vault-secret-id:
+        description: Vault AppRole secret id (typically secrets.VAULT_SECRET_ID).
+        required: true
+    vault-secret-path:
+        description: |
+            Vault KV v2 data path holding the basic-auth credentials.
+            Defaults to the shared `ci/common` secret already used by other
+            workflows: its `CI_CAMUNDA_USER_TEST_CLIENT_ID` /
+            `CI_CAMUNDA_USER_TEST_CLIENT_SECRET` keys are reused here as the
+            Camunda basic-auth username/password (the chart provisions a local
+            user matching them via the generated overlay values).
+        required: false
+        default: secret/data/products/infrastructure-experience/ci/common
+
+outputs:
+    values-file:
+        description: Path of the generated Helm overlay values file.
+        value: ${{ steps.write-values.outputs.values-file }}
+
+runs:
+    using: composite
+    steps:
+        - name: Import Camunda CI basic-auth credentials
+          id: camunda-ci-credentials
+          uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3
+          with:
+              url: ${{ inputs.vault-addr }}
+              method: approle
+              roleId: ${{ inputs.vault-role-id }}
+              secretId: ${{ inputs.vault-secret-id }}
+              exportEnv: false
+              secrets: |
+                  ${{ inputs.vault-secret-path }} CI_CAMUNDA_USER_TEST_CLIENT_ID | CAMUNDA_BASIC_AUTH_USER;
+                  ${{ inputs.vault-secret-path }} CI_CAMUNDA_USER_TEST_CLIENT_SECRET | CAMUNDA_BASIC_AUTH_PASSWORD;
+
+        - name: Export Camunda CI basic-auth credentials to env
+          shell: bash
+          run: |
+              set -euo pipefail
+              {
+                echo "CAMUNDA_BASIC_AUTH_USER=${{ steps.camunda-ci-credentials.outputs.CAMUNDA_BASIC_AUTH_USER }}"
+                echo "CAMUNDA_BASIC_AUTH_PASSWORD=${{ steps.camunda-ci-credentials.outputs.CAMUNDA_BASIC_AUTH_PASSWORD }}"
+              } >> "$GITHUB_ENV"
+
+        - name: Write Helm overlay values file
+          id: write-values
+          shell: bash
+          env:
+              CAMUNDA_BASIC_AUTH_USER: ${{ steps.camunda-ci-credentials.outputs.CAMUNDA_BASIC_AUTH_USER }}
+              CAMUNDA_BASIC_AUTH_PASSWORD: ${{ steps.camunda-ci-credentials.outputs.CAMUNDA_BASIC_AUTH_PASSWORD }}
+          run: |
+              set -euo pipefail
+              values_file="${RUNNER_TEMP}/ci-camunda-basic-auth.yml"
+
+              # The orchestration chart ships two initial users (index 0 = connectors,
+              # index 1 = admin/demo). We override only the admin entry so that
+              # the connectors user keeps working as documented and so that the
+              # admin login is not demo:demo on the CI cluster.
+              cat > "${values_file}" <<EOF
+              orchestration:
+                  security:
+                      initialization:
+                          users:
+                              - username: connectors
+                                password: connector
+                                name: Connector User
+                                email: connector@demo.com
+                              - username: ${CAMUNDA_BASIC_AUTH_USER}
+                                password: ${CAMUNDA_BASIC_AUTH_PASSWORD}
+                                name: CI Admin User
+                                email: ${CAMUNDA_BASIC_AUTH_USER}@ci.local
+                          defaultRoles:
+                              admin:
+                                  users:
+                                      - ${CAMUNDA_BASIC_AUTH_USER}
+                              connectors:
+                                  users:
+                                      - connectors
+                                  clients:
+                                      - connectors
+              EOF
+
+              {
+                echo "CAMUNDA_BASIC_AUTH_VALUES_FILE=${values_file}"
+              } >> "$GITHUB_ENV"
+              echo "values-file=${values_file}" >> "$GITHUB_OUTPUT"
+              echo "[INFO] Helm overlay values file written to ${values_file}"

--- a/.github/actions/internal-camunda-ci-credentials/action.yml
+++ b/.github/actions/internal-camunda-ci-credentials/action.yml
@@ -8,13 +8,15 @@ description: |
 
     Outputs:
     - The credentials are exported to `$GITHUB_ENV` as `CAMUNDA_BASIC_AUTH_USER`
-      and `CAMUNDA_BASIC_AUTH_PASSWORD`.
-    - A Helm overlay values file is written at `${{ runner.temp }}/ci-camunda-basic-auth.yml`
-      with init-user overrides for the `camunda-platform` chart. Its path is
-      exported as `CAMUNDA_BASIC_AUTH_VALUES_FILE` env var and as the
-      `values-file` step output, so callers can append it to their `helm`
-      / `--values` invocation (or to a multi-region tests `extra-values-yaml`
-      input) to make the deployed chart use the Vault credentials.
+      and `CAMUNDA_BASIC_AUTH_PASSWORD` (written via the GITHUB_ENV heredoc
+      form so the values are never interpolated into the shell source).
+    - A Helm overlay values file (JSON, which is valid YAML for helm) is
+      written at `${{ runner.temp }}/ci-camunda-basic-auth.json` with
+      init-user overrides for the `camunda-platform` chart, with `0600`
+      perms. Its path is exposed as the `values-file` step output, so
+      callers can append it to their `helm -f` invocation (or to a
+      multi-region tests `extra-values-yaml` input) to make the deployed
+      chart use the Vault credentials.
 
 inputs:
     vault-addr:
@@ -58,55 +60,80 @@ runs:
                   ${{ inputs.vault-secret-path }} CI_CAMUNDA_USER_TEST_CLIENT_ID | CAMUNDA_BASIC_AUTH_USER;
                   ${{ inputs.vault-secret-path }} CI_CAMUNDA_USER_TEST_CLIENT_SECRET | CAMUNDA_BASIC_AUTH_PASSWORD;
 
+        # Export the credentials to $GITHUB_ENV using the heredoc form so the
+        # values are never interpolated by the GHA expression engine inside a
+        # `run:` script (which would put the secret literally in the shell
+        # source, defeating GitHub's masker on transformations / shell traces).
+        # The values come in via the `env:` table; bash only sees "$VAR".
         - name: Export Camunda CI basic-auth credentials to env
-          shell: bash
-          run: |
-              set -euo pipefail
-              {
-                echo "CAMUNDA_BASIC_AUTH_USER=${{ steps.camunda-ci-credentials.outputs.CAMUNDA_BASIC_AUTH_USER }}"
-                echo "CAMUNDA_BASIC_AUTH_PASSWORD=${{ steps.camunda-ci-credentials.outputs.CAMUNDA_BASIC_AUTH_PASSWORD }}"
-              } >> "$GITHUB_ENV"
-
-        - name: Write Helm overlay values file
-          id: write-values
           shell: bash
           env:
               CAMUNDA_BASIC_AUTH_USER: ${{ steps.camunda-ci-credentials.outputs.CAMUNDA_BASIC_AUTH_USER }}
               CAMUNDA_BASIC_AUTH_PASSWORD: ${{ steps.camunda-ci-credentials.outputs.CAMUNDA_BASIC_AUTH_PASSWORD }}
           run: |
               set -euo pipefail
-              values_file="${RUNNER_TEMP}/ci-camunda-basic-auth.yml"
-
-              # The orchestration chart ships two initial users (index 0 = connectors,
-              # index 1 = admin/demo). We override only the admin entry so that
-              # the connectors user keeps working as documented and so that the
-              # admin login is not demo:demo on the CI cluster.
-              cat > "${values_file}" <<EOF
-              orchestration:
-                  security:
-                      initialization:
-                          users:
-                              - username: connectors
-                                password: connector
-                                name: Connector User
-                                email: connector@demo.com
-                              - username: ${CAMUNDA_BASIC_AUTH_USER}
-                                password: ${CAMUNDA_BASIC_AUTH_PASSWORD}
-                                name: CI Admin User
-                                email: ${CAMUNDA_BASIC_AUTH_USER}@ci.local
-                          defaultRoles:
-                              admin:
-                                  users:
-                                      - ${CAMUNDA_BASIC_AUTH_USER}
-                              connectors:
-                                  users:
-                                      - connectors
-                                  clients:
-                                      - connectors
-              EOF
-
+              delim="GH_ENV_$(openssl rand -hex 16)"
               {
-                echo "CAMUNDA_BASIC_AUTH_VALUES_FILE=${values_file}"
+                printf '%s<<%s\n%s\n%s\n' "CAMUNDA_BASIC_AUTH_USER"     "$delim" "$CAMUNDA_BASIC_AUTH_USER"     "$delim"
+                printf '%s<<%s\n%s\n%s\n' "CAMUNDA_BASIC_AUTH_PASSWORD" "$delim" "$CAMUNDA_BASIC_AUTH_PASSWORD" "$delim"
               } >> "$GITHUB_ENV"
-              echo "values-file=${values_file}" >> "$GITHUB_OUTPUT"
-              echo "[INFO] Helm overlay values file written to ${values_file}"
+
+        # Render the Helm overlay through python's json module (helm accepts
+        # JSON values files) so the password is treated as opaque data and
+        # cannot be interpolated by either the GHA expression engine or by
+        # bash heredoc expansion. The file is written with 0600 perms in
+        # ${RUNNER_TEMP} so only the runner user can read it back.
+        - name: Write Helm overlay values file
+          id: write-values
+          shell: bash
+          env:
+              CAMUNDA_BASIC_AUTH_USER: ${{ steps.camunda-ci-credentials.outputs.CAMUNDA_BASIC_AUTH_USER }}
+              CAMUNDA_BASIC_AUTH_PASSWORD: ${{ steps.camunda-ci-credentials.outputs.CAMUNDA_BASIC_AUTH_PASSWORD }}
+              VALUES_FILE: ${{ runner.temp }}/ci-camunda-basic-auth.json
+          run: |
+              set -euo pipefail
+              umask 077
+
+              # The orchestration chart ships two initial users (index 0 =
+              # connectors, index 1 = admin/demo). We override only the admin
+              # entry so that the connectors user keeps working as documented
+              # and so the admin login is not demo:demo on the CI cluster.
+              python3 - <<'PY'
+              import json, os
+              user = os.environ["CAMUNDA_BASIC_AUTH_USER"]
+              pw   = os.environ["CAMUNDA_BASIC_AUTH_PASSWORD"]
+              doc = {
+                  "orchestration": {
+                      "security": {
+                          "initialization": {
+                              "users": [
+                                  {
+                                      "username": "connectors",
+                                      "password": "connector",
+                                      "name": "Connector User",
+                                      "email": "connector@demo.com",
+                                  },
+                                  {
+                                      "username": user,
+                                      "password": pw,
+                                      "name": "CI Admin User",
+                                      "email": f"{user}@ci.local",
+                                  },
+                              ],
+                              "defaultRoles": {
+                                  "admin":      {"users": [user]},
+                                  "connectors": {
+                                      "users":   ["connectors"],
+                                      "clients": ["connectors"],
+                                  },
+                              },
+                          }
+                      }
+                  }
+              }
+              with open(os.environ["VALUES_FILE"], "w", encoding="utf-8") as f:
+                  json.dump(doc, f)
+              PY
+              chmod 600 "${VALUES_FILE}"
+              echo "values-file=${VALUES_FILE}" >> "$GITHUB_OUTPUT"
+              echo "[INFO] Helm overlay values file written to ${VALUES_FILE}"

--- a/.github/actions/internal-camunda-ci-credentials/action.yml
+++ b/.github/actions/internal-camunda-ci-credentials/action.yml
@@ -11,7 +11,7 @@ description: |
       and `CAMUNDA_BASIC_AUTH_PASSWORD` (written via the GITHUB_ENV heredoc
       form so the values are never interpolated into the shell source).
     - A Helm overlay values file (JSON, which is valid YAML for helm) is
-      written at `${{ runner.temp }}/ci-camunda-basic-auth.json` with
+      written at `$RUNNER_TEMP/ci-camunda-basic-auth.json` with
       init-user overrides for the `camunda-platform` chart, with `0600`
       perms. Its path is exposed as the `values-file` step output, so
       callers can append it to their `helm -f` invocation (or to a

--- a/.github/workflows/aws_openshift_rosa_hcp_dual_region_tests.yml
+++ b/.github/workflows/aws_openshift_rosa_hcp_dual_region_tests.yml
@@ -570,6 +570,34 @@ jobs:
                   ./generic/openshift/dual-region/procedure/assemble-envsubst-values.sh
 
 
+            # Fetches CAMUNDA_BASIC_AUTH_USER/PASSWORD from Vault and writes a
+            # Helm overlay values file so the CI cluster is not protected by
+            # the chart default demo:demo admin (see incident INC-5340).
+            - name: Camunda CI basic-auth credentials
+              id: camunda-ci-credentials
+              uses: ./.github/actions/internal-camunda-ci-credentials
+              with:
+                  vault-addr: ${{ secrets.VAULT_ADDR }}
+                  vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+                  vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+
+            # Merge the CI overlay into the values files produced by
+            # assemble-envsubst-values.sh, so install-chart.sh stays
+            # untouched and customer-facing procedures keep their default
+            # behavior.
+            - name: Merge CI basic-auth overlay into generated values
+              shell: bash
+              env:
+                  OVERLAY_FILE: ${{ steps.camunda-ci-credentials.outputs.values-file }}
+              run: |
+                  set -euo pipefail
+                  for region_values in generated-values-region-1.yml generated-values-region-2.yml; do
+                      # shellcheck disable=SC2016 # $item is a yq expression, not a shell variable
+                      yq eval-all '. as $item ireduce ({}; . *+ $item)' \
+                          "${region_values}" "${OVERLAY_FILE}" > "${region_values}.merged"
+                      mv "${region_values}.merged" "${region_values}"
+                  done
+
             - name: 🏁 Install Camunda 8 using the generic/openshift helm chart procedure
               timeout-minutes: 30
               run: |

--- a/.github/workflows/aws_openshift_rosa_hcp_dual_region_tests.yml
+++ b/.github/workflows/aws_openshift_rosa_hcp_dual_region_tests.yml
@@ -17,6 +17,7 @@ on:
             - .github/actions/aws-openshift-rosa-hcp-dual-region-cleanup/**
             - .github/actions/aws-configure-cli/**
             - .github/actions/internal-apply-skip-label/**
+            - .github/actions/internal-camunda-ci-credentials/**
             - .github/actions/internal-generic-encrypt-export/**
             - .github/actions/internal-generic-decrypt-import/**
             - .github/actions/internal-tests-matrix/**


### PR DESCRIPTION
## Backport

This PR backports the CI portion of the main-branch [fix/remove-hardcoded-demo-credentials](https://github.com/camunda/camunda-deployment-references/tree/fix/remove-hardcoded-demo-credentials) work to `stable/8.7`.

Original work / context: INC-5340 — the chart's default `demo:demo` admin credentials were inherited by every CI deployment. We now override them in CI to ensure the cluster is never deployed with `demo:demo` even by accident.

## What this PR contains

Strategy: **CI-only override** (no breaking changes to user-facing defaults).

Reusable composite action `internal-camunda-ci-credentials` fetches a Camunda basic-auth user/password from the shared Vault entry `secret/data/products/infrastructure-experience/ci/common` (reusing the existing `CI_CAMUNDA_USER_TEST_CLIENT_ID` and `CI_CAMUNDA_USER_TEST_CLIENT_SECRET` keys via vault-action key aliasing). It then writes a Helm overlay values file that overrides:
- `orchestration.security.initialization.users[1]` (the chart's default `demo` admin) — `users[0]` (connectors) is preserved
- `defaultRoles.admin.users`

### Ref archs covered on 8.7
- `aws/openshift/rosa-hcp-dual-region` — wiring via a new `EXTRA_HELM_VALUES_FILE` env var honored by `generic/openshift/dual-region/procedure/install-chart.sh`. The script remains backwards compatible: when the variable is unset the behavior is unchanged.

8.7 does not ship `aws/compute/ec2-single-region` nor `aws/kubernetes/eks-dual-region`, so only the ROSA HCP dual-region ref arch is part of this backport.

## Notes
- No new Vault secret had to be provisioned: we reuse the existing `ci/common` entry already used by other workflows.
- User-facing documentation still describes `demo:demo` as the default. A docs PR clarifying that this is an insecure default suitable only for local/quickstart is tracked separately.
