### PR TITLE
fix(generic-debian): drop sudo from camunda-checks.sh (broke EC2 RA over SSH)

### DIFF
--- a/generic/compute/debian/procedure/camunda-checks.sh
+++ b/generic/compute/debian/procedure/camunda-checks.sh
@@ -40,14 +40,14 @@ check_service() {
 check_service_running() {
     local service_name=$1
 
-    if sudo systemctl is-active --quiet "$service_name"; then
+    if systemctl is-active --quiet "$service_name"; then
         echo "[OK] The service '$service_name' is running."
     else
         echo "[FAIL] The service '$service_name' is not running."
         echo "[INFO] systemctl status (last 50 lines):"
-        sudo systemctl status --no-pager -n 50 "$service_name" || true
+        systemctl status --no-pager -n 50 "$service_name" || true
         echo "[INFO] journalctl (last 200 lines):"
-        sudo journalctl -u "$service_name" --no-pager -n 200 || true
+        journalctl -u "$service_name" --no-pager -n 200 || true
         SCRIPT_STATUS_OUTPUT=2
     fi
 }


### PR DESCRIPTION
## Summary

Reverts the sudo additions made in #2510 (commit 4a65fd42) to `generic/compute/debian/procedure/camunda-checks.sh`.

`camunda-checks.sh` is piped over SSH by the EC2 RA smoke test:

```
ssh -J admin@BASTION_IP admin@CAMUNDA_IP < ./camunda-checks.sh
```

No TTY is allocated and the `admin` user has no NOPASSWD rule, so every `sudo` call fails with:

```
sudo: a terminal is required to read the password; either use the -S option to read from standard input or configure an askpass helper
sudo: a password is required
```

This blocked the EC2 single-region CI on stable/8.9 — see e.g. https://github.com/camunda/camunda-deployment-references/actions/runs/26302507282/job/77433127668?pr=2505.

`systemctl is-active` / `systemctl status` work fine for any user via the systemd D-Bus API, and `journalctl -u <unit>` is readable by members of `systemd-journal` (default for `adm` on Debian/Ubuntu cloud images). The original (pre-#2510) behaviour was correct — restore it.

## Test plan

- [ ] CI green on Tests - Integration - AWS Compute EC2 Single Region