### PR TITLE
ci(aks): drop obsolete values-enterprise.yaml base

### DIFF
--- a/.github/workflows/azure_kubernetes_aks_single_region_tests.yml
+++ b/.github/workflows/azure_kubernetes_aks_single_region_tests.yml
@@ -478,22 +478,16 @@ jobs:
 
                   echo "Construct the values.yml file"
 
-                  # Get the Camunda version to determine the correct values-enterprise.yaml file
-                  CAMUNDA_VERSION=$(cat .camunda-version)
-                  echo "Using Camunda version: $CAMUNDA_VERSION"
-
-                  # TODO: In the future, we should pass values-enterprise.yaml directly to helm install command
-                  # using the -f flag as documented in the official Camunda documentation:
-                  # However, we cannot update the procedure documentation yet, so we download and merge manually for now.
-
-                  # Download values-enterprise.yaml from the corresponding chart version
-                  # This follows the best practice of using enterprise images for Camunda components.
-                  # For third-party images (e.g., Bitnami charts like PostgreSQL, Keycloak),
-                  # values-enterprise.yaml already points to enterprise-supported registries when available.
-                  # This configuration is applied in both test and non-test scenarios to ensure consistency.
-                  curl -fsSL \
-                    "https://raw.githubusercontent.com/camunda/camunda-platform-helm/refs/heads/main/charts/camunda-platform-${CAMUNDA_VERSION}/values-enterprise.yaml" \
-                    -o ./values.yml
+                  # Start from an empty base and build the deployment values purely from
+                  # the reference-architecture overlays merged below (operator-managed
+                  # Elasticsearch/Keycloak, OIDC, etc.).
+                  #
+                  # The previous enterprise-image base (values-enterprise.yaml) only ever
+                  # configured the bundled Bitnami sub-charts. Chart 15 (Camunda 8.10)
+                  # removed those sub-charts, so values-enterprise.yaml no longer exists
+                  # upstream and is irrelevant to the operator-based architecture deployed
+                  # here.
+                  echo "{}" > ./values.yml
 
                   # Merge with specific azure/kubernetes values
                   yq ". *+ load(\"azure/kubernetes/${{ matrix.scenario.name }}/helm-values/values-${{ matrix.declination.name }}.yml\")" values.yml > values-result.yml

--- a/aws/kubernetes/eks-single-region-irsa/helm-values/values-domain.yml
+++ b/aws/kubernetes/eks-single-region-irsa/helm-values/values-domain.yml
@@ -174,11 +174,3 @@ webModeler:
                 existingSecret: webmodeler-secret
                 existingSecretKey: smtp-password
             fromAddress: changeme@example.com   # change this required value
-
-webModelerPostgresql:
-    # Will deploy a postgresql database for webModeler.
-    # If you enable webModeler, you either need to turn it true or use an external database
-    enabled: false
-
-elasticsearch:
-    enabled: false

--- a/aws/kubernetes/eks-single-region-irsa/helm-values/values-no-domain.yml
+++ b/aws/kubernetes/eks-single-region-irsa/helm-values/values-no-domain.yml
@@ -137,11 +137,3 @@ webModeler:
                 existingSecret: webmodeler-secret
                 existingSecretKey: smtp-password
             fromAddress: changeme@example.com   # change this required value
-
-webModelerPostgresql:
-    # Will deploy a postgresql datbase for webModeler.
-    # If you enable webModeler, you either need to turn it true or use an external database
-    enabled: false
-
-elasticsearch:
-    enabled: false

--- a/aws/kubernetes/eks-single-region/helm-values/values-domain.yml
+++ b/aws/kubernetes/eks-single-region/helm-values/values-domain.yml
@@ -136,11 +136,3 @@ webModeler:
                 existingSecret: webmodeler-secret
                 existingSecretKey: smtp-password
             fromAddress: changeme@example.com   # change this required value
-
-webModelerPostgresql:
-    # Will deploy a postgresql datbase for webModeler.
-    # If you enable webModeler, you either need to turn it true or use an external database
-    enabled: false
-
-elasticsearch:
-    enabled: false

--- a/aws/kubernetes/eks-single-region/helm-values/values-no-domain.yml
+++ b/aws/kubernetes/eks-single-region/helm-values/values-no-domain.yml
@@ -96,12 +96,3 @@ orchestration:
                 admin:
                     users:
                         - admin
-
-
-webModelerPostgresql:
-    # Will deploy a postgresql datbase for webModeler.
-    # If you enable webModeler, you either need to turn it true or use an external database
-    enabled: false
-
-elasticsearch:
-    enabled: false

--- a/azure/kubernetes/aks-single-region-rdbms/helm-values/values-domain.yml
+++ b/azure/kubernetes/aks-single-region-rdbms/helm-values/values-domain.yml
@@ -86,9 +86,6 @@ webModeler:
             fromAddress: changeme@example.com
 
 
-webModelerPostgresql:
-    enabled: false
-
 # Optimize requires Elasticsearch and is not available in RDBMS mode
 optimize:
     enabled: false
@@ -129,10 +126,6 @@ orchestration:
                 secretName: zeebe-c8-tls-grpc
             annotations:
                 kubernetes.io/tls-acme: 'true'
-
-# Disable Elasticsearch (not needed in RDBMS mode)
-elasticsearch:
-    enabled: false
 
 console:
     enabled: false # by default, console is not enabled

--- a/azure/kubernetes/aks-single-region-rdbms/helm-values/values-no-domain.yml
+++ b/azure/kubernetes/aks-single-region-rdbms/helm-values/values-no-domain.yml
@@ -95,12 +95,5 @@ webModeler:
                 existingSecretKey: smtp-password
             fromAddress: changeme@example.com
 
-webModelerPostgresql:
-    enabled: false
-
-# Disable Elasticsearch (not needed in RDBMS mode)
-elasticsearch:
-    enabled: false
-
 console:
     enabled: false # by default, console is not enabled

--- a/azure/kubernetes/aks-single-region/helm-values/values-domain.yml
+++ b/azure/kubernetes/aks-single-region/helm-values/values-domain.yml
@@ -85,9 +85,6 @@ webModeler:
             fromAddress: changeme@example.com
 
 
-webModelerPostgresql:
-    enabled: false
-
 optimize:
     enabled: true
     contextPath: /optimize

--- a/azure/kubernetes/aks-single-region/helm-values/values-no-domain.yml
+++ b/azure/kubernetes/aks-single-region/helm-values/values-no-domain.yml
@@ -78,8 +78,5 @@ webModeler:
                 existingSecretKey: smtp-password
             fromAddress: changeme@example.com
 
-webModelerPostgresql:
-    enabled: false
-
 console:
     enabled: false # by default, console is not enabled

--- a/generic/kubernetes/dual-region/tests/helm-values/registry.yml
+++ b/generic/kubernetes/dual-region/tests/helm-values/registry.yml
@@ -4,17 +4,7 @@
 
 # Auth to avoid Docker download rate limit.
 # https://docs.docker.com/docker-hub/download-rate-limit/
-identityKeycloak:
-    image:
-        pullSecrets:
-            - name: index-docker-io
-
 global:
     image:
         pullSecrets:
-            - name: index-docker-io
-
-elasticsearch:
-    global:
-        imagePullSecrets:
             - name: index-docker-io

--- a/generic/kubernetes/operator-based/keycloak/camunda-keycloak-domain-values.yml
+++ b/generic/kubernetes/operator-based/keycloak/camunda-keycloak-domain-values.yml
@@ -47,11 +47,6 @@ orchestration:
             oidc:
                 redirectUrl: https://${CAMUNDA_DOMAIN}
 
-identityKeycloak:
-    enabled: false
-    postgresql:
-        enabled: false
-
 identity:
     enabled: true
     contextPath: /managementidentity

--- a/generic/kubernetes/operator-based/keycloak/camunda-keycloak-no-domain-values.yml
+++ b/generic/kubernetes/operator-based/keycloak/camunda-keycloak-no-domain-values.yml
@@ -50,11 +50,6 @@ orchestration:
             oidc:
                 redirectUrl: http://localhost:8080
 
-identityKeycloak:
-    enabled: false
-    postgresql:
-        enabled: false
-
 identity:
     enabled: true
     contextPath: /managementidentity

--- a/generic/kubernetes/operator-based/postgresql/camunda-identity-values.yml
+++ b/generic/kubernetes/operator-based/postgresql/camunda-identity-values.yml
@@ -20,6 +20,3 @@ identity:
         secret:
             existingSecret: pg-identity-secret
             existingSecretKey: password
-
-identityPostgresql:
-    enabled: false

--- a/generic/kubernetes/operator-based/postgresql/camunda-rdbms-values.yml
+++ b/generic/kubernetes/operator-based/postgresql/camunda-rdbms-values.yml
@@ -25,10 +25,6 @@ orchestration:
                     existingSecret: pg-camunda-secret
                     existingSecretKey: password
 
-# Disable Elasticsearch (not needed in RDBMS mode)
-elasticsearch:
-    enabled: false
-
 # Disable Optimize (requires Elasticsearch, not available in RDBMS mode)
 optimize:
     enabled: false

--- a/generic/kubernetes/operator-based/postgresql/camunda-webmodeler-values.yml
+++ b/generic/kubernetes/operator-based/postgresql/camunda-webmodeler-values.yml
@@ -28,6 +28,3 @@ webModeler:
         mail:
             fromAddress: noreply@camunda.local
             fromName: Camunda Platform
-
-webModelerPostgresql:
-    enabled: false

--- a/generic/kubernetes/single-region/helm-values/values-oidc.yml
+++ b/generic/kubernetes/single-region/helm-values/values-oidc.yml
@@ -104,9 +104,6 @@ identity:
         - name: IDENTITY_INITIAL_CLAIM_VALUE
           value: ${IDENTITY_INITIAL_USER_EMAIL}
 
-identityKeycloak:
-    enabled: false
-
 connectors:
     # ⚠️ AWS Cognito M2M Authentication Issue
     # Connectors uses M2M (Client Credentials) authentication to connect to Zeebe.

--- a/generic/kubernetes/single-region/tests/helm-values/registry-harbor.yml
+++ b/generic/kubernetes/single-region/tests/helm-values/registry-harbor.yml
@@ -8,8 +8,3 @@ global:
         pullSecrets:
             - name: registry-camunda-cloud
             - name: index-docker-io
-
-elasticsearch:
-    global:
-        imagePullSecrets:
-            - name: index-docker-io

--- a/generic/kubernetes/single-region/tests/helm-values/registry.yml
+++ b/generic/kubernetes/single-region/tests/helm-values/registry.yml
@@ -4,17 +4,7 @@
 
 # Auth to avoid Docker download rate limit.
 # https://docs.docker.com/docker-hub/download-rate-limit/
-identityKeycloak:
-    image:
-        pullSecrets:
-            - name: index-docker-io
-
 global:
     image:
         pullSecrets:
-            - name: index-docker-io
-
-elasticsearch:
-    global:
-        imagePullSecrets:
             - name: index-docker-io

--- a/generic/openshift/dual-region/helm-values/values-base.yml
+++ b/generic/openshift/dual-region/helm-values/values-base.yml
@@ -112,14 +112,8 @@ orchestration:
 identity:
     enabled: false
 
-identityKeycloak:
-    enabled: false
-
 console:
     enabled: false # by default, console is not enabled
 
 optimize:
-    enabled: false
-
-elasticsearch:
     enabled: false

--- a/generic/openshift/single-region/helm-values/base.yml
+++ b/generic/openshift/single-region/helm-values/base.yml
@@ -65,9 +65,3 @@ webModeler:
                 existingSecret: webmodeler-secret
                 existingSecretKey: smtp-password
             fromAddress: changeme@example.com   # change this required value
-
-# WebModeler PostgreSQL is managed by the CNPG operator.
-# See generic/kubernetes/operator-based/postgresql/ for the CNPG cluster definitions
-# and camunda-webmodeler-values.yml for the corresponding Helm overlay.
-webModelerPostgresql:
-    enabled: false


### PR DESCRIPTION
## Root cause

The AKS single-region workflow downloaded the per-chart `values-enterprise.yaml` as the base `values.yml`. That overlay only ever configured the **bundled Bitnami sub-charts** (enterprise image registries for PostgreSQL / Keycloak / Elasticsearch).

Chart 15 (Camunda 8.10) **removed those sub-charts**, so `values-enterprise.yaml` no longer exists upstream:

```
charts/camunda-platform-8.10/values-enterprise.yaml -> 404
charts/camunda-platform-8.9/values-enterprise.yaml  -> 200
```

Every 8.10 AKS run therefore failed in **setup** with `curl` exit 22 (HTTP 404), before any Helm deploy.

## Fix

Remove the `values-enterprise.yaml` download **entirely** and start from an empty base. The deployment is built purely from the reference-architecture overlays merged afterwards (operator-managed Elasticsearch / Keycloak, OIDC) — which is what AKS actually deploys on chart 15. The enterprise Bitnami overlay is obsolete for this architecture.

## Scope

Only the AKS single-region workflow downloaded this file. EKS single-region and OpenShift carry a TODO to align but do **not** download it today, so they are unaffected.

> Draft — a maintainer should review and approve before merge.
