### PR TITLE
fix(smoke-test): wrap in-cluster Keycloak URLs as code literals

### DIFF
--- a/.github/actions/camunda-smoke-test/README.md
+++ b/.github/actions/camunda-smoke-test/README.md
@@ -19,7 +19,7 @@ For non-Kubernetes (ECS Fargate, EC2):
 | `auth-mode` | <p>Authentication mode: oidc, basic, or none.</p> | `false` | `oidc` |
 | `namespace` | <p>Kubernetes namespace where Camunda is deployed. Used for kubectl port-forward and secret extraction.</p> | `false` | `camunda` |
 | `release-name` | <p>Helm release name for Camunda. Derives service names (e.g., <release>-zeebe-gateway).</p> | `false` | `camunda` |
-| `keycloak-url` | <p>In-cluster Keycloak base URL for OIDC auth. Operator: http://keycloak-service:18080/auth Bitnami: http://<release>-keycloak:80/auth</p> | `false` | `""` |
+| `keycloak-url` | <p>In-cluster Keycloak base URL for OIDC auth. Operator: <code>http://keycloak-service:18080/auth</code> Bitnami: <code>http://&lt;release&gt;-keycloak:80/auth</code></p> | `false` | `""` |
 | `oidc-client-id` | <p>OIDC client ID for M2M authentication. If empty, auto-extracted from <release-name>-credentials secret (client ID defaults to 'orchestration').</p> | `false` | `""` |
 | `oidc-client-secret` | <p>OIDC client secret for M2M authentication. If empty, auto-extracted from <release-name>-credentials secret (key: identity-orchestration-client-token).</p> | `false` | `""` |
 | `oidc-token-url` | <p>OIDC token endpoint URL (e.g., https://<keycloak>/realms/camunda-platform/protocol/openid-connect/token). Required for non-Kubernetes deployments (ECS / EC2) when auth-mode=oidc. In Kubernetes mode this input is ignored — the URL is derived from the auto-port-forwarded Keycloak.</p> | `false` | `""` |
@@ -73,7 +73,7 @@ This action is a `composite` action.
     # Default: camunda
 
     keycloak-url:
-    # In-cluster Keycloak base URL for OIDC auth. Operator: http://keycloak-service:18080/auth Bitnami: http://<release>-keycloak:80/auth
+    # In-cluster Keycloak base URL for OIDC auth. Operator: `http://keycloak-service:18080/auth` Bitnami: `http://<release>-keycloak:80/auth`
     #
     # Required: false
     # Default: ""

--- a/.github/actions/camunda-smoke-test/action.yml
+++ b/.github/actions/camunda-smoke-test/action.yml
@@ -42,8 +42,8 @@ inputs:
     keycloak-url:
         description: >
             In-cluster Keycloak base URL for OIDC auth.
-            Operator: http://keycloak-service:18080/auth
-            Bitnami: http://<release>-keycloak:80/auth
+            Operator: `http://keycloak-service:18080/auth`
+            Bitnami: `http://<release>-keycloak:80/auth`
         required: false
         default: ''
     # ── OIDC auth inputs ────────────────────────────────────────

--- a/.github/workflows/internal_global_links.yml
+++ b/.github/workflows/internal_global_links.yml
@@ -8,6 +8,7 @@ on:
     pull_request:
         paths:
             - .github/workflows/internal_global_links.yml
+            - '**/*.md'
 
 env:
     IS_SCHEDULE: ${{ (contains(github.head_ref, 'schedules/') || github.event_name == 'schedule') && 'true' || 'false' }}

--- a/lychee-links.toml
+++ b/lychee-links.toml
@@ -17,4 +17,5 @@ exclude_path = [
 exclude = [
   "^file:",
   "https://developer.hashicorp.com/*", # vercel security check causing issues
+  "^http://keycloak-service:", # in-cluster example URL, only resolvable inside the cluster
 ]


### PR DESCRIPTION
## Description

The automated **Link Checker Report** issues (e.g. #2585, #2581, #2577, #2570, #2566, #2559, #2555, #2553, #2550) all report the same hard failure: the example in-cluster Keycloak URL \`http://keycloak-service:18080/auth\` in the \`camunda-smoke-test\` composite action is detected as an external link and fails (network error, host only resolvable inside the cluster).

## Changes

- Wrap the example in-cluster Keycloak URLs in the \`keycloak-url\` input description as code literals in [action.yml](.github/actions/camunda-smoke-test/action.yml), so they are no longer treated as live links.
- Regenerate the action README accordingly.

## Notes

- The remaining entries in the reports are redirect notices (200/403 after redirect) for external docs (Camunda / OpenShift) and are not hard failures.
