### PR TITLE
ci(rosa): retry transient compute-node provisioning timeouts on apply (backport 8.7)

### DIFF
--- a/.github/actions/aws-openshift-rosa-hcp-dual-region-create/action.yml
+++ b/.github/actions/aws-openshift-rosa-hcp-dual-region-create/action.yml
@@ -334,7 +334,12 @@ runs:
               RHCS_TOKEN: ${{ inputs.rh-token }}
           shell: bash
           run: |
-              terraform apply -no-color clusters.plan
+              set -uo pipefail
+
+              # Convergent apply with retry for transient ROSA HCP compute-node
+              # provisioning timeouts (see the shared helper for the rationale).
+              source "${{ github.workspace }}/.github/scripts/rosa-hcp-convergent-apply.sh"
+              rosa_hcp_convergent_apply clusters.plan terraform.tfvars
 
               export cluster_1_cluster_id="$(terraform output -raw cluster_1_cluster_id)"
               echo "cluster_1_cluster_id=$cluster_1_cluster_id" | tee -a "$GITHUB_OUTPUT"

--- a/.github/actions/aws-openshift-rosa-hcp-single-region-create/action.yml
+++ b/.github/actions/aws-openshift-rosa-hcp-single-region-create/action.yml
@@ -288,9 +288,12 @@ runs:
               RHCS_TOKEN: ${{ inputs.rh-token }}
           shell: bash
           run: |
-              set -euo pipefail
+              set -uo pipefail
 
-              terraform apply -no-color rosa.plan
+              # Convergent apply with retry for transient ROSA HCP compute-node
+              # provisioning timeouts (see the shared helper for the rationale).
+              source "${{ github.workspace }}/.github/scripts/rosa-hcp-convergent-apply.sh"
+              rosa_hcp_convergent_apply rosa.plan terraform.tfvars
 
               export cluster_id="$(terraform output -raw cluster_id)"
               echo "cluster_id=$cluster_id" | tee -a "$GITHUB_OUTPUT"

--- a/.github/scripts/rosa-hcp-convergent-apply.sh
+++ b/.github/scripts/rosa-hcp-convergent-apply.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# ------------------------------------------------------------------------------
+# Shared helper: convergent Terraform apply with retry for transient ROSA HCP
+# compute-node provisioning timeouts.
+#
+# ROSA HCP compute-node provisioning is occasionally slow on the AWS side, which
+# makes the rhcs provider's `wait_for_std_compute_nodes_complete` time out *after*
+# the cluster itself has already been created. This is a transient infrastructure
+# delay, not a configuration error.
+#
+# We retry such timeouts with a convergent apply: the cluster(s) already exist in
+# the Terraform state, so a fresh plan + apply simply re-enters the wait on the
+# existing cluster(s) (it does not recreate anything). Any error that is NOT a
+# known compute-node provisioning timeout fails fast on the first attempt.
+#
+# This file only DEFINES the function; it intentionally does not enable `set -e`
+# at file scope so it can be sourced into a step that runs with `set -uo pipefail`
+# (the retry relies on inspecting non-zero exit codes itself).
+#
+# Usage:
+#   source .github/scripts/rosa-hcp-convergent-apply.sh
+#   rosa_hcp_convergent_apply <plan-file> [var-file] [max-attempts]
+#
+# Parameters:
+#   $1 - Terraform plan file produced by the preceding `terraform plan` step
+#        (e.g. rosa.plan or clusters.plan). Required.
+#   $2 - Terraform var-file used when re-planning on retries. Default: terraform.tfvars
+#   $3 - Maximum number of apply attempts. Default: 3
+# ------------------------------------------------------------------------------
+
+rosa_hcp_convergent_apply() {
+  local plan_file="${1:?plan file is required}"
+  local var_file="${2:-terraform.tfvars}"
+  local max_attempts="${3:-3}"
+
+  # Patterns emitted by the rhcs provider when the post-create node wait times out.
+  local transient_pattern='std compute nodes|compute nodes completion|waiting for (std )?compute|context deadline exceeded|timeout while waiting'
+
+  local attempt=1
+  local rc
+  while true; do
+    if [ "${attempt}" -eq 1 ]; then
+      # First attempt uses the plan produced by the previous step.
+      terraform apply -no-color "${plan_file}" 2>&1 | tee apply.log
+      rc="${PIPESTATUS[0]}"
+    else
+      # The saved plan is stale once the state has partially advanced, so we
+      # re-plan against the current state before re-applying.
+      terraform plan -no-color -var-file="${var_file}" -out "${plan_file}" 2>&1 | tee plan.log
+      terraform apply -no-color "${plan_file}" 2>&1 | tee apply.log
+      rc="${PIPESTATUS[0]}"
+    fi
+
+    if [ "${rc}" -eq 0 ]; then
+      echo "Terraform apply succeeded on attempt ${attempt}."
+      return 0
+    fi
+
+    if [ "${attempt}" -lt "${max_attempts}" ] && grep -Eiq "${transient_pattern}" apply.log; then
+      echo "::warning::ROSA HCP compute-node provisioning timed out on attempt ${attempt}/${max_attempts} (rc=${rc})."
+      echo "::warning::The cluster(s) exist in the Terraform state; re-planning and retrying the convergent apply."
+      attempt=$((attempt + 1))
+      sleep 60
+      continue
+    fi
+
+    echo "::error::Terraform apply failed on attempt ${attempt} (rc=${rc}) and the error is not a known transient compute-node provisioning timeout. Failing."
+    return "${rc}"
+  done
+}


### PR DESCRIPTION
## Description

Backport to `stable/8.7` of the ROSA HCP convergent-apply retry from #2588.

ROSA HCP compute-node provisioning is occasionally slow on the AWS side, which makes the `rhcs` provider's node wait time out **after** the cluster has already been created. This is a transient infrastructure delay, not a configuration error, yet it failed the whole cluster-create action.

This PR adds a shared helper, `.github/scripts/rosa-hcp-convergent-apply.sh`, that retries such timeouts with a convergent apply (the cluster already exists in the Terraform state, so a fresh plan + apply simply re-enters the wait on the existing cluster — nothing is recreated). Any non-transient error still fails fast on the first attempt. Both the single-region and dual-region cluster-create actions are wired to use it.

## Related

Backport of #2588.
