### PR TITLE
fix(eks-dual-region): evaluate basic-auth header lazily (INC-5340)

### DIFF
--- a/aws/kubernetes/eks-dual-region/test/internal/helpers/kubectl/helpers.go
+++ b/aws/kubernetes/eks-dual-region/test/internal/helpers/kubectl/helpers.go
@@ -27,19 +27,22 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// basicAuthDemoHeader is the Authorization header for the Camunda basic-auth user
-// used by the test suite. Sourced from CAMUNDA_BASIC_AUTH_USER and
-// CAMUNDA_BASIC_AUTH_PASSWORD env vars (set in CI by internal-camunda-ci-credentials).
-// Panics if either is empty — the publicly reachable CI cluster must never
-// authenticate with demo:demo (see incident INC-5340).
-var basicAuthDemoHeader = func() string {
+// basicAuthDemoHeader returns the Authorization header for the Camunda basic-auth
+// user. Sourced from CAMUNDA_BASIC_AUTH_USER and CAMUNDA_BASIC_AUTH_PASSWORD env
+// vars (set in CI by internal-camunda-ci-credentials).
+// It is evaluated lazily (not at package init) so test phases that never issue
+// authenticated requests — e.g. kubeconfig generation during cluster prepare and
+// cleanup — do not require these credentials. Panics if either is empty when an
+// authenticated request is actually made — the publicly reachable CI cluster
+// must never authenticate with demo:demo (see incident INC-5340).
+func basicAuthDemoHeader() string {
 	user := os.Getenv("CAMUNDA_BASIC_AUTH_USER")
 	password := os.Getenv("CAMUNDA_BASIC_AUTH_PASSWORD")
 	if user == "" || password == "" {
 		panic("CAMUNDA_BASIC_AUTH_USER and CAMUNDA_BASIC_AUTH_PASSWORD must be set (see INC-5340)")
 	}
 	return "Basic " + base64.StdEncoding.EncodeToString([]byte(user+":"+password))
-}()
+}
 
 var (
 	// ElasticsearchPodName is the ECK-managed Elasticsearch pod used for exec operations (backup, restore, health checks).
@@ -265,7 +268,7 @@ func CheckOperateForProcesses(t *testing.T, cluster helpers.Cluster, tenantId st
 			return
 		}
 		req.Header.Add("Content-Type", "application/json")
-		req.Header.Add("Authorization", basicAuthDemoHeader)
+		req.Header.Add("Authorization", basicAuthDemoHeader())
 
 		res, err := client.Do(req)
 		if err != nil {
@@ -328,7 +331,7 @@ func CheckOperateForProcessInstances(t *testing.T, cluster helpers.Cluster, size
 			return
 		}
 		req.Header.Add("Content-Type", "application/json")
-		req.Header.Add("Authorization", basicAuthDemoHeader)
+		req.Header.Add("Authorization", basicAuthDemoHeader())
 
 		res, err := client.Do(req)
 		if err != nil {
@@ -726,7 +729,7 @@ func StartProcessInstances(t *testing.T, kubectlOptions *k8s.KubectlOptions, pro
 			Headers: map[string]string{
 				"Content-Type":  "application/json",
 				"Accept":        "application/json",
-				"Authorization": basicAuthDemoHeader,
+				"Authorization": basicAuthDemoHeader(),
 			},
 			TlsConfig: nil,
 			Timeout:   30,
@@ -792,7 +795,7 @@ func DeployBpmnProcess(t *testing.T, kubectlOptions *k8s.KubectlOptions, bpmnFil
 		Headers: map[string]string{
 			"Content-Type":  writer.FormDataContentType(),
 			"Accept":        "application/json",
-			"Authorization": basicAuthDemoHeader,
+			"Authorization": basicAuthDemoHeader(),
 		},
 		TlsConfig: nil,
 		Timeout:   30,
@@ -887,7 +890,7 @@ func CreateTenant(t *testing.T, cluster helpers.Cluster, tenantId, name, descrip
 
 	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("Accept", "application/json")
-	req.Header.Add("Authorization", basicAuthDemoHeader)
+	req.Header.Add("Authorization", basicAuthDemoHeader())
 
 	res, err := client.Do(req)
 	if err != nil {
@@ -929,7 +932,7 @@ func AssignRoleToTenant(t *testing.T, cluster helpers.Cluster, tenantId, roleID 
 		return
 	}
 
-	req.Header.Add("Authorization", basicAuthDemoHeader)
+	req.Header.Add("Authorization", basicAuthDemoHeader())
 
 	res, err := client.Do(req)
 	if err != nil {
@@ -971,7 +974,7 @@ func CheckTenantExists(t *testing.T, cluster helpers.Cluster, tenantId string) {
 	}
 
 	req.Header.Add("Accept", "application/json")
-	req.Header.Add("Authorization", basicAuthDemoHeader)
+	req.Header.Add("Authorization", basicAuthDemoHeader())
 
 	res, err := client.Do(req)
 	if err != nil {
@@ -1128,7 +1131,7 @@ func WaitForGatewayAuthReady(t *testing.T, kubectlOptions *k8s.KubectlOptions, m
 			time.Sleep(interval)
 			continue
 		}
-		req.Header.Set("Authorization", basicAuthDemoHeader)
+		req.Header.Set("Authorization", basicAuthDemoHeader())
 
 		resp, err := client.Do(req)
 		if err != nil {
@@ -1164,7 +1167,7 @@ func GetClusterTopology(t *testing.T, kubectlOptions *k8s.KubectlOptions) Cluste
 		Method: "GET",
 		Url:    fmt.Sprintf("http://%s/v2/topology", endpoint),
 		Headers: map[string]string{
-			"Authorization": basicAuthDemoHeader,
+			"Authorization": basicAuthDemoHeader(),
 			"Accept":        "application/json",
 		},
 		TlsConfig: nil,


### PR DESCRIPTION
## Description

The INC-5340 hardening introduced a package-level guard for the Camunda
basic-auth credentials in the EKS dual-region test helpers:

```go
var basicAuthDemoHeader = func() string {
    user := os.Getenv("CAMUNDA_BASIC_AUTH_USER")
    password := os.Getenv("CAMUNDA_BASIC_AUTH_PASSWORD")
    if user == "" || password == "" {
        panic("CAMUNDA_BASIC_AUTH_USER and CAMUNDA_BASIC_AUTH_PASSWORD must be set (see INC-5340)")
    }
    ...
}()
```

Because it is evaluated **at package init**, *any* `go test` invocation that
imports the `kubectl` helper package panics when the credentials are absent —
including phases that never issue an authenticated request.

In particular, the `prepare-clusters` and `cleanup-clusters` jobs only run
`go test -run TestAWSKubeConfigCreation` (kubeconfig generation) and only fetch
`CI_ENCRYPTION_KEY` from Vault — never the Camunda credentials. As a result both
jobs fail at init with:

```
panic: CAMUNDA_BASIC_AUTH_USER and CAMUNDA_BASIC_AUTH_PASSWORD must be set (see INC-5340)
```

## Fix

Convert `basicAuthDemoHeader` from an init-evaluated variable into a function
that is evaluated **on demand** at each authenticated request. The guard now
only trips when an authenticated request is actually made, so kubeconfig
generation and cleanup no longer require the credentials.

The INC-5340 protection (the publicly reachable CI cluster must never
authenticate with `demo:demo`) is fully preserved for every real request.

## Changes

- `basicAuthDemoHeader` → `basicAuthDemoHeader()` (lazy function).
- Updated all 9 call sites to invoke the function.

## Validation

- `go build ./...` and `go vet ./internal/helpers/kubectl/` pass.
- No remaining bare references to the variable.

## Backports

- `stable/8.9`: #2573 (variable named `basicAuthHeader`).
- `stable/8.8` and `stable/8.7`: not affected — the `eks-dual-region` test
  helper does not exist on those branches.
