### PR TITLE
fix(eks-dual-region): drop removed identityKeycloak values key (chart 15)

### DIFF
--- a/aws/kubernetes/eks-dual-region/helm-values/camunda-values.yml
+++ b/aws/kubernetes/eks-dual-region/helm-values/camunda-values.yml
@@ -37,9 +37,6 @@ global:
 identity:
     enabled: false
 
-identityKeycloak:
-    enabled: false
-
 console:
     enabled: false # by default, console is not enabled
 

--- a/generic/kubernetes/operator-based/elasticsearch/camunda-elastic-values.yml
+++ b/generic/kubernetes/operator-based/elasticsearch/camunda-elastic-values.yml
@@ -37,7 +37,3 @@ optimize:
                 secret:
                     existingSecret: elasticsearch-es-elastic-user
                     existingSecretKey: elastic
-
-# Disable bundled Elasticsearch sub-chart (using ECK-managed instance)
-elasticsearch:
-    enabled: false


### PR DESCRIPTION
## Description

The EKS dual-region integration test (`TestAWSDeployDualRegCamunda/TestDeployC8Helm`)
fails when deploying the Camunda Platform Helm chart `15-dev-latest`
(chart 15.x / Camunda 8.10):

```
Error: execution error at (camunda-platform/templates/common/constraints.tpl):
[camunda][error] The Helm values file key "identityKeycloak" has been removed.
```

In chart 15.x the bundled Bitnami subcharts (`identityKeycloak`,
`identityPostgresql`, `webModelerPostgresql`, `elasticsearch`) were removed.
The constraint now fails on the mere **presence** of the `identityKeycloak`
key (`hasKey .Values "identityKeycloak"`), even when set to `enabled: false`.

## Fix

Remove the now-invalid top-level `identityKeycloak: { enabled: false }` block
from the dual-region values file. There is no bundled Keycloak subchart to
disable anymore, so the key is no longer needed.

The deployment intent is unchanged: this dual-region setup uses basic-auth
(`demo/demo`) with Identity authentication disabled
(`global.security.authentication.method: basic`, `identity.enabled: false`),
so no Keycloak is deployed regardless.

## Scope

Only the EKS dual-region values file is touched, since that is the scenario
failing in CI against the `15-dev-latest` chart. Other values files that still
reference bundled subcharts target different scenarios/chart versions and are
out of scope here.

## Validation

- `grep` confirms no remaining removed-subchart keys
  (`identityKeycloak`, `identityPostgresql`, `webModelerPostgresql`,
  `elasticsearch`) in `aws/kubernetes/eks-dual-region/helm-values/`.
