### PR TITLE
fix(test): remove leftover demo:demo fallback defaults (INC-5340)

### DIFF
--- a/.github/workflows/_migration_test_run.yml
+++ b/.github/workflows/_migration_test_run.yml
@@ -480,9 +480,13 @@ jobs:
                   export NAMESPACE="${{ env.CAMUNDA_NAMESPACE }}"
                   export TEST_CLIENT_ID="${{ steps.secrets.outputs.CI_CAMUNDA_USER_TEST_CLIENT_ID }}"
                   export TEST_CLIENT_SECRET="${{ steps.secrets.outputs.CI_CAMUNDA_USER_TEST_CLIENT_SECRET }}"
+                  # Empty in this workflow today (no internal-camunda-ci-credentials wired in);
+                  # kept here so the rendered job never falls back to demo:demo (INC-5340).
+                  export CAMUNDA_BASIC_AUTH_USER="${CAMUNDA_BASIC_AUTH_USER:-}"
+                  export CAMUNDA_BASIC_AUTH_PASSWORD="${CAMUNDA_BASIC_AUTH_PASSWORD:-}"
 
                   # shellcheck disable=SC2016
-                  envsubst '${NAMESPACE} ${TEST_CLIENT_ID} ${TEST_CLIENT_SECRET}' \
+                  envsubst '${NAMESPACE} ${TEST_CLIENT_ID} ${TEST_CLIENT_SECRET} ${CAMUNDA_BASIC_AUTH_USER} ${CAMUNDA_BASIC_AUTH_PASSWORD}' \
                       < generic/kubernetes/migration/tests/verify-test-data-job.yml \
                       | kubectl apply -n "${{ env.CAMUNDA_NAMESPACE }}" -f -
 
@@ -594,12 +598,14 @@ jobs:
                   export NAMESPACE="${{ env.CAMUNDA_NAMESPACE }}"
                   export TEST_CLIENT_ID="${{ steps.secrets.outputs.CI_CAMUNDA_USER_TEST_CLIENT_ID }}"
                   export TEST_CLIENT_SECRET="${{ steps.secrets.outputs.CI_CAMUNDA_USER_TEST_CLIENT_SECRET }}"
+                  export CAMUNDA_BASIC_AUTH_USER="${CAMUNDA_BASIC_AUTH_USER:-}"
+                  export CAMUNDA_BASIC_AUTH_PASSWORD="${CAMUNDA_BASIC_AUTH_PASSWORD:-}"
 
                   # Delete previous verify job from Phase 4
                   kubectl delete job verify-test-data -n "${{ env.CAMUNDA_NAMESPACE }}" --ignore-not-found=true
 
                   # shellcheck disable=SC2016
-                  envsubst '${NAMESPACE} ${TEST_CLIENT_ID} ${TEST_CLIENT_SECRET}' \
+                  envsubst '${NAMESPACE} ${TEST_CLIENT_ID} ${TEST_CLIENT_SECRET} ${CAMUNDA_BASIC_AUTH_USER} ${CAMUNDA_BASIC_AUTH_PASSWORD}' \
                       < generic/kubernetes/migration/tests/verify-test-data-job.yml \
                       | kubectl apply -n "${{ env.CAMUNDA_NAMESPACE }}" -f -
 

--- a/aws/kubernetes/eks-dual-region/test/internal/helpers/kubectl/helpers.go
+++ b/aws/kubernetes/eks-dual-region/test/internal/helpers/kubectl/helpers.go
@@ -28,13 +28,16 @@ import (
 )
 
 // basicAuthHeader is the Authorization header for the Camunda basic-auth user
-// used by the test suite. Defaults to demo:demo (the chart's default), but CI
-// overrides it by exporting CAMUNDA_BASIC_AUTH_USER and CAMUNDA_BASIC_AUTH_PASSWORD
-// so the publicly reachable CI cluster never authenticates with demo:demo
-// (see incident INC-5340).
+// used by the test suite. Sourced from CAMUNDA_BASIC_AUTH_USER and
+// CAMUNDA_BASIC_AUTH_PASSWORD env vars (set in CI by internal-camunda-ci-credentials).
+// Panics if either is empty — the publicly reachable CI cluster must never
+// authenticate with demo:demo (see incident INC-5340).
 var basicAuthHeader = func() string {
-	user := helpers.GetEnv("CAMUNDA_BASIC_AUTH_USER", "demo")
-	password := helpers.GetEnv("CAMUNDA_BASIC_AUTH_PASSWORD", "demo")
+	user := os.Getenv("CAMUNDA_BASIC_AUTH_USER")
+	password := os.Getenv("CAMUNDA_BASIC_AUTH_PASSWORD")
+	if user == "" || password == "" {
+		panic("CAMUNDA_BASIC_AUTH_USER and CAMUNDA_BASIC_AUTH_PASSWORD must be set (see INC-5340)")
+	}
 	return "Basic " + base64.StdEncoding.EncodeToString([]byte(user+":"+password))
 }()
 

--- a/generic/kubernetes/migration/tests/verify-test-data-job.yml
+++ b/generic/kubernetes/migration/tests/verify-test-data-job.yml
@@ -56,8 +56,12 @@ spec:
                         WM_URL="http://camunda-web-modeler-restapi:80"
                         WM_MGMT_URL="http://camunda-web-modeler-restapi:8091"
 
-                        DEMO_USER="demo"
-                        DEMO_PASS="demo"
+                        # Basic-auth credentials are sourced from env (injected via
+                        # envsubst from CAMUNDA_BASIC_AUTH_USER/PASSWORD on the runner —
+                        # see INC-5340: never authenticate with demo:demo). The basic-auth
+                        # branch below fails loudly if these are empty.
+                        DEMO_USER="${CAMUNDA_BASIC_AUTH_USER}"
+                        DEMO_PASS="${CAMUNDA_BASIC_AUTH_PASSWORD}"
                         KC_REALM="camunda-platform"
 
                         # Determine KC admin credentials:
@@ -176,6 +180,10 @@ spec:
                                     -H "Accept: application/json" \
                                     -d "{\"filter\":{\"processDefinitionId\":\"${PROCESS_ID}\"}}" 2>/dev/null || echo '{}')
                             else
+                                if [ -z "${DEMO_USER}" ] || [ -z "${DEMO_PASS}" ]; then
+                                    fail_test "Basic auth requested but CAMUNDA_BASIC_AUTH_USER/PASSWORD are empty (refusing to fall back to demo:demo — see INC-5340)"
+                                    break
+                                fi
                                 SEARCH_RESP=$(curl -sf --connect-timeout 5 --max-time 30 \
                                     -u "${DEMO_USER}:${DEMO_PASS}" \
                                     -X POST "${ZEEBE_URL}/v2/process-instances/search" \

--- a/generic/kubernetes/single-region/tests/integration/config/config.go
+++ b/generic/kubernetes/single-region/tests/integration/config/config.go
@@ -67,8 +67,8 @@ func FromEnv() (*Config, error) {
 		DomainGRPC: envOr("CAMUNDA_DOMAIN_GRPC", ""),
 
 		AuthMode:     envOr("TEST_AUTH_MODE", "oidc"),
-		BasicUser:    envOr("TEST_BASIC_USER", "demo"),
-		BasicPass:    envOr("TEST_BASIC_PASSWORD", "demo"),
+		BasicUser:    envOr("TEST_BASIC_USER", ""),
+		BasicPass:    envOr("TEST_BASIC_PASSWORD", ""),
 		OIDCTokenURL: envOr("TEST_OIDC_TOKEN_URL", ""),
 		OIDCClientID: envOr("TEST_OIDC_CLIENT_ID", ""),
 		OIDCSecret:   envOr("TEST_OIDC_CLIENT_SECRET", ""),


### PR DESCRIPTION
## Summary

Backport of #2523 to `stable/8.9`. Follow-up to #2515 — three sites still defaulted to `demo`/`demo`:

- `aws/kubernetes/eks-dual-region/test/internal/helpers/kubectl/helpers.go` — panic at init if `CAMUNDA_BASIC_AUTH_USER`/`PASSWORD` are missing.
- `generic/kubernetes/single-region/tests/integration/config/config.go` — drop `"demo"` defaults from `TEST_BASIC_USER` / `TEST_BASIC_PASSWORD`.
- `generic/kubernetes/migration/tests/verify-test-data-job.yml` — source basic-auth from env via envsubst, refuse to run with empty values.
- `.github/workflows/_migration_test_run.yml` — export `CAMUNDA_BASIC_AUTH_USER`/`PASSWORD` with empty fallback and add to envsubst allowlist.

## Test plan

- [x] `go build ./...` passes in both modified Go modules.
- [x] Pre-commit hooks pass.
- [ ] CI re-runs green on the migration / EKS Dual jobs.