### PR TITLE
docs(aurora): make subnet_ids and vpc_id descriptions source-agnostic

### DIFF
--- a/aws/modules/aurora/README.md
+++ b/aws/modules/aurora/README.md
@@ -63,10 +63,10 @@ No modules.
 | <a name="input_instance_class"></a> [instance\_class](#input\_instance\_class) | The instance type of the Aurora instances | `string` | `"db.t3.medium"` | no |
 | <a name="input_num_instances"></a> [num\_instances](#input\_num\_instances) | Number of instances | `string` | `"1"` | no |
 | <a name="input_password"></a> [password](#input\_password) | The password for the postgres admin user. Important: secret value! | `string` | n/a | yes |
-| <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | The subnet IDs to create the cluster in (private subnets recommended). In the EKS reference architectures these are passed through from the AWS EKS Cluster module; other consumers (e.g. ECS Fargate) pass them from a standalone VPC module. | `list(string)` | n/a | yes |
+| <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | The subnet IDs to create the Aurora cluster in. Private subnets are recommended. Provide subnets from any networking source (the repo's reference architectures wire these from their respective VPC/EKS modules). | `list(string)` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags to add to the resources | `map` | `{}` | no |
 | <a name="input_username"></a> [username](#input\_username) | The username for the postgres admin user. Important: secret value! | `string` | n/a | yes |
-| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The VPC ID to create the cluster in. In the EKS reference architectures this is passed through from the AWS EKS Cluster module; other consumers (e.g. ECS Fargate) pass it from a standalone VPC module. | `any` | n/a | yes |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The VPC ID to create the Aurora cluster in. Provide a VPC ID from any networking source (the repo's reference architectures wire this from their respective VPC/EKS modules). | `any` | n/a | yes |
 ## Outputs
 
 | Name | Description |

--- a/aws/modules/aurora/README.md
+++ b/aws/modules/aurora/README.md
@@ -63,10 +63,10 @@ No modules.
 | <a name="input_instance_class"></a> [instance\_class](#input\_instance\_class) | The instance type of the Aurora instances | `string` | `"db.t3.medium"` | no |
 | <a name="input_num_instances"></a> [num\_instances](#input\_num\_instances) | Number of instances | `string` | `"1"` | no |
 | <a name="input_password"></a> [password](#input\_password) | The password for the postgres admin user. Important: secret value! | `string` | n/a | yes |
-| <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | The subnet IDs to create the cluster in. For easier usage we are passing through the subnet IDs from the AWS EKS Cluster module. | `list(string)` | n/a | yes |
+| <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | The subnet IDs to create the cluster in (private subnets recommended). In the EKS reference architectures these are passed through from the AWS EKS Cluster module; other consumers (e.g. ECS Fargate) pass them from a standalone VPC module. | `list(string)` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags to add to the resources | `map` | `{}` | no |
 | <a name="input_username"></a> [username](#input\_username) | The username for the postgres admin user. Important: secret value! | `string` | n/a | yes |
-| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The VPC ID to create the cluster in. For easier usage we are passing through the VPC ID from the AWS EKS Cluster module. | `any` | n/a | yes |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The VPC ID to create the cluster in. In the EKS reference architectures this is passed through from the AWS EKS Cluster module; other consumers (e.g. ECS Fargate) pass it from a standalone VPC module. | `any` | n/a | yes |
 ## Outputs
 
 | Name | Description |

--- a/aws/modules/aurora/variables.tf
+++ b/aws/modules/aurora/variables.tf
@@ -55,7 +55,7 @@ variable "tags" {
 
 variable "subnet_ids" {
   type        = list(string)
-  description = "The subnet IDs to create the cluster in. For easier usage we are passing through the subnet IDs from the AWS EKS Cluster module."
+  description = "The subnet IDs to create the Aurora cluster in. Private subnets are recommended. Provide subnets from any networking source (the repo's reference architectures wire these from their respective VPC/EKS modules)."
 }
 
 variable "cidr_blocks" {
@@ -65,7 +65,7 @@ variable "cidr_blocks" {
 
 # pass through from root
 variable "vpc_id" {
-  description = "The VPC ID to create the cluster in. For easier usage we are passing through the VPC ID from the AWS EKS Cluster module."
+  description = "The VPC ID to create the Aurora cluster in. Provide a VPC ID from any networking source (the repo's reference architectures wire this from their respective VPC/EKS modules)."
 }
 
 # Allows adding additional iam roles to grant access from Aurora to e.g. S3


### PR DESCRIPTION
## Description

The `subnet_ids` and `vpc_id` variable descriptions in `aws/modules/aurora` stated the values are passed through from the AWS EKS Cluster module. That is only true for the EKS reference architectures — the ECS Fargate reference architecture sources the same inputs from a standalone VPC module (`module.vpc`).

This rewords the descriptions to describe the module's actual (source-agnostic) contract, while keeping the EKS wiring as an example. README terraform-docs table updated to match.

## Changes

- `aws/modules/aurora/variables.tf`: reworded `subnet_ids` and `vpc_id` descriptions.
- `aws/modules/aurora/README.md`: regenerated input table rows accordingly.

## Notes

- Documentation-only; no functional impact. The module already works for all consumers (EKS standard, EKS IRSA, ECS Fargate).
- `pre-commit`/`terraform-docs` were not available locally, so the README rows were updated by hand to match the new descriptions.

Closes #2571