### PR TITLE
fix(ec2/test): also bypass search-engine schema manager pre-release check during upgrade

### DIFF
--- a/aws/compute/ec2-single-region/test/src/default_ec2_test.go
+++ b/aws/compute/ec2-single-region/test/src/default_ec2_test.go
@@ -344,11 +344,18 @@ func TestCamundaUpgrade(t *testing.T) {
 		t.Fatalf("Error writing file: %v", err)
 	}
 
-	// Zeebe has a prerelease protection that results in unhealthy clusters if not disabled
+	// Zeebe and the search-engine schema manager both have a pre-release version
+	// protection. Without disabling them, upgrading to a SNAPSHOT/alpha build results
+	// in either unhealthy Zeebe clusters or a failed app start with
+	// io.camunda.search.schema.exceptions.IncompatibleVersionException
+	// ("Cannot upgrade to or from a pre-release version").
 	if strings.Contains(camundaCurrentVersionFull, "SNAPSHOT") || strings.Contains(camundaCurrentVersionFull, "alpha") {
 		cmd = shell.Command{
 			Command: "bash",
-			Args:    []string{"-c", "echo ZEEBE_BROKER_EXPERIMENTAL_VERSIONCHECKRESTRICTIONENABLED=false >> ../../configs/camunda-environment"},
+			Args: []string{"-c", "cat <<'EOF' >> ../../configs/camunda-environment\n" +
+				"ZEEBE_BROKER_EXPERIMENTAL_VERSIONCHECKRESTRICTIONENABLED=false\n" +
+				"CAMUNDA_DATABASE_SCHEMAMANAGER_VERSIONCHECKRESTRICTIONENABLED=false\n" +
+				"EOF\n"},
 		}
 		shell.RunCommand(t, cmd)
 	}


### PR DESCRIPTION
### Which problem does the PR fix?

`TestCamundaUpgrade` for the EC2 single-region reference exercises an upgrade from N-1 (current stable, e.g. `8.9.0`) to N (current SNAPSHOT, e.g. `8.10.0-SNAPSHOT`). On the SNAPSHOT target, the search-engine schema manager refuses to migrate from/to a pre-release version and the application fails to start with:

```
io.camunda.search.schema.exceptions.IncompatibleVersionException:
Cannot upgrade to or from a pre-release version: UseOfPreReleaseVersion[from=8.9.0, to=8.10.0-SNAPSHOT]
```

This blocks every PR that touches EC2 (or any PR re-running the suite), e.g. failing on #2505: https://github.com/camunda/camunda-deployment-references/actions/runs/26292821777/job/77400025963

### What's in this PR?

We already neutralize the equivalent **Zeebe** check via `ZEEBE_BROKER_EXPERIMENTAL_VERSIONCHECKRESTRICTIONENABLED=false`. This PR adds the **search-engine** counterpart in the same SNAPSHOT/alpha branch:

```
CAMUNDA_DATABASE_SCHEMAMANAGER_VERSIONCHECKRESTRICTIONENABLED=false
```

Both env vars are appended to `configs/camunda-environment` only when the upgrade target is a pre-release (`SNAPSHOT` / `alpha`), so production deployments are unaffected.

This is the same pattern already used by the chart integration scenarios (e.g. `charts/camunda-platform-{8.8,8.9,8.10}/test/integration/scenarios/.../base-upgrade.yaml`, `rba.yaml`, `oidc.yaml`).

### Backports

Same broken test (and same Zeebe-only workaround) exists on `stable/8.9` and `stable/8.8`. I'll open backports once this merges. `stable/8.7` does not have the EC2 reference, so no backport needed there.
