### PR TITLE
fix(test): drop demo:demo defaults from http-smoke-test (INC-5340)

### DIFF
--- a/.github/actions/camunda-smoke-test/README.md
+++ b/.github/actions/camunda-smoke-test/README.md
@@ -23,8 +23,8 @@ For non-Kubernetes (ECS Fargate, EC2):
 | `oidc-client-id` | <p>OIDC client ID for M2M authentication. If empty, auto-extracted from <release-name>-credentials secret (client ID defaults to 'orchestration').</p> | `false` | `""` |
 | `oidc-client-secret` | <p>OIDC client secret for M2M authentication. If empty, auto-extracted from <release-name>-credentials secret (key: identity-orchestration-client-token).</p> | `false` | `""` |
 | `oidc-token-url` | <p>OIDC token endpoint URL (e.g., https://<keycloak>/realms/camunda-platform/protocol/openid-connect/token). Required for non-Kubernetes deployments (ECS / EC2) when auth-mode=oidc. In Kubernetes mode this input is ignored — the URL is derived from the auto-port-forwarded Keycloak.</p> | `false` | `""` |
-| `basic-auth-user` | <p>Username for basic auth.</p> | `false` | `demo` |
-| `basic-auth-password` | <p>Password for basic auth.</p> | `false` | `demo` |
+| `basic-auth-user` | <p>Username for basic auth. Required when auth-mode=basic. No default — callers must supply real credentials (see INC-5340).</p> | `false` | `""` |
+| `basic-auth-password` | <p>Password for basic auth. Required when auth-mode=basic. No default — callers must supply real credentials (see INC-5340).</p> | `false` | `""` |
 | `benchmark-duration` | <p>Duration in seconds. Default 300 = 5 minutes.</p> | `false` | `300` |
 | `benchmark-pi-per-second` | <p>Process instances per second to generate.</p> | `false` | `5` |
 | `min-expected-instances` | <p>Minimum process instances expected.</p> | `false` | `10` |
@@ -97,16 +97,16 @@ This action is a `composite` action.
     # Default: ""
 
     basic-auth-user:
-    # Username for basic auth.
+    # Username for basic auth. Required when auth-mode=basic. No default — callers must supply real credentials (see INC-5340).
     #
     # Required: false
-    # Default: demo
+    # Default: ""
 
     basic-auth-password:
-    # Password for basic auth.
+    # Password for basic auth. Required when auth-mode=basic. No default — callers must supply real credentials (see INC-5340).
     #
     # Required: false
-    # Default: demo
+    # Default: ""
 
     benchmark-duration:
     # Duration in seconds. Default 300 = 5 minutes.

--- a/.github/actions/camunda-smoke-test/action.yml
+++ b/.github/actions/camunda-smoke-test/action.yml
@@ -73,13 +73,17 @@ inputs:
 
     # ── Basic auth inputs ─────────────────────────────────────────
     basic-auth-user:
-        description: Username for basic auth.
+        description: >
+            Username for basic auth. Required when auth-mode=basic.
+            No default — callers must supply real credentials (see INC-5340).
         required: false
-        default: demo
+        default: ''
     basic-auth-password:
-        description: Password for basic auth.
+        description: >
+            Password for basic auth. Required when auth-mode=basic.
+            No default — callers must supply real credentials (see INC-5340).
         required: false
-        default: demo
+        default: ''
 
     # ── Benchmark inputs ──────────────────────────────────────────
     benchmark-duration:

--- a/.github/actions/camunda-smoke-test/scripts/http-smoke-test.sh
+++ b/.github/actions/camunda-smoke-test/scripts/http-smoke-test.sh
@@ -19,8 +19,8 @@ FAILURES=0
 # ── Configuration from environment ──────────────────────────────────
 ZEEBE_URL="${SMOKE_ZEEBE_REST_URL:?SMOKE_ZEEBE_REST_URL is required}"
 AUTH_MODE="${SMOKE_AUTH_MODE:-basic}"
-BASIC_USER="${SMOKE_BASIC_USER:-demo}"
-BASIC_PASSWORD="${SMOKE_BASIC_PASSWORD:-demo}"
+BASIC_USER="${SMOKE_BASIC_USER:-}"
+BASIC_PASSWORD="${SMOKE_BASIC_PASSWORD:-}"
 TOKEN_URL="${SMOKE_OIDC_TOKEN_URL:-}"
 CLIENT_ID="${SMOKE_OIDC_CLIENT_ID:-}"
 CLIENT_SECRET="${SMOKE_OIDC_CLIENT_SECRET:-}"
@@ -70,6 +70,10 @@ refresh_auth() {
 }
 
 if [[ "$AUTH_MODE" == "basic" ]]; then
+    if [[ -z "$BASIC_USER" || -z "$BASIC_PASSWORD" ]]; then
+        fail_test "basic auth requires SMOKE_BASIC_USER and SMOKE_BASIC_PASSWORD (refusing to fall back to demo:demo — see INC-5340)"
+        exit 1
+    fi
     AUTH_ARGS=(-u "${BASIC_USER}:${BASIC_PASSWORD}")
     log "Auth mode: basic (user=${BASIC_USER})"
 elif [[ "$AUTH_MODE" == "oidc" ]]; then


### PR DESCRIPTION
Backport of the main follow-up (#2526) to #2524. Closes the two remaining demo:demo fallbacks in the smoke-test path:

1. **`action.yml`** — `basic-auth-user` / `basic-auth-password` no longer default to `demo`. Callers using `auth-mode: basic` must supply real credentials (today: EC2 + ECS workflows, both already pass real creds).
2. **`http-smoke-test.sh`** — when `AUTH_MODE=basic`, refuses to run if `SMOKE_BASIC_USER` / `SMOKE_BASIC_PASSWORD` are empty (fail-fast with explicit message).

The customer-facing dual-region topology check (`generic/kubernetes/dual-region/procedure/check-zeebe-cluster-topology.sh`) is intentionally **not** touched — it is a documented procedure.