### PR TITLE
ci(links): broaden in-cluster keycloak-service link exclusion

### DIFF
--- a/lychee-links.toml
+++ b/lychee-links.toml
@@ -17,5 +17,5 @@ exclude_path = [
 exclude = [
   "^file:",
   "https://developer.hashicorp.com/*", # vercel security check causing issues
-  "^http://keycloak-service:", # in-cluster example URL, only resolvable inside the cluster
+  "^https?://keycloak-service(:|/)", # in-cluster service hostname documented in smoke-test action, only resolvable inside the cluster
 ]


### PR DESCRIPTION
## Description

Follow-up to #2591. Align `main`'s lychee exclusion for the in-cluster
`keycloak-service` hostname with the more robust pattern already used on the
stable branches (`stable/8.8`, `stable/8.9`).

The `keycloak-service` hostname is an in-cluster example URL documented in the
`camunda-smoke-test` composite action. It is only resolvable inside the cluster,
so the external link checker must skip it. The previous pattern only matched
`^http://keycloak-service:`, which leaves room for false positives on other
documented variants (e.g. the `https` scheme or the `/auth` path form without an
explicit port).

```diff
- "^http://keycloak-service:", # in-cluster example URL, only resolvable inside the cluster
+ "^https?://keycloak-service(:|/)", # in-cluster service hostname documented in smoke-test action, only resolvable inside the cluster
```

## Motivation

- `stable/8.8` and `stable/8.9` already ship the broader `^https?://keycloak-service(:|/)`
  exclusion. This brings `main` in line so the regex behaves consistently across branches.
- Covers both `http`/`https` schemes and both the `:port` and `/path` forms.

## Implications

- Link-checker only; no runtime/Terraform/Helm changes.
- No backport needed — the stable branches already carry the equivalent (or broader) exclusion.
