### PR TITLE
fix(ci): clarify CI basic-auth overlay comment (INC-5340 follow-up)

### DIFF
--- a/.github/actions/internal-camunda-ci-credentials/action.yml
+++ b/.github/actions/internal-camunda-ci-credentials/action.yml
@@ -95,9 +95,12 @@ runs:
               umask 077
 
               # The orchestration chart ships two initial users (index 0 =
-              # connectors, index 1 = admin/demo). We override only the admin
-              # entry so that the connectors user keeps working as documented
-              # and so the admin login is not demo:demo on the CI cluster.
+              # connectors, index 1 = admin/demo). Helm merges arrays by full
+              # replacement, so we must emit the COMPLETE users list here —
+              # the connectors entry below is the verbatim chart default and
+              # must stay in sync with it so the connectors auth keeps
+              # working; only the admin entry is rewritten with CI-provided
+              # credentials so the cluster never comes up as demo:demo.
               python3 - <<'PY'
               import json, os
               user = os.environ["CAMUNDA_BASIC_AUTH_USER"]


### PR DESCRIPTION
## Description

Follow-up on the INC-5340 backport series ([#2517](https://github.com/camunda/camunda-deployment-references/pull/2517) is already merged on `stable/8.7`). Addresses a Copilot review comment that landed on `.github/actions/internal-camunda-ci-credentials/action.yml` after the original PR was merged.

The previous comment claimed the overlay "overrides only the admin entry", but the rendered JSON sets the entire `orchestration.security.initialization.users` array. Helm replaces arrays wholesale, so the connectors entry must be re-declared from the chart defaults — otherwise the connectors user would disappear and connector auth would break. The comment is now explicit about this so future maintainers don't accidentally trim the array down to just the admin user.

Mirror PRs:
- `stable/8.9` — [#2515](https://github.com/camunda/camunda-deployment-references/pull/2515)
- `stable/8.8` — [#2516](https://github.com/camunda/camunda-deployment-references/pull/2516)

The other Copilot fixes from those PRs (envsubst preflight in `camunda-configure.sh`, `basicAuthDemoHeader` rename in `helpers.go`, test doc comment, workflow secret-export hardening) don't apply to `stable/8.7` because those files don't exist on this branch.

## Related issues / links

- INC-5340
- [#2517](https://github.com/camunda/camunda-deployment-references/pull/2517) (already-merged backport this follows up on)

## Definition of Done

<!-- markdown-link-check-disable -->

- Code changes:
  - [x] The changes are working as expected and according to the requirements discussed.
  - [x] Comment-only change, no behavior change.
  - [x] No deployment side effects.

<!-- markdown-link-check-enable -->
