### PR TITLE
fix(test): drop demo:demo default in check-zeebe-cluster-topology.sh (INC-5340)

### DIFF
--- a/generic/kubernetes/dual-region/procedure/check-zeebe-cluster-topology.sh
+++ b/generic/kubernetes/dual-region/procedure/check-zeebe-cluster-topology.sh
@@ -15,7 +15,14 @@ trap cleanup EXIT
 sleep 2
 
 echo "📡 Fetching Zeebe cluster topology..."
-topology=$(curl -s -L -u "${ZEEBE_BASIC_AUTH_USER:-demo}:${ZEEBE_BASIC_AUTH_PASSWORD:-demo}" -X GET 'http://localhost:8080/v2/topology' -H 'Accept: application/json')
+# Only attach basic-auth when both vars are set. Never default to demo:demo
+# (see INC-5340) — an unauthenticated cluster works without -u, an
+# authenticated one must receive real credentials from the caller.
+AUTH_ARGS=()
+if [[ -n "${ZEEBE_BASIC_AUTH_USER:-}" && -n "${ZEEBE_BASIC_AUTH_PASSWORD:-}" ]]; then
+    AUTH_ARGS=(-u "${ZEEBE_BASIC_AUTH_USER}:${ZEEBE_BASIC_AUTH_PASSWORD}")
+fi
+topology=$(curl -s -L "${AUTH_ARGS[@]}" -X GET 'http://localhost:8080/v2/topology' -H 'Accept: application/json')
 echo "$topology" > zeebe-topology.json
 
 jq . zeebe-topology.json


### PR DESCRIPTION
## Summary

Backport of the topology-script fix landed on main (#2523) and stable/8.9 (#2524).

`generic/kubernetes/dual-region/procedure/check-zeebe-cluster-topology.sh` unconditionally sent \`-u demo:demo\` when \`ZEEBE_BASIC_AUTH_USER/PASSWORD\` were unset. Replaced with a conditional \`-u\` so:

- an unauthenticated cluster (current CI mode on \`rosa-hcp-dual-region\`) works without auth header,
- an authenticated cluster receives only real credentials from the caller.

Note: \`http-smoke-test.sh\` does not exist on stable/8.8, so only the topology script is touched here.

## Test plan

- [x] \`bash -n\` passes on the modified script.
- [x] Pre-commit hooks pass.
- [ ] \`aws_openshift_rosa_hcp_dual_region_tests.yml\` re-runs green.