### PR TITLE
ci(rosa): pin 8.7 single-region chart ref to 12.8.5

### DIFF
--- a/.github/workflows/aws_openshift_rosa_hcp_single_region_tests.yml
+++ b/.github/workflows/aws_openshift_rosa_hcp_single_region_tests.yml
@@ -75,8 +75,10 @@ env:
     # Docker Hub auth to avoid image pull rate limit.
     # Vars with "TEST_" prefix are used in the test runner tool (Task).
     TESTS_ENABLED: ${{ github.event.inputs.enable_tests || 'true' }}
-    # renovate: datasource=github-tags depName=camunda/camunda-platform-helm
-    TESTS_CAMUNDA_HELM_CHART_REPO_REF: camunda-platform-8.7-12.10.0
+    # 12.8.5 is the last 8.7 tag that still ships test/integration/testsuites/vars/files/,
+    # which the internal-camunda-chart-tests action depends on. Newer tags (>=12.9.0) drop it,
+    # so do NOT bump this past 12.8.5 without updating the action.
+    TESTS_CAMUNDA_HELM_CHART_REPO_REF: camunda-platform-8.7-12.8.5
     TESTS_CAMUNDA_HELM_CHART_REPO_PATH: ./.camunda_helm_repo   # where to clone it
 
     # Components that are not enabled by default in the doc, but enabled in our tests to have a better coverage


### PR DESCRIPTION
## What

Pin `TESTS_CAMUNDA_HELM_CHART_REPO_REF` in the **ROSA HCP single-region** 8.7 test workflow to `camunda-platform-8.7-12.8.5` and drop the renovate auto-bump marker.

## Why

The `internal-camunda-chart-tests` action depends on `test/integration/testsuites/vars/files/` from the `camunda-platform-8.7` chart. That directory was removed upstream in chart tags `>= 12.9.0`. Renovate had bumped this ref to `12.10.0`, so the action's `find … | xargs -0 sed …` step fails (`No such file or directory` → exit 123) and the ROSA single-region tests break.

`12.8.5` is the last `camunda-platform-8.7-*` tag that still ships the venom testsuites (verified against the GitHub Contents API). The EKS single-region 8.7 workflow was already pinned this way — this change brings the ROSA workflow in line.

## Notes

- This is a pre-existing branch-wide breakage, independent of any single PR.
- The renovate marker is intentionally removed (mirroring the EKS workflow) so the ref is not bumped past `12.8.5` until the venom→Go test migration is backported to `stable/8.7`.
- Cannot be validated locally (requires a real ROSA cluster); relies on CI.
