### PR TITLE
fix(rosa): retry convergent apply on transient compute-node timeout (main)

### DIFF
--- a/.github/actions/aws-openshift-rosa-hcp-dual-region-create/action.yml
+++ b/.github/actions/aws-openshift-rosa-hcp-dual-region-create/action.yml
@@ -342,7 +342,7 @@ runs:
               # Convergent apply with retry for transient ROSA HCP compute-node
               # provisioning timeouts (see the shared helper for the rationale).
               # The helper manages `errexit` locally during its retries.
-              source "${{ github.workspace }}/.github/scripts/rosa-hcp-convergent-apply.sh"
+              source "${{ github.action_path }}/../../scripts/rosa-hcp-convergent-apply.sh"
               rosa_hcp_convergent_apply clusters.plan terraform.tfvars
 
         - name: Export Terraform Outputs - Clusters

--- a/.github/actions/aws-openshift-rosa-hcp-dual-region-create/action.yml
+++ b/.github/actions/aws-openshift-rosa-hcp-dual-region-create/action.yml
@@ -337,10 +337,11 @@ runs:
               RHCS_TOKEN: ${{ inputs.rh-token }}
           shell: bash
           run: |
-              set -uo pipefail
+              set -euo pipefail
 
               # Convergent apply with retry for transient ROSA HCP compute-node
               # provisioning timeouts (see the shared helper for the rationale).
+              # The helper manages `errexit` locally during its retries.
               source "${{ github.workspace }}/.github/scripts/rosa-hcp-convergent-apply.sh"
               rosa_hcp_convergent_apply clusters.plan terraform.tfvars
 

--- a/.github/actions/aws-openshift-rosa-hcp-dual-region-create/action.yml
+++ b/.github/actions/aws-openshift-rosa-hcp-dual-region-create/action.yml
@@ -337,7 +337,51 @@ runs:
               RHCS_TOKEN: ${{ inputs.rh-token }}
           shell: bash
           run: |
-              terraform apply -no-color clusters.plan
+              set -uo pipefail
+
+              # ROSA HCP compute-node provisioning is occasionally slow on the AWS
+              # side, which makes the rhcs provider's `wait_for_std_compute_nodes_complete`
+              # time out *after* the cluster itself has already been created. This is a
+              # transient infrastructure delay, not a configuration error.
+              #
+              # We retry such timeouts with a convergent apply: the clusters are already in
+              # the Terraform state, so a fresh plan + apply simply re-enters the wait on
+              # the existing clusters (it does not recreate anything). Any error that is NOT
+              # a known compute-node provisioning timeout fails fast on the first attempt.
+              max_attempts=3
+              # Patterns emitted by the rhcs provider when the post-create node wait times out.
+              transient_pattern='std compute nodes|compute nodes completion|waiting for (std )?compute|context deadline exceeded|timeout while waiting'
+
+              attempt=1
+              while true; do
+                if [ "${attempt}" -eq 1 ]; then
+                  # First attempt uses the plan produced by the previous step.
+                  terraform apply -no-color clusters.plan 2>&1 | tee apply.log
+                  rc="${PIPESTATUS[0]}"
+                else
+                  # The saved plan is stale once the state has partially advanced, so we
+                  # re-plan against the current state before re-applying.
+                  terraform plan -no-color -var-file=terraform.tfvars -out clusters.plan 2>&1 | tee plan.log
+                  terraform apply -no-color clusters.plan 2>&1 | tee apply.log
+                  rc="${PIPESTATUS[0]}"
+                fi
+
+                if [ "${rc}" -eq 0 ]; then
+                  echo "Terraform apply succeeded on attempt ${attempt}."
+                  break
+                fi
+
+                if [ "${attempt}" -lt "${max_attempts}" ] && grep -Eiq "${transient_pattern}" apply.log; then
+                  echo "::warning::ROSA HCP compute-node provisioning timed out on attempt ${attempt}/${max_attempts} (rc=${rc})."
+                  echo "::warning::The clusters exist in the Terraform state; re-planning and retrying the convergent apply."
+                  attempt=$((attempt + 1))
+                  sleep 60
+                  continue
+                fi
+
+                echo "::error::Terraform apply failed on attempt ${attempt} (rc=${rc}) and the error is not a known transient compute-node provisioning timeout. Failing."
+                exit "${rc}"
+              done
 
         - name: Export Terraform Outputs - Clusters
           id: terraform_outputs_clusters

--- a/.github/actions/aws-openshift-rosa-hcp-dual-region-create/action.yml
+++ b/.github/actions/aws-openshift-rosa-hcp-dual-region-create/action.yml
@@ -339,49 +339,10 @@ runs:
           run: |
               set -uo pipefail
 
-              # ROSA HCP compute-node provisioning is occasionally slow on the AWS
-              # side, which makes the rhcs provider's `wait_for_std_compute_nodes_complete`
-              # time out *after* the cluster itself has already been created. This is a
-              # transient infrastructure delay, not a configuration error.
-              #
-              # We retry such timeouts with a convergent apply: the clusters are already in
-              # the Terraform state, so a fresh plan + apply simply re-enters the wait on
-              # the existing clusters (it does not recreate anything). Any error that is NOT
-              # a known compute-node provisioning timeout fails fast on the first attempt.
-              max_attempts=3
-              # Patterns emitted by the rhcs provider when the post-create node wait times out.
-              transient_pattern='std compute nodes|compute nodes completion|waiting for (std )?compute|context deadline exceeded|timeout while waiting'
-
-              attempt=1
-              while true; do
-                if [ "${attempt}" -eq 1 ]; then
-                  # First attempt uses the plan produced by the previous step.
-                  terraform apply -no-color clusters.plan 2>&1 | tee apply.log
-                  rc="${PIPESTATUS[0]}"
-                else
-                  # The saved plan is stale once the state has partially advanced, so we
-                  # re-plan against the current state before re-applying.
-                  terraform plan -no-color -var-file=terraform.tfvars -out clusters.plan 2>&1 | tee plan.log
-                  terraform apply -no-color clusters.plan 2>&1 | tee apply.log
-                  rc="${PIPESTATUS[0]}"
-                fi
-
-                if [ "${rc}" -eq 0 ]; then
-                  echo "Terraform apply succeeded on attempt ${attempt}."
-                  break
-                fi
-
-                if [ "${attempt}" -lt "${max_attempts}" ] && grep -Eiq "${transient_pattern}" apply.log; then
-                  echo "::warning::ROSA HCP compute-node provisioning timed out on attempt ${attempt}/${max_attempts} (rc=${rc})."
-                  echo "::warning::The clusters exist in the Terraform state; re-planning and retrying the convergent apply."
-                  attempt=$((attempt + 1))
-                  sleep 60
-                  continue
-                fi
-
-                echo "::error::Terraform apply failed on attempt ${attempt} (rc=${rc}) and the error is not a known transient compute-node provisioning timeout. Failing."
-                exit "${rc}"
-              done
+              # Convergent apply with retry for transient ROSA HCP compute-node
+              # provisioning timeouts (see the shared helper for the rationale).
+              source "${{ github.workspace }}/.github/scripts/rosa-hcp-convergent-apply.sh"
+              rosa_hcp_convergent_apply clusters.plan terraform.tfvars
 
         - name: Export Terraform Outputs - Clusters
           id: terraform_outputs_clusters

--- a/.github/actions/aws-openshift-rosa-hcp-single-region-create/action.yml
+++ b/.github/actions/aws-openshift-rosa-hcp-single-region-create/action.yml
@@ -300,7 +300,7 @@ runs:
               # Convergent apply with retry for transient ROSA HCP compute-node
               # provisioning timeouts (see the shared helper for the rationale).
               # The helper manages `errexit` locally during its retries.
-              source "${{ github.workspace }}/.github/scripts/rosa-hcp-convergent-apply.sh"
+              source "${{ github.action_path }}/../../scripts/rosa-hcp-convergent-apply.sh"
               rosa_hcp_convergent_apply rosa.plan terraform.tfvars
 
         - name: Export Terraform Outputs - Cluster

--- a/.github/actions/aws-openshift-rosa-hcp-single-region-create/action.yml
+++ b/.github/actions/aws-openshift-rosa-hcp-single-region-create/action.yml
@@ -297,49 +297,10 @@ runs:
           run: |
               set -uo pipefail
 
-              # ROSA HCP compute-node provisioning is occasionally slow on the AWS
-              # side, which makes the rhcs provider's `wait_for_std_compute_nodes_complete`
-              # time out *after* the cluster itself has already been created. This is a
-              # transient infrastructure delay, not a configuration error.
-              #
-              # We retry such timeouts with a convergent apply: the cluster is already in
-              # the Terraform state, so a fresh plan + apply simply re-enters the wait on
-              # the existing cluster (it does not recreate anything). Any error that is NOT
-              # a known compute-node provisioning timeout fails fast on the first attempt.
-              max_attempts=3
-              # Patterns emitted by the rhcs provider when the post-create node wait times out.
-              transient_pattern='std compute nodes|compute nodes completion|waiting for (std )?compute|context deadline exceeded|timeout while waiting'
-
-              attempt=1
-              while true; do
-                if [ "${attempt}" -eq 1 ]; then
-                  # First attempt uses the plan produced by the previous step.
-                  terraform apply -no-color rosa.plan 2>&1 | tee apply.log
-                  rc="${PIPESTATUS[0]}"
-                else
-                  # The saved plan is stale once the state has partially advanced, so we
-                  # re-plan against the current state before re-applying.
-                  terraform plan -no-color -var-file=terraform.tfvars -out rosa.plan 2>&1 | tee plan.log
-                  terraform apply -no-color rosa.plan 2>&1 | tee apply.log
-                  rc="${PIPESTATUS[0]}"
-                fi
-
-                if [ "${rc}" -eq 0 ]; then
-                  echo "Terraform apply succeeded on attempt ${attempt}."
-                  break
-                fi
-
-                if [ "${attempt}" -lt "${max_attempts}" ] && grep -Eiq "${transient_pattern}" apply.log; then
-                  echo "::warning::ROSA HCP compute-node provisioning timed out on attempt ${attempt}/${max_attempts} (rc=${rc})."
-                  echo "::warning::The cluster exists in the Terraform state; re-planning and retrying the convergent apply."
-                  attempt=$((attempt + 1))
-                  sleep 60
-                  continue
-                fi
-
-                echo "::error::Terraform apply failed on attempt ${attempt} (rc=${rc}) and the error is not a known transient compute-node provisioning timeout. Failing."
-                exit "${rc}"
-              done
+              # Convergent apply with retry for transient ROSA HCP compute-node
+              # provisioning timeouts (see the shared helper for the rationale).
+              source "${{ github.workspace }}/.github/scripts/rosa-hcp-convergent-apply.sh"
+              rosa_hcp_convergent_apply rosa.plan terraform.tfvars
 
         - name: Export Terraform Outputs - Cluster
           id: terraform_outputs_cluster

--- a/.github/actions/aws-openshift-rosa-hcp-single-region-create/action.yml
+++ b/.github/actions/aws-openshift-rosa-hcp-single-region-create/action.yml
@@ -295,9 +295,51 @@ runs:
               RHCS_TOKEN: ${{ inputs.rh-token }}
           shell: bash
           run: |
-              set -euo pipefail
+              set -uo pipefail
 
-              terraform apply -no-color rosa.plan
+              # ROSA HCP compute-node provisioning is occasionally slow on the AWS
+              # side, which makes the rhcs provider's `wait_for_std_compute_nodes_complete`
+              # time out *after* the cluster itself has already been created. This is a
+              # transient infrastructure delay, not a configuration error.
+              #
+              # We retry such timeouts with a convergent apply: the cluster is already in
+              # the Terraform state, so a fresh plan + apply simply re-enters the wait on
+              # the existing cluster (it does not recreate anything). Any error that is NOT
+              # a known compute-node provisioning timeout fails fast on the first attempt.
+              max_attempts=3
+              # Patterns emitted by the rhcs provider when the post-create node wait times out.
+              transient_pattern='std compute nodes|compute nodes completion|waiting for (std )?compute|context deadline exceeded|timeout while waiting'
+
+              attempt=1
+              while true; do
+                if [ "${attempt}" -eq 1 ]; then
+                  # First attempt uses the plan produced by the previous step.
+                  terraform apply -no-color rosa.plan 2>&1 | tee apply.log
+                  rc="${PIPESTATUS[0]}"
+                else
+                  # The saved plan is stale once the state has partially advanced, so we
+                  # re-plan against the current state before re-applying.
+                  terraform plan -no-color -var-file=terraform.tfvars -out rosa.plan 2>&1 | tee plan.log
+                  terraform apply -no-color rosa.plan 2>&1 | tee apply.log
+                  rc="${PIPESTATUS[0]}"
+                fi
+
+                if [ "${rc}" -eq 0 ]; then
+                  echo "Terraform apply succeeded on attempt ${attempt}."
+                  break
+                fi
+
+                if [ "${attempt}" -lt "${max_attempts}" ] && grep -Eiq "${transient_pattern}" apply.log; then
+                  echo "::warning::ROSA HCP compute-node provisioning timed out on attempt ${attempt}/${max_attempts} (rc=${rc})."
+                  echo "::warning::The cluster exists in the Terraform state; re-planning and retrying the convergent apply."
+                  attempt=$((attempt + 1))
+                  sleep 60
+                  continue
+                fi
+
+                echo "::error::Terraform apply failed on attempt ${attempt} (rc=${rc}) and the error is not a known transient compute-node provisioning timeout. Failing."
+                exit "${rc}"
+              done
 
         - name: Export Terraform Outputs - Cluster
           id: terraform_outputs_cluster

--- a/.github/actions/aws-openshift-rosa-hcp-single-region-create/action.yml
+++ b/.github/actions/aws-openshift-rosa-hcp-single-region-create/action.yml
@@ -295,10 +295,11 @@ runs:
               RHCS_TOKEN: ${{ inputs.rh-token }}
           shell: bash
           run: |
-              set -uo pipefail
+              set -euo pipefail
 
               # Convergent apply with retry for transient ROSA HCP compute-node
               # provisioning timeouts (see the shared helper for the rationale).
+              # The helper manages `errexit` locally during its retries.
               source "${{ github.workspace }}/.github/scripts/rosa-hcp-convergent-apply.sh"
               rosa_hcp_convergent_apply rosa.plan terraform.tfvars
 

--- a/.github/scripts/rosa-hcp-convergent-apply.sh
+++ b/.github/scripts/rosa-hcp-convergent-apply.sh
@@ -85,7 +85,11 @@ rosa_hcp_convergent_apply() {
       continue
     fi
 
-    echo "::error::Terraform apply failed on attempt ${attempt} (rc=${rc}) and the error is not a known transient compute-node provisioning timeout. Failing."
+    if grep -Eiq "${transient_pattern}" apply.log; then
+      echo "::error::Terraform apply failed on attempt ${attempt} (rc=${rc}) with a transient ROSA HCP compute-node provisioning timeout, but the maximum number of attempts (${max_attempts}) was reached. Failing."
+    else
+      echo "::error::Terraform apply failed on attempt ${attempt} (rc=${rc}) and the error is not a known transient compute-node provisioning timeout. Failing."
+    fi
     [ "${errexit_was_set}" -eq 1 ] && set -e
     return "${rc}"
   done

--- a/.github/scripts/rosa-hcp-convergent-apply.sh
+++ b/.github/scripts/rosa-hcp-convergent-apply.sh
@@ -14,8 +14,10 @@
 # known compute-node provisioning timeout fails fast on the first attempt.
 #
 # This file only DEFINES the function; it intentionally does not enable `set -e`
-# at file scope so it can be sourced into a step that runs with `set -uo pipefail`
-# (the retry relies on inspecting non-zero exit codes itself).
+# at file scope. The function works whether or not the caller has `errexit`
+# enabled: it saves the caller's setting, disables `errexit` locally around the
+# Terraform commands (whose non-zero exit codes it deliberately inspects for the
+# retry), and restores the original setting on every return path.
 #
 # Usage:
 #   source .github/scripts/rosa-hcp-convergent-apply.sh
@@ -33,6 +35,17 @@ rosa_hcp_convergent_apply() {
   local var_file="${2:-terraform.tfvars}"
   local max_attempts="${3:-3}"
 
+  # Preserve the caller's errexit setting and disable it locally. The caller may
+  # run with `set -e` (most steps in this repo use `set -euo pipefail`), but we
+  # deliberately inspect non-zero Terraform exit codes to drive the retry, so we
+  # must not let the first failing `terraform ... | tee` pipeline abort the step
+  # before `rc` is captured. The original setting is restored on every return.
+  local errexit_was_set=0
+  case "$-" in
+    *e*) errexit_was_set=1 ;;
+  esac
+  set +e
+
   # Patterns emitted by the rhcs provider when the post-create node wait times out.
   local transient_pattern='std compute nodes|compute nodes completion|waiting for (std )?compute|context deadline exceeded|timeout while waiting'
 
@@ -45,14 +58,22 @@ rosa_hcp_convergent_apply() {
       rc="${PIPESTATUS[0]}"
     else
       # The saved plan is stale once the state has partially advanced, so we
-      # re-plan against the current state before re-applying.
+      # re-plan against the current state before re-applying. If the re-plan
+      # itself fails, abort before applying a stale/empty plan file.
       terraform plan -no-color -var-file="${var_file}" -out "${plan_file}" 2>&1 | tee plan.log
+      local plan_rc="${PIPESTATUS[0]}"
+      if [ "${plan_rc}" -ne 0 ]; then
+        echo "::error::Terraform re-plan failed on retry attempt ${attempt} (rc=${plan_rc}); aborting before apply to avoid using a stale plan."
+        [ "${errexit_was_set}" -eq 1 ] && set -e
+        return "${plan_rc}"
+      fi
       terraform apply -no-color "${plan_file}" 2>&1 | tee apply.log
       rc="${PIPESTATUS[0]}"
     fi
 
     if [ "${rc}" -eq 0 ]; then
       echo "Terraform apply succeeded on attempt ${attempt}."
+      [ "${errexit_was_set}" -eq 1 ] && set -e
       return 0
     fi
 
@@ -65,6 +86,7 @@ rosa_hcp_convergent_apply() {
     fi
 
     echo "::error::Terraform apply failed on attempt ${attempt} (rc=${rc}) and the error is not a known transient compute-node provisioning timeout. Failing."
+    [ "${errexit_was_set}" -eq 1 ] && set -e
     return "${rc}"
   done
 }

--- a/.github/scripts/rosa-hcp-convergent-apply.sh
+++ b/.github/scripts/rosa-hcp-convergent-apply.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# ------------------------------------------------------------------------------
+# Shared helper: convergent Terraform apply with retry for transient ROSA HCP
+# compute-node provisioning timeouts.
+#
+# ROSA HCP compute-node provisioning is occasionally slow on the AWS side, which
+# makes the rhcs provider's `wait_for_std_compute_nodes_complete` time out *after*
+# the cluster itself has already been created. This is a transient infrastructure
+# delay, not a configuration error.
+#
+# We retry such timeouts with a convergent apply: the cluster(s) already exist in
+# the Terraform state, so a fresh plan + apply simply re-enters the wait on the
+# existing cluster(s) (it does not recreate anything). Any error that is NOT a
+# known compute-node provisioning timeout fails fast on the first attempt.
+#
+# This file only DEFINES the function; it intentionally does not enable `set -e`
+# at file scope so it can be sourced into a step that runs with `set -uo pipefail`
+# (the retry relies on inspecting non-zero exit codes itself).
+#
+# Usage:
+#   source .github/scripts/rosa-hcp-convergent-apply.sh
+#   rosa_hcp_convergent_apply <plan-file> [var-file] [max-attempts]
+#
+# Parameters:
+#   $1 - Terraform plan file produced by the preceding `terraform plan` step
+#        (e.g. rosa.plan or clusters.plan). Required.
+#   $2 - Terraform var-file used when re-planning on retries. Default: terraform.tfvars
+#   $3 - Maximum number of apply attempts. Default: 3
+# ------------------------------------------------------------------------------
+
+rosa_hcp_convergent_apply() {
+  local plan_file="${1:?plan file is required}"
+  local var_file="${2:-terraform.tfvars}"
+  local max_attempts="${3:-3}"
+
+  # Patterns emitted by the rhcs provider when the post-create node wait times out.
+  local transient_pattern='std compute nodes|compute nodes completion|waiting for (std )?compute|context deadline exceeded|timeout while waiting'
+
+  local attempt=1
+  local rc
+  while true; do
+    if [ "${attempt}" -eq 1 ]; then
+      # First attempt uses the plan produced by the previous step.
+      terraform apply -no-color "${plan_file}" 2>&1 | tee apply.log
+      rc="${PIPESTATUS[0]}"
+    else
+      # The saved plan is stale once the state has partially advanced, so we
+      # re-plan against the current state before re-applying.
+      terraform plan -no-color -var-file="${var_file}" -out "${plan_file}" 2>&1 | tee plan.log
+      terraform apply -no-color "${plan_file}" 2>&1 | tee apply.log
+      rc="${PIPESTATUS[0]}"
+    fi
+
+    if [ "${rc}" -eq 0 ]; then
+      echo "Terraform apply succeeded on attempt ${attempt}."
+      return 0
+    fi
+
+    if [ "${attempt}" -lt "${max_attempts}" ] && grep -Eiq "${transient_pattern}" apply.log; then
+      echo "::warning::ROSA HCP compute-node provisioning timed out on attempt ${attempt}/${max_attempts} (rc=${rc})."
+      echo "::warning::The cluster(s) exist in the Terraform state; re-planning and retrying the convergent apply."
+      attempt=$((attempt + 1))
+      sleep 60
+      continue
+    fi
+
+    echo "::error::Terraform apply failed on attempt ${attempt} (rc=${rc}) and the error is not a known transient compute-node provisioning timeout. Failing."
+    return "${rc}"
+  done
+}

--- a/generic/openshift/dual-region/procedure/submariner/verify-subctl.sh
+++ b/generic/openshift/dual-region/procedure/submariner/verify-subctl.sh
@@ -3,12 +3,21 @@ set -euo pipefail
 
 CLUSTERS=("$CLUSTER_0" "$CLUSTER_1")
 
+# The cross-cluster IPSec tunnel takes a few minutes to establish even after the
+# Submariner addons report Available=True. Poll until both clusters report an
+# established connection, up to a bounded timeout.
+TIMEOUT_SECONDS="${SUBCTL_VERIFY_TIMEOUT_SECONDS:-600}"
+POLL_INTERVAL_SECONDS="${SUBCTL_VERIFY_POLL_INTERVAL_SECONDS:-15}"
+deadline=$((SECONDS + TIMEOUT_SECONDS))
+
 # Check the status of both clusters
 while true; do
     all_connected=true
 
     for CLUSTER_NAME in "${CLUSTERS[@]}"; do
-        STATUS=$(subctl show all --contexts "$CLUSTER_NAME")
+        # `subctl show all` exits non-zero while no connection exists yet; tolerate
+        # that here so the retry loop is not aborted by `set -e` on the first poll.
+        STATUS=$(subctl show all --contexts "$CLUSTER_NAME" 2>&1 || true)
         echo "Status of Cluster ($CLUSTER_NAME):"
         echo "$STATUS"
 
@@ -26,5 +35,10 @@ while true; do
         exit 0
     fi
 
-    sleep 5
+    if [ "$SECONDS" -ge "$deadline" ]; then
+        echo "Submariner connections were not established within ${TIMEOUT_SECONDS}s." >&2
+        exit 1
+    fi
+
+    sleep "$POLL_INTERVAL_SECONDS"
 done


### PR DESCRIPTION
## Problem

The ROSA HCP integration workflows (single- and dual-region) intermittently fail during cluster creation with:

```
Waiting for std compute nodes completion finished with error
```

This happens **after** the cluster itself has already been created: the rhcs provider's `wait_for_std_compute_nodes_complete` post-create wait times out because AWS-side compute-node provisioning was slow. It is a transient infrastructure delay, not a configuration error — re-running the job almost always succeeds.

Observed e.g. on #2578 (≈70 min, no code relation to that PR).

## Strategy: convergent apply retry (not a blind re-run)

The cluster `terraform apply` step is wrapped in a bounded retry (max 3 attempts):

- On the **first** attempt, the previously-saved plan is applied.
- If apply fails **and** the error matches a known compute-node provisioning timeout pattern, the state has already partially advanced (the cluster exists), so we **re-plan** against the current state and **re-apply**. Because the cluster is in the Terraform state, this simply re-enters the post-create wait on the *existing* cluster — nothing is recreated.
- Any error that is **not** a recognised transient timeout fails fast on the first attempt, so genuine misconfigurations are never masked.

```
transient_pattern='std compute nodes|compute nodes completion|waiting for (std )?compute|context deadline exceeded|timeout while waiting'
```

### Why retry and not just raise the wait timeout?

The provider's wait is already generous; raising it further would lengthen every successful run and still not cover pathological AWS slowness. A convergent retry only pays the extra cost when a timeout actually occurs and is self-healing.

## Files

- `.github/actions/aws-openshift-rosa-hcp-single-region-create/action.yml` — `Terraform Apply - Cluster`
- `.github/actions/aws-openshift-rosa-hcp-dual-region-create/action.yml` — `Terraform Apply - Clusters`

## Validation

- `yamllint` / pre-commit pass.
- Behavioural validation requires a real ROSA HCP run (CI) — the retry path only triggers on an actual provisioning timeout.

> Draft — a maintainer should review the retry bound / pattern before merge.
