### PR TITLE
feat(migration): add KEYCLOAK_TARGET_MODE=external for migrating Bitnami Keycloak to an external instance

### DIFF
--- a/generic/kubernetes/migration/1-deploy-targets.sh
+++ b/generic/kubernetes/migration/1-deploy-targets.sh
@@ -119,17 +119,24 @@ if [[ "${MIGRATE_ELASTICSEARCH}" == "true" ]]; then
 fi
 
 # ─────────────────────────────────────────────────────────────────────────────
-# 3. Keycloak Operator
+# 3. Keycloak
 # ─────────────────────────────────────────────────────────────────────────────
 
 if [[ "${MIGRATE_KEYCLOAK}" == "true" ]]; then
-    section "3/3 — Keycloak Operator"
-
-    if kubectl get keycloak keycloak -n "${NAMESPACE}" &>/dev/null; then
-        log_success "Keycloak CR already exists — skipping"
+    if is_external_keycloak; then
+        section "3/3 — Keycloak (external)"
+        log_info "KEYCLOAK_TARGET_MODE=external — Keycloak Operator deployment skipped"
+        log_info "  Expecting an external Keycloak at ${EXTERNAL_KEYCLOAK_PROTOCOL:-http}://${EXTERNAL_KEYCLOAK_HOST}:${EXTERNAL_KEYCLOAK_PORT:-80}${EXTERNAL_KEYCLOAK_CONTEXT_PATH:-/auth}"
+        log_info "  It must use the external Keycloak database (EXTERNAL_PG_KEYCLOAK_*) so the restored realm is served."
     else
-        deploy_keycloak
-        save_state "KEYCLOAK_OPERATOR_DEPLOYED" "true"
+        section "3/3 — Keycloak Operator"
+
+        if kubectl get keycloak keycloak -n "${NAMESPACE}" &>/dev/null; then
+            log_success "Keycloak CR already exists — skipping"
+        else
+            deploy_keycloak
+            save_state "KEYCLOAK_OPERATOR_DEPLOYED" "true"
+        fi
     fi
 fi
 

--- a/generic/kubernetes/migration/2-backup.sh
+++ b/generic/kubernetes/migration/2-backup.sh
@@ -72,16 +72,22 @@ do_pg_backup() {
     save_state "${component^^}_BACKUP_TIMESTAMP" "$TIMESTAMP"
 }
 
+# The backup reads the SOURCE database, which may use different database/user
+# names than the migration target (e.g. the Camunda bundled Bitnami Keycloak
+# uses db "bitnami_keycloak"/user "bn_keycloak", while the target uses
+# "keycloak"/"keycloak"). The *_SOURCE_DB_NAME/_USER overrides decouple the
+# source names from the target names (which Phase 3 restore uses); they default
+# to the target names for the common same-name case.
 if [[ "${MIGRATE_IDENTITY}" == "true" ]]; then
-    do_pg_backup identity "${IDENTITY_DB_NAME}" "${IDENTITY_DB_USER}"
+    do_pg_backup identity "${IDENTITY_SOURCE_DB_NAME:-${IDENTITY_DB_NAME}}" "${IDENTITY_SOURCE_DB_USER:-${IDENTITY_DB_USER}}"
 fi
 
 if [[ "${MIGRATE_KEYCLOAK}" == "true" ]]; then
-    do_pg_backup keycloak "${KEYCLOAK_DB_NAME}" "${KEYCLOAK_DB_USER}"
+    do_pg_backup keycloak "${KEYCLOAK_SOURCE_DB_NAME:-${KEYCLOAK_DB_NAME}}" "${KEYCLOAK_SOURCE_DB_USER:-${KEYCLOAK_DB_USER}}"
 fi
 
 if [[ "${MIGRATE_WEBMODELER}" == "true" ]]; then
-    do_pg_backup webmodeler "${WEBMODELER_DB_NAME}" "${WEBMODELER_DB_USER}"
+    do_pg_backup webmodeler "${WEBMODELER_SOURCE_DB_NAME:-${WEBMODELER_DB_NAME}}" "${WEBMODELER_SOURCE_DB_USER:-${WEBMODELER_DB_USER}}"
 fi
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/generic/kubernetes/migration/3-cutover.sh
+++ b/generic/kubernetes/migration/3-cutover.sh
@@ -347,8 +347,17 @@ elif [[ "${SKIP_HELM_UPGRADE:-false}" == "true" ]]; then
     section "Data migration complete ($(timer_elapsed))"
     echo ""
     echo "Data has been migrated to the target backends."
-    echo "The Helm upgrade was skipped (SKIP_HELM_UPGRADE=true) — the caller is"
-    echo "responsible for upgrading Camunda to point at the new backends."
+    echo "Camunda is still frozen (scaled to 0) and pointed at the OLD backends —"
+    echo "the caller is responsible for the Helm upgrade that switches Camunda to"
+    echo "the new backends and restarts the components."
+    echo ""
+    echo "Phase 3 is marked complete so ./4-validate.sh and ./5-cleanup-bitnami.sh"
+    echo "can run — but only AFTER the caller's Helm upgrade has switched Camunda over."
+    # Mark phase 3 complete even though the Helm upgrade is deferred: the data
+    # migration that phase 3 owns IS done, so the phase state machine must not
+    # stay stuck (otherwise require_phase blocks the later phases entirely).
+    run_hooks "post-phase-3"
+    complete_phase 3
 else
 section "Step 5/5: Helm upgrade"
 

--- a/generic/kubernetes/migration/3-cutover.sh
+++ b/generic/kubernetes/migration/3-cutover.sh
@@ -335,6 +335,17 @@ if [[ "${ESTIMATE_MODE}" == "true" ]]; then
     echo ""
     echo "No changes were made to the running application."
     echo "You can run the real cutover with:  ./3-cutover.sh"
+elif [[ "${SKIP_HELM_UPGRADE:-false}" == "true" ]]; then
+    # Data-only migration: the realm/databases have been migrated to the target
+    # backends, but the Helm upgrade is intentionally deferred to the caller
+    # (e.g. a CI harness that owns the chart upgrade to the next version).
+    section "Step 5/5: Helm upgrade — SKIPPED (SKIP_HELM_UPGRADE=true)"
+    save_state "PHASE_3_DURATION" "$(timer_elapsed)"
+    section "Data migration complete ($(timer_elapsed))"
+    echo ""
+    echo "Data has been migrated to the target backends."
+    echo "The Helm upgrade was skipped (SKIP_HELM_UPGRADE=true) — the caller is"
+    echo "responsible for upgrading Camunda to point at the new backends."
 else
 section "Step 5/5: Helm upgrade"
 

--- a/generic/kubernetes/migration/3-cutover.sh
+++ b/generic/kubernetes/migration/3-cutover.sh
@@ -356,8 +356,11 @@ if [[ "${MIGRATE_ELASTICSEARCH}" == "true" ]] && ! is_external_es; then
 fi
 
 if [[ "${MIGRATE_KEYCLOAK}" == "true" ]]; then
-    # Keycloak always uses the operator — values are always needed
-    if [[ -n "${CAMUNDA_DOMAIN:-}" && "${CAMUNDA_DOMAIN}" != "localhost" ]]; then
+    if is_external_keycloak; then
+        # External Keycloak: point Camunda at the pre-existing instance and
+        # disable the bundled Bitnami subchart.
+        HELM_VALUES_ARGS+=("$(generate_external_keycloak_values)")
+    elif [[ -n "${CAMUNDA_DOMAIN:-}" && "${CAMUNDA_DOMAIN}" != "localhost" ]]; then
         HELM_VALUES_ARGS+=("$(get_helm_values keycloak-domain)")
     else
         HELM_VALUES_ARGS+=("$(get_helm_values keycloak-no-domain)")

--- a/generic/kubernetes/migration/3-cutover.sh
+++ b/generic/kubernetes/migration/3-cutover.sh
@@ -161,16 +161,19 @@ do_final_pg_backup() {
     save_state "${component^^}_FINAL_BACKUP" "${component}-db-final.dump"
 }
 
+# The final backup reads the SOURCE database, so it honours the same
+# *_SOURCE_DB_NAME/_USER overrides as the Phase 2 initial backup (defaulting to
+# the target names). The restore below uses the target names.
 if [[ "${MIGRATE_IDENTITY}" == "true" ]]; then
-    do_final_pg_backup identity "${IDENTITY_DB_NAME}" "${IDENTITY_DB_USER}"
+    do_final_pg_backup identity "${IDENTITY_SOURCE_DB_NAME:-${IDENTITY_DB_NAME}}" "${IDENTITY_SOURCE_DB_USER:-${IDENTITY_DB_USER}}"
 fi
 
 if [[ "${MIGRATE_KEYCLOAK}" == "true" ]]; then
-    do_final_pg_backup keycloak "${KEYCLOAK_DB_NAME}" "${KEYCLOAK_DB_USER}"
+    do_final_pg_backup keycloak "${KEYCLOAK_SOURCE_DB_NAME:-${KEYCLOAK_DB_NAME}}" "${KEYCLOAK_SOURCE_DB_USER:-${KEYCLOAK_DB_USER}}"
 fi
 
 if [[ "${MIGRATE_WEBMODELER}" == "true" ]]; then
-    do_final_pg_backup webmodeler "${WEBMODELER_DB_NAME}" "${WEBMODELER_DB_USER}"
+    do_final_pg_backup webmodeler "${WEBMODELER_SOURCE_DB_NAME:-${WEBMODELER_DB_NAME}}" "${WEBMODELER_SOURCE_DB_USER:-${WEBMODELER_DB_USER}}"
 fi
 
 if [[ "${MIGRATE_ELASTICSEARCH}" == "true" ]]; then

--- a/generic/kubernetes/migration/3-cutover.sh
+++ b/generic/kubernetes/migration/3-cutover.sh
@@ -370,11 +370,9 @@ if [[ "${MIGRATE_ELASTICSEARCH}" == "true" ]] && ! is_external_es; then
 fi
 
 if [[ "${MIGRATE_KEYCLOAK}" == "true" ]]; then
-    if is_external_keycloak; then
-        # External Keycloak: point Camunda at the pre-existing instance and
-        # disable the bundled Bitnami subchart.
-        HELM_VALUES_ARGS+=("$(generate_external_keycloak_values)")
-    elif [[ -n "${CAMUNDA_DOMAIN:-}" && "${CAMUNDA_DOMAIN}" != "localhost" ]]; then
+    # External Keycloak is data-only (it implies SKIP_HELM_UPGRADE=true), so this
+    # helm-upgrade branch only ever runs for the operator-managed Keycloak.
+    if [[ -n "${CAMUNDA_DOMAIN:-}" && "${CAMUNDA_DOMAIN}" != "localhost" ]]; then
         HELM_VALUES_ARGS+=("$(get_helm_values keycloak-domain)")
     else
         HELM_VALUES_ARGS+=("$(get_helm_values keycloak-no-domain)")

--- a/generic/kubernetes/migration/4-validate.sh
+++ b/generic/kubernetes/migration/4-validate.sh
@@ -226,15 +226,23 @@ fi
 # 4. Keycloak Operator
 # ─────────────────────────────────────────────────────────────────────────────
 if [[ "${MIGRATE_KEYCLOAK}" == "true" ]]; then
-    section "Keycloak Operator"
-
-    kc_ready=$(kubectl get keycloak keycloak -n "${NAMESPACE}" \
-        -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || echo "False")
-    if [[ "$kc_ready" == "True" ]]; then
-        log_success "Keycloak CR: Ready"
+    if is_external_keycloak; then
+        section "Keycloak (external)"
+        # No operator CR to inspect — Keycloak is managed outside this chart.
+        # Camunda's connection to the external instance is exercised by the
+        # Identity/Orchestration readiness checks elsewhere in this script.
+        log_success "Keycloak: external instance at ${EXTERNAL_KEYCLOAK_PROTOCOL:-http}://${EXTERNAL_KEYCLOAK_HOST}:${EXTERNAL_KEYCLOAK_PORT:-80}${EXTERNAL_KEYCLOAK_CONTEXT_PATH:-/auth} (operator CR check skipped)"
     else
-        log_error "Keycloak CR: Not ready (${kc_ready})"
-        ERRORS=$((ERRORS + 1))
+        section "Keycloak Operator"
+
+        kc_ready=$(kubectl get keycloak keycloak -n "${NAMESPACE}" \
+            -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || echo "False")
+        if [[ "$kc_ready" == "True" ]]; then
+            log_success "Keycloak CR: Ready"
+        else
+            log_error "Keycloak CR: Not ready (${kc_ready})"
+            ERRORS=$((ERRORS + 1))
+        fi
     fi
 fi
 

--- a/generic/kubernetes/migration/5-cleanup-bitnami.sh
+++ b/generic/kubernetes/migration/5-cleanup-bitnami.sh
@@ -240,13 +240,17 @@ if [[ "${MIGRATE_ELASTICSEARCH}" == "true" ]] && ! is_external_es; then
 fi
 
 if [[ "${MIGRATE_KEYCLOAK}" == "true" ]]; then
-    kc_ready=$(kubectl get keycloak keycloak -n "${NAMESPACE}" \
-        -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || echo "False")
-    if [[ "$kc_ready" == "True" ]]; then
-        log_success "Keycloak CR: Ready"
+    if is_external_keycloak; then
+        log_success "Keycloak: external instance (operator CR check skipped)"
     else
-        log_error "Keycloak CR: Not ready after cleanup"
-        ERRORS=$((ERRORS + 1))
+        kc_ready=$(kubectl get keycloak keycloak -n "${NAMESPACE}" \
+            -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || echo "False")
+        if [[ "$kc_ready" == "True" ]]; then
+            log_success "Keycloak CR: Ready"
+        else
+            log_error "Keycloak CR: Not ready after cleanup"
+            ERRORS=$((ERRORS + 1))
+        fi
     fi
 fi
 

--- a/generic/kubernetes/migration/README.md
+++ b/generic/kubernetes/migration/README.md
@@ -165,6 +165,7 @@ Set any `MIGRATE_*` to `false` to skip a component (e.g. if it's not deployed or
 | ---------------------------- | --------------- | -------------------------------------------- |
 | `PG_TARGET_MODE`             | `operator`      | `operator`: deploy CNPG. `external`: skip deployment, migrate to pre-existing target |
 | `ES_TARGET_MODE`             | `operator`      | `operator`: deploy ECK. `external`: skip deployment, point to pre-existing target |
+| `KEYCLOAK_TARGET_MODE`       | `operator`      | `operator`: deploy the Keycloak Operator + CR. `external`: skip deployment, point Camunda at a pre-existing Keycloak. Requires `PG_TARGET_MODE=external` |
 
 **Operator mode** (when `*_TARGET_MODE=operator`):
 
@@ -188,7 +189,13 @@ Set any `MIGRATE_*` to `false` to skip a component (e.g. if it's not deployed or
 | `EXTERNAL_ES_PORT`              | `443`                    | Elasticsearch port                           |
 | `EXTERNAL_ES_SECRET`            | `external-es`            | K8s Secret containing the password           |
 | `CUSTOM_HELM_VALUES_FILE`       | (empty)                  | Helm values file for external connections    |
-| `CUSTOM_KEYCLOAK_CONFIG_FILE`   | (empty)                  | Custom Keycloak CR for external PG           |
+| `CUSTOM_KEYCLOAK_CONFIG_FILE`   | (empty)                  | Custom Keycloak CR for external PG (operator mode) |
+| `EXTERNAL_KEYCLOAK_PROTOCOL`    | `http`                   | External Keycloak protocol (`KEYCLOAK_TARGET_MODE=external`) |
+| `EXTERNAL_KEYCLOAK_HOST`        | (empty)                  | External Keycloak host                       |
+| `EXTERNAL_KEYCLOAK_PORT`        | `80`                     | External Keycloak port                       |
+| `EXTERNAL_KEYCLOAK_CONTEXT_PATH`| `/auth`                  | External Keycloak context path               |
+| `EXTERNAL_KEYCLOAK_REALM`       | `/realms/camunda-platform`| External Keycloak realm path                |
+| `EXTERNAL_KEYCLOAK_ADMIN_SECRET`| (empty)                  | K8s Secret with the Keycloak admin `password` |
 
 ### When to use `external` target mode
 
@@ -199,10 +206,16 @@ Set `PG_TARGET_MODE=external` or `ES_TARGET_MODE=external` when the migration **
 | Fresh cluster, no operators installed | `operator` (default) | Scripts install CNPG/ECK + create clusters |
 | Operators already installed by a platform team | `external` | Avoids overwriting the operator version (scripts apply a pinned version via `kubectl apply --server-side`) |
 | Target is a managed service (RDS, OpenSearch, …) | `external` | No operator needed — data migrates directly to the managed endpoint |
+| Keycloak runs as a managed/standalone/Helm instance (not the operator) | `KEYCLOAK_TARGET_MODE=external` | Migrates the realm into the external Keycloak database and points Camunda at the existing instance |
 
 When using `external` mode, you must also provide:
 - Connection details: `EXTERNAL_PG_*` or `EXTERNAL_ES_*` variables in `env.sh`
 - A `CUSTOM_HELM_VALUES_FILE` with Helm values pointing Camunda at the external targets
+
+When using `KEYCLOAK_TARGET_MODE=external`, you must also provide the `EXTERNAL_KEYCLOAK_*`
+variables, and `PG_TARGET_MODE=external` (the external Keycloak serves the migrated realm
+from the external Keycloak database). The scripts do not deploy or manage the Keycloak
+instance itself — only the realm database is migrated and Camunda is rewired to it.
 
 ## Detailed Phase Descriptions
 

--- a/generic/kubernetes/migration/README.md
+++ b/generic/kubernetes/migration/README.md
@@ -217,10 +217,11 @@ When using `external` mode, you must also provide:
 - Connection details: `EXTERNAL_PG_*` or `EXTERNAL_ES_*` variables in `env.sh`
 - A `CUSTOM_HELM_VALUES_FILE` with Helm values pointing Camunda at the external targets
 
-When using `KEYCLOAK_TARGET_MODE=external`, you must also provide:
-- `EXTERNAL_KEYCLOAK_*` connection variables
-- `PG_TARGET_MODE=external` (the external Keycloak serves the migrated realm from the external Keycloak database)
-- `SKIP_HELM_UPGRADE=true` — **external Keycloak mode is data-only**. The scripts migrate the realm database and then exit; the caller must perform the Helm upgrade, wiring Camunda at the external Keycloak (`global.identity.keycloak.url` + auth credentials). The scripts do not wire Keycloak admin credentials into the Helm values.
+When using `KEYCLOAK_TARGET_MODE=external`, you only set that one flag plus the
+`EXTERNAL_KEYCLOAK_*` connection variables. The two coupled settings are derived
+automatically when you `source env.sh` (a `[auto]` line is logged for each):
+- `PG_TARGET_MODE=external` — the external Keycloak serves the migrated realm from the external Keycloak database.
+- `SKIP_HELM_UPGRADE=true` — **external Keycloak mode is data-only**. The scripts migrate the realm database and then exit; the caller performs the Helm upgrade, wiring Camunda at the external Keycloak (`global.identity.keycloak.url` + auth credentials). The scripts do not wire Keycloak admin credentials into the Helm values.
 
 If your Bitnami installation uses non-standard database or user names (common with the Bitnami Keycloak chart, which defaults to `bitnami_keycloak`/`bn_keycloak`), set the `*_SOURCE_DB_NAME`/`*_SOURCE_DB_USER` overrides accordingly:
 
@@ -237,7 +238,8 @@ upgrade. This is intended for CI harnesses that migrate Bitnami data onto
 external infrastructure and then perform an N→N+1 chart upgrade themselves
 (for example, the Camunda Helm test suites). Normal migrations leave it `false`.
 
-`KEYCLOAK_TARGET_MODE=external` always requires `SKIP_HELM_UPGRADE=true` — see above.
+`KEYCLOAK_TARGET_MODE=external` implies `SKIP_HELM_UPGRADE=true` — it is derived
+automatically when you source `env.sh`, so you do not set it yourself (see above).
 
 ## Detailed Phase Descriptions
 

--- a/generic/kubernetes/migration/README.md
+++ b/generic/kubernetes/migration/README.md
@@ -217,6 +217,14 @@ variables, and `PG_TARGET_MODE=external` (the external Keycloak serves the migra
 from the external Keycloak database). The scripts do not deploy or manage the Keycloak
 instance itself — only the realm database is migrated and Camunda is rewired to it.
 
+### Advanced: data-only cutover (`SKIP_HELM_UPGRADE`)
+
+Set `SKIP_HELM_UPGRADE=true` to run Phase 3 data migration (backup/restore +
+reindex) but skip the final `helm upgrade`. The caller then owns the chart
+upgrade. This is intended for CI harnesses that migrate Bitnami data onto
+external infrastructure and then perform an N→N+1 chart upgrade themselves
+(for example, the Camunda Helm test suites). Normal migrations leave it `false`.
+
 ## Detailed Phase Descriptions
 
 ### Phase 1: Deploy Targets (`1-deploy-targets.sh`)

--- a/generic/kubernetes/migration/README.md
+++ b/generic/kubernetes/migration/README.md
@@ -195,7 +195,12 @@ Set any `MIGRATE_*` to `false` to skip a component (e.g. if it's not deployed or
 | `EXTERNAL_KEYCLOAK_PORT`        | `80`                     | External Keycloak port                       |
 | `EXTERNAL_KEYCLOAK_CONTEXT_PATH`| `/auth`                  | External Keycloak context path               |
 | `EXTERNAL_KEYCLOAK_REALM`       | `/realms/camunda-platform`| External Keycloak realm path                |
-| `EXTERNAL_KEYCLOAK_ADMIN_SECRET`| (empty)                  | K8s Secret with the Keycloak admin `password` |
+| `IDENTITY_SOURCE_DB_NAME`       | `identity`               | Bitnami source DB name for Identity (override when Bitnami uses a different name) |
+| `IDENTITY_SOURCE_DB_USER`       | `identity`               | Bitnami source DB user for Identity          |
+| `KEYCLOAK_SOURCE_DB_NAME`       | `keycloak`               | Bitnami source DB name for Keycloak. Bitnami default: `bitnami_keycloak` |
+| `KEYCLOAK_SOURCE_DB_USER`       | `keycloak`               | Bitnami source DB user for Keycloak. Bitnami default: `bn_keycloak` |
+| `WEBMODELER_SOURCE_DB_NAME`     | `webmodeler`             | Bitnami source DB name for WebModeler        |
+| `WEBMODELER_SOURCE_DB_USER`     | `webmodeler`             | Bitnami source DB user for WebModeler        |
 
 ### When to use `external` target mode
 
@@ -212,10 +217,17 @@ When using `external` mode, you must also provide:
 - Connection details: `EXTERNAL_PG_*` or `EXTERNAL_ES_*` variables in `env.sh`
 - A `CUSTOM_HELM_VALUES_FILE` with Helm values pointing Camunda at the external targets
 
-When using `KEYCLOAK_TARGET_MODE=external`, you must also provide the `EXTERNAL_KEYCLOAK_*`
-variables, and `PG_TARGET_MODE=external` (the external Keycloak serves the migrated realm
-from the external Keycloak database). The scripts do not deploy or manage the Keycloak
-instance itself — only the realm database is migrated and Camunda is rewired to it.
+When using `KEYCLOAK_TARGET_MODE=external`, you must also provide:
+- `EXTERNAL_KEYCLOAK_*` connection variables
+- `PG_TARGET_MODE=external` (the external Keycloak serves the migrated realm from the external Keycloak database)
+- `SKIP_HELM_UPGRADE=true` — **external Keycloak mode is data-only**. The scripts migrate the realm database and then exit; the caller must perform the Helm upgrade, wiring Camunda at the external Keycloak (`global.identity.keycloak.url` + auth credentials). The scripts do not wire Keycloak admin credentials into the Helm values.
+
+If your Bitnami installation uses non-standard database or user names (common with the Bitnami Keycloak chart, which defaults to `bitnami_keycloak`/`bn_keycloak`), set the `*_SOURCE_DB_NAME`/`*_SOURCE_DB_USER` overrides accordingly:
+
+```bash
+KEYCLOAK_SOURCE_DB_NAME=bitnami_keycloak
+KEYCLOAK_SOURCE_DB_USER=bn_keycloak
+```
 
 ### Advanced: data-only cutover (`SKIP_HELM_UPGRADE`)
 
@@ -224,6 +236,8 @@ reindex) but skip the final `helm upgrade`. The caller then owns the chart
 upgrade. This is intended for CI harnesses that migrate Bitnami data onto
 external infrastructure and then perform an N→N+1 chart upgrade themselves
 (for example, the Camunda Helm test suites). Normal migrations leave it `false`.
+
+`KEYCLOAK_TARGET_MODE=external` always requires `SKIP_HELM_UPGRADE=true` — see above.
 
 ## Detailed Phase Descriptions
 

--- a/generic/kubernetes/migration/env.sh
+++ b/generic/kubernetes/migration/env.sh
@@ -165,14 +165,25 @@ export CUSTOM_KEYCLOAK_CONFIG_FILE="${CUSTOM_KEYCLOAK_CONFIG_FILE:-}"
 # which must be backed by the external Keycloak database (EXTERNAL_PG_KEYCLOAK_*)
 # so the migrated realm is served. Mirrors global.identity.keycloak.url.* in the
 # Camunda Helm chart.
+# NOTE: KEYCLOAK_TARGET_MODE=external is data-only (requires SKIP_HELM_UPGRADE=true).
+# The caller owns the Helm upgrade and must wire Camunda's Keycloak auth credentials.
 export EXTERNAL_KEYCLOAK_PROTOCOL="${EXTERNAL_KEYCLOAK_PROTOCOL:-http}"
 export EXTERNAL_KEYCLOAK_HOST="${EXTERNAL_KEYCLOAK_HOST:-}"
 export EXTERNAL_KEYCLOAK_PORT="${EXTERNAL_KEYCLOAK_PORT:-80}"
 export EXTERNAL_KEYCLOAK_CONTEXT_PATH="${EXTERNAL_KEYCLOAK_CONTEXT_PATH:-/auth}"
 export EXTERNAL_KEYCLOAK_REALM="${EXTERNAL_KEYCLOAK_REALM:-/realms/camunda-platform}"
-# Secret (in NAMESPACE) holding the Keycloak admin credentials the restored
-# realm uses. Must contain a 'password' key; 'username' defaults to admin.
-export EXTERNAL_KEYCLOAK_ADMIN_SECRET="${EXTERNAL_KEYCLOAK_ADMIN_SECRET:-}"
+
+# ---[ Source DB name/user overrides ]-----------------------------------------
+# Bitnami uses non-standard database and user names that differ from the target
+# (e.g. bitnami_keycloak/bn_keycloak instead of keycloak/keycloak). These
+# overrides let the backup scripts connect to the correct source database without
+# changing the target schema names. Default to the target DB_NAME/DB_USER values.
+export IDENTITY_SOURCE_DB_NAME="${IDENTITY_SOURCE_DB_NAME:-${IDENTITY_DB_NAME}}"
+export IDENTITY_SOURCE_DB_USER="${IDENTITY_SOURCE_DB_USER:-${IDENTITY_DB_USER}}"
+export KEYCLOAK_SOURCE_DB_NAME="${KEYCLOAK_SOURCE_DB_NAME:-${KEYCLOAK_DB_NAME}}"
+export KEYCLOAK_SOURCE_DB_USER="${KEYCLOAK_SOURCE_DB_USER:-${KEYCLOAK_DB_USER}}"
+export WEBMODELER_SOURCE_DB_NAME="${WEBMODELER_SOURCE_DB_NAME:-${WEBMODELER_DB_NAME}}"
+export WEBMODELER_SOURCE_DB_USER="${WEBMODELER_SOURCE_DB_USER:-${WEBMODELER_DB_USER}}"
 
 # =============================================================================
 echo "Migration config loaded:"
@@ -191,4 +202,10 @@ if [[ "${ES_TARGET_MODE}" == "external" ]]; then
 else
     echo "  ES target:    operator"
 fi
+if [[ "${KEYCLOAK_TARGET_MODE}" == "external" ]]; then
+    echo "  KC target:    external (${EXTERNAL_KEYCLOAK_PROTOCOL:-http}://${EXTERNAL_KEYCLOAK_HOST:-<not set>}:${EXTERNAL_KEYCLOAK_PORT:-80})"
+else
+    echo "  KC target:    operator"
+fi
+echo "  Skip upgrade: ${SKIP_HELM_UPGRADE:-false}"
 echo ""

--- a/generic/kubernetes/migration/env.sh
+++ b/generic/kubernetes/migration/env.sh
@@ -82,6 +82,16 @@ export ES_INDEX_PREFIXES="${ES_INDEX_PREFIXES:-zeebe-* operate-* tasklist-* opti
 export PG_TARGET_MODE="${PG_TARGET_MODE:-operator}"
 export ES_TARGET_MODE="${ES_TARGET_MODE:-operator}"
 
+# Keycloak target mode:
+#   "operator"  → Scripts deploy the Keycloak Operator + a Keycloak CR.
+#   "external"  → Scripts do NOT deploy Keycloak. An external Keycloak instance
+#                 (managed service, companion Helm release, standalone) must
+#                 already exist and be backed by the external Keycloak database
+#                 (EXTERNAL_PG_KEYCLOAK_*), so the restored realm is served by it.
+#                 Configure the "External Keycloak instance" subsection below.
+# Requires PG_TARGET_MODE=external (the external Keycloak owns its database).
+export KEYCLOAK_TARGET_MODE="${KEYCLOAK_TARGET_MODE:-operator}"
+
 # ┌───────────────────────────────────────────────────────────────────────────┐
 # │  OPERATOR MODE  (PG_TARGET_MODE=operator / ES_TARGET_MODE=operator)     │
 # │  Skip this section if using "external" mode.                            │
@@ -141,6 +151,21 @@ export CUSTOM_HELM_VALUES_FILE="${CUSTOM_HELM_VALUES_FILE:-}"
 # the external database instead of a CNPG cluster.
 # Provide a custom Keycloak CR file here (overrides automatic selection).
 export CUSTOM_KEYCLOAK_CONFIG_FILE="${CUSTOM_KEYCLOAK_CONFIG_FILE:-}"
+
+# ---[ External Keycloak instance ]--------------------------------------------
+# Used only when KEYCLOAK_TARGET_MODE=external. The scripts do not deploy
+# Keycloak; instead Camunda is pointed at this pre-existing external instance,
+# which must be backed by the external Keycloak database (EXTERNAL_PG_KEYCLOAK_*)
+# so the migrated realm is served. Mirrors global.identity.keycloak.url.* in the
+# Camunda Helm chart.
+export EXTERNAL_KEYCLOAK_PROTOCOL="${EXTERNAL_KEYCLOAK_PROTOCOL:-http}"
+export EXTERNAL_KEYCLOAK_HOST="${EXTERNAL_KEYCLOAK_HOST:-}"
+export EXTERNAL_KEYCLOAK_PORT="${EXTERNAL_KEYCLOAK_PORT:-80}"
+export EXTERNAL_KEYCLOAK_CONTEXT_PATH="${EXTERNAL_KEYCLOAK_CONTEXT_PATH:-/auth}"
+export EXTERNAL_KEYCLOAK_REALM="${EXTERNAL_KEYCLOAK_REALM:-/realms/camunda-platform}"
+# Secret (in NAMESPACE) holding the Keycloak admin credentials the restored
+# realm uses. Must contain a 'password' key; 'username' defaults to admin.
+export EXTERNAL_KEYCLOAK_ADMIN_SECRET="${EXTERNAL_KEYCLOAK_ADMIN_SECRET:-}"
 
 # =============================================================================
 echo "Migration config loaded:"

--- a/generic/kubernetes/migration/env.sh
+++ b/generic/kubernetes/migration/env.sh
@@ -92,6 +92,13 @@ export ES_TARGET_MODE="${ES_TARGET_MODE:-operator}"
 # Requires PG_TARGET_MODE=external (the external Keycloak owns its database).
 export KEYCLOAK_TARGET_MODE="${KEYCLOAK_TARGET_MODE:-operator}"
 
+# Data-only cutover: when "true", Phase 3 migrates all data to the target
+# backends but SKIPS the final `helm upgrade`. The caller is then responsible
+# for upgrading Camunda to point at the new backends. Intended for CI harnesses
+# that own the chart upgrade (e.g. testing an N→N+1 chart upgrade onto migrated
+# external infrastructure). Normal migrations leave this "false".
+export SKIP_HELM_UPGRADE="${SKIP_HELM_UPGRADE:-false}"
+
 # ┌───────────────────────────────────────────────────────────────────────────┐
 # │  OPERATOR MODE  (PG_TARGET_MODE=operator / ES_TARGET_MODE=operator)     │
 # │  Skip this section if using "external" mode.                            │

--- a/generic/kubernetes/migration/env.sh
+++ b/generic/kubernetes/migration/env.sh
@@ -89,7 +89,8 @@ export ES_TARGET_MODE="${ES_TARGET_MODE:-operator}"
 #                 already exist and be backed by the external Keycloak database
 #                 (EXTERNAL_PG_KEYCLOAK_*), so the restored realm is served by it.
 #                 Configure the "External Keycloak instance" subsection below.
-# Requires PG_TARGET_MODE=external (the external Keycloak owns its database).
+# Set this alone — the two coupled settings below (PG_TARGET_MODE=external and
+# SKIP_HELM_UPGRADE=true) are derived automatically; you do not need to set them.
 export KEYCLOAK_TARGET_MODE="${KEYCLOAK_TARGET_MODE:-operator}"
 
 # Data-only cutover: when "true", Phase 3 migrates all data to the target
@@ -98,6 +99,22 @@ export KEYCLOAK_TARGET_MODE="${KEYCLOAK_TARGET_MODE:-operator}"
 # that own the chart upgrade (e.g. testing an N→N+1 chart upgrade onto migrated
 # external infrastructure). Normal migrations leave this "false".
 export SKIP_HELM_UPGRADE="${SKIP_HELM_UPGRADE:-false}"
+
+# ---[ Derived coupling for KEYCLOAK_TARGET_MODE=external ]---------------------
+# External Keycloak is data-only and serves its realm from the external Keycloak
+# database, so it strictly implies PG_TARGET_MODE=external and SKIP_HELM_UPGRADE=true.
+# Rather than make the customer set three vars in lock-step, derive the other two
+# from KEYCLOAK_TARGET_MODE and log loudly if we change a non-default value.
+if [[ "${KEYCLOAK_TARGET_MODE}" == "external" ]]; then
+    if [[ "${PG_TARGET_MODE}" != "external" ]]; then
+        echo "  [auto] KEYCLOAK_TARGET_MODE=external → setting PG_TARGET_MODE=external (realm DB must be external)"
+        export PG_TARGET_MODE="external"
+    fi
+    if [[ "${SKIP_HELM_UPGRADE}" != "true" ]]; then
+        echo "  [auto] KEYCLOAK_TARGET_MODE=external → setting SKIP_HELM_UPGRADE=true (data-only; caller owns the upgrade)"
+        export SKIP_HELM_UPGRADE="true"
+    fi
+fi
 
 # ┌───────────────────────────────────────────────────────────────────────────┐
 # │  OPERATOR MODE  (PG_TARGET_MODE=operator / ES_TARGET_MODE=operator)     │

--- a/generic/kubernetes/migration/jobs/pg-backup.job.yml
+++ b/generic/kubernetes/migration/jobs/pg-backup.job.yml
@@ -21,6 +21,14 @@ spec:
                 migration.camunda.io/type: backup
         spec:
             restartPolicy: Never
+            # Make the backup PVC writable by the non-root postgres image
+            # (UID/GID 1001 in the Bitnami/community images). Without an fsGroup
+            # the dynamically-provisioned volume is root-owned and `mkdir
+            # /backup/<component>` fails with EACCES on storage classes that
+            # don't pre-chown the mount (e.g. GKE pd.csi).
+            securityContext:
+                fsGroup: 1001
+                fsGroupChangePolicy: OnRootMismatch
             containers:
                 - name: backup
                   image: ${PG_IMAGE}

--- a/generic/kubernetes/migration/jobs/pg-restore.job.yml
+++ b/generic/kubernetes/migration/jobs/pg-restore.job.yml
@@ -22,6 +22,13 @@ spec:
                 migration.camunda.io/type: restore
         spec:
             restartPolicy: Never
+            # Read the backup PVC as the non-root postgres image group (1001).
+            # Matches the fsGroup used by the backup job so the dump written
+            # there is group-readable on storage classes that don't pre-chown
+            # the mount (e.g. GKE pd.csi).
+            securityContext:
+                fsGroup: 1001
+                fsGroupChangePolicy: OnRootMismatch
             containers:
                 - name: restore
                   image: ${PG_IMAGE}

--- a/generic/kubernetes/migration/lib.sh
+++ b/generic/kubernetes/migration/lib.sh
@@ -2169,7 +2169,10 @@ wait_for_targets_ready() {
     fi
 
     # --- Keycloak CR ---
-    if [[ "${MIGRATE_KEYCLOAK:-false}" == "true" ]]; then
+    # Only the operator path has a Keycloak CR to wait on. In external mode the
+    # Keycloak instance is provided/owned by the caller (managed service or a
+    # companion release), so there is no CR here — skip the wait.
+    if [[ "${MIGRATE_KEYCLOAK:-false}" == "true" ]] && ! is_external_keycloak; then
         log_info "Waiting for Keycloak CR to be ready ..."
         while true; do
             local kc_ready

--- a/generic/kubernetes/migration/lib.sh
+++ b/generic/kubernetes/migration/lib.sh
@@ -1694,14 +1694,22 @@ get_bitnami_pg_password() {
 introspect_es() {
     log_info "Introspecting Elasticsearch ..."
 
-    local sts_name
-    sts_name=$(kubectl get statefulset -n "${NAMESPACE}" -o name 2>/dev/null \
-        | grep -E "elasticsearch" | head -1 | sed 's|statefulset.apps/||' || echo "")
+    # Detect the SOURCE (Bitnami/bundled) Elasticsearch StatefulSet. When the
+    # migration target is an in-cluster companion ES, both clusters coexist in
+    # the namespace, so prefer the release-prefixed bundled cluster
+    # (<release>-elasticsearch*) and never match the companion. Fall back to any
+    # ES StatefulSet for the classic single-cluster case.
+    local sts_name all_es
+    all_es=$(kubectl get statefulset -n "${NAMESPACE}" -o name 2>/dev/null \
+        | sed 's|statefulset.apps/||' | grep -E "elasticsearch" || true)
+    sts_name=$(echo "$all_es" | grep -E "^${CAMUNDA_RELEASE_NAME}-" | head -1)
+    [[ -z "$sts_name" ]] && sts_name=$(echo "$all_es" | head -1)
 
     if [[ -z "$sts_name" ]]; then
         log_error "No Elasticsearch StatefulSet found"
         return 1
     fi
+    log_info "Source Elasticsearch StatefulSet: ${sts_name}"
 
     local json
     json=$(kubectl get statefulset "${sts_name}" -n "${NAMESPACE}" -o json)

--- a/generic/kubernetes/migration/lib.sh
+++ b/generic/kubernetes/migration/lib.sh
@@ -217,11 +217,21 @@ check_env() {
             # Compare major.minor of deployed version against expected version
             local deployed_major_minor="${deployed_app_version%.*}"
             if [[ "$deployed_major_minor" != "$expected_version" ]]; then
-                log_error "Deployed Camunda version ${deployed_app_version} (${deployed_major_minor}) does not match expected version ${expected_version} from .camunda-version"
-                log_error "These migration scripts are designed for Camunda ${expected_version}. Check that you are using the correct branch."
-                exit 1
+                if [[ "${SKIP_HELM_UPGRADE:-false}" == "true" ]]; then
+                    # Data-only migration: the deployed version is intentionally the
+                    # previous minor — the caller upgrades to ${expected_version}
+                    # after the data has moved onto the external backends. (This is
+                    # the only supported order when the target minor has dropped the
+                    # bundled Bitnami subcharts, so the source cannot be on it.)
+                    log_warn "Deployed Camunda version ${deployed_app_version} (${deployed_major_minor}) differs from ${expected_version}; allowed because SKIP_HELM_UPGRADE=true (caller performs the version upgrade)"
+                else
+                    log_error "Deployed Camunda version ${deployed_app_version} (${deployed_major_minor}) does not match expected version ${expected_version} from .camunda-version"
+                    log_error "These migration scripts are designed for Camunda ${expected_version}. Check that you are using the correct branch."
+                    exit 1
+                fi
+            else
+                log_info "Deployed Camunda version ${deployed_app_version} matches expected ${expected_version}"
             fi
-            log_info "Deployed Camunda version ${deployed_app_version} matches expected ${expected_version}"
         fi
     else
         log_warn ".camunda-version file not found at ${version_file} — skipping version pre-check"

--- a/generic/kubernetes/migration/lib.sh
+++ b/generic/kubernetes/migration/lib.sh
@@ -817,6 +817,13 @@ validate_external_es_config() {
 
 # Validate custom helm values file exists when external targets are used.
 validate_custom_helm_values() {
+    # When SKIP_HELM_UPGRADE=true the scripts migrate data only and do not run
+    # the helm upgrade (the caller owns it), so a custom values file pointing
+    # Camunda at the external targets is not needed here.
+    if [[ "${SKIP_HELM_UPGRADE:-false}" == "true" ]]; then
+        return 0
+    fi
+
     if (is_external_pg || is_external_es) && [[ -z "${CUSTOM_HELM_VALUES_FILE:-}" ]]; then
         log_error "CUSTOM_HELM_VALUES_FILE must be set when using external targets"
         log_error "  This file should contain helm values to connect Camunda to your managed services"

--- a/generic/kubernetes/migration/lib.sh
+++ b/generic/kubernetes/migration/lib.sh
@@ -1433,20 +1433,15 @@ sync_keycloak_admin_credentials() {
     local admin_user="admin"
 
     # Update the operator secret to match the restored DB credentials.
-    # Skipped in external mode: the external Keycloak owns its own admin (served
-    # from the restored realm DB); there is no operator "keycloak-initial-admin"
-    # secret to reconcile.
-    if ! is_external_keycloak; then
-        kubectl create secret generic "$operator_secret" \
-            -n "${NAMESPACE}" \
-            --from-literal=username="$admin_user" \
-            --from-literal=password="$admin_pass" \
-            --dry-run=client -o yaml \
-            | kubectl apply -f - >/dev/null
-        log_info "Updated ${operator_secret} secret (user=${admin_user})"
-    else
-        log_info "External Keycloak — skipping operator '${operator_secret}' secret reconcile"
-    fi
+    # (External mode already returned at the top of this function — it owns its
+    # admin via the restored realm DB and has no operator secret to reconcile.)
+    kubectl create secret generic "$operator_secret" \
+        -n "${NAMESPACE}" \
+        --from-literal=username="$admin_user" \
+        --from-literal=password="$admin_pass" \
+        --dry-run=client -o yaml \
+        | kubectl apply -f - >/dev/null
+    log_info "Updated ${operator_secret} secret (user=${admin_user})"
     unset admin_pass
     eval "$_xtrace" 2>/dev/null
 

--- a/generic/kubernetes/migration/lib.sh
+++ b/generic/kubernetes/migration/lib.sh
@@ -715,6 +715,63 @@ warn_customization() {
 
 is_external_pg() { [[ "${PG_TARGET_MODE:-operator}" == "external" ]]; }
 is_external_es() { [[ "${ES_TARGET_MODE:-operator}" == "external" ]]; }
+is_external_keycloak() { [[ "${KEYCLOAK_TARGET_MODE:-operator}" == "external" ]]; }
+
+# Validate external Keycloak configuration.
+# In external mode the scripts do not deploy Keycloak; Camunda is pointed at a
+# pre-existing instance whose realm lives in the external Keycloak database, so
+# the Keycloak PostgreSQL target must also be external.
+validate_external_keycloak_config() {
+    local errs=0
+
+    if [[ -z "${EXTERNAL_KEYCLOAK_HOST:-}" ]]; then
+        log_error "EXTERNAL_KEYCLOAK_HOST must be set when KEYCLOAK_TARGET_MODE=external"
+        errs=1
+    fi
+
+    if ! is_external_pg; then
+        log_error "KEYCLOAK_TARGET_MODE=external requires PG_TARGET_MODE=external"
+        log_error "  The external Keycloak must serve the migrated realm from the external Keycloak database."
+        errs=1
+    fi
+
+    if [[ -z "${EXTERNAL_KEYCLOAK_ADMIN_SECRET:-}" ]]; then
+        log_error "EXTERNAL_KEYCLOAK_ADMIN_SECRET must be set when KEYCLOAK_TARGET_MODE=external"
+        errs=1
+    elif ! kubectl get secret "${EXTERNAL_KEYCLOAK_ADMIN_SECRET}" -n "${NAMESPACE}" &>/dev/null; then
+        log_error "Secret '${EXTERNAL_KEYCLOAK_ADMIN_SECRET}' not found in namespace ${NAMESPACE}"
+        errs=1
+    fi
+
+    if [[ "$errs" -eq 0 ]]; then
+        log_success "  keycloak: external instance OK (${EXTERNAL_KEYCLOAK_PROTOCOL:-http}://${EXTERNAL_KEYCLOAK_HOST}:${EXTERNAL_KEYCLOAK_PORT:-80}${EXTERNAL_KEYCLOAK_CONTEXT_PATH:-/auth})"
+    fi
+    return "$errs"
+}
+
+# Generate Camunda Helm values that point at an EXTERNAL Keycloak instance.
+# Used during cutover instead of the operator keycloak values. Disables the
+# bundled Bitnami subchart and wires global.identity.keycloak.url at the
+# external endpoint. The admin user override (client tokens + adminUser) is
+# applied separately by sync_keycloak_admin_credentials.
+generate_external_keycloak_values() {
+    local out="${STATE_DIR}/keycloak-external-values.yml"
+    cat > "$out" <<EOF
+global:
+    identity:
+        keycloak:
+            internal: false
+            url:
+                protocol: ${EXTERNAL_KEYCLOAK_PROTOCOL:-http}
+                host: ${EXTERNAL_KEYCLOAK_HOST}
+                port: "${EXTERNAL_KEYCLOAK_PORT:-80}"
+            contextPath: ${EXTERNAL_KEYCLOAK_CONTEXT_PATH:-/auth}
+            realm: ${EXTERNAL_KEYCLOAK_REALM:-/realms/camunda-platform}
+identityKeycloak:
+    enabled: false
+EOF
+    echo "$out"
+}
 
 # Validate that external PG configuration is complete for a component.
 # Usage: validate_external_pg_config <component>
@@ -1133,8 +1190,11 @@ validate_target_resources() {
     local has_errors=0
 
     # --- External target configuration checks ---
-    if is_external_pg || is_external_es; then
+    if is_external_pg || is_external_es || is_external_keycloak; then
         log_info "External target configuration:"
+        if is_external_keycloak && [[ "${MIGRATE_KEYCLOAK}" == "true" ]]; then
+            validate_external_keycloak_config || has_errors=1
+        fi
         if is_external_pg; then
             if [[ "${MIGRATE_IDENTITY}" == "true" ]]; then
                 validate_external_pg_config identity || has_errors=1
@@ -1338,17 +1398,23 @@ sync_keycloak_admin_credentials() {
     # The Bitnami Keycloak chart default admin user is "admin"
     local admin_user="admin"
 
-    # Update the operator secret to match the restored DB credentials
-    kubectl create secret generic "$operator_secret" \
-        -n "${NAMESPACE}" \
-        --from-literal=username="$admin_user" \
-        --from-literal=password="$admin_pass" \
-        --dry-run=client -o yaml \
-        | kubectl apply -f - >/dev/null
+    # Update the operator secret to match the restored DB credentials.
+    # Skipped in external mode: the external Keycloak owns its own admin (served
+    # from the restored realm DB); there is no operator "keycloak-initial-admin"
+    # secret to reconcile.
+    if ! is_external_keycloak; then
+        kubectl create secret generic "$operator_secret" \
+            -n "${NAMESPACE}" \
+            --from-literal=username="$admin_user" \
+            --from-literal=password="$admin_pass" \
+            --dry-run=client -o yaml \
+            | kubectl apply -f - >/dev/null
+        log_info "Updated ${operator_secret} secret (user=${admin_user})"
+    else
+        log_info "External Keycloak — skipping operator '${operator_secret}' secret reconcile"
+    fi
     unset admin_pass
     eval "$_xtrace" 2>/dev/null
-
-    log_info "Updated ${operator_secret} secret (user=${admin_user})"
 
     # Ensure the Bitnami secret has ALL keys that the operator chart references.
     # Bitnami generates some client tokens (optimize, admin) but NOT all

--- a/generic/kubernetes/migration/lib.sh
+++ b/generic/kubernetes/migration/lib.sh
@@ -708,11 +708,18 @@ warn_customization() {
         echo "║  • ES data migration must be done manually (see README)                ║"
         echo "║  • You must provide CUSTOM_HELM_VALUES_FILE with ES connection info    ║"
         fi
-        if is_external_pg && [[ "${MIGRATE_KEYCLOAK}" == "true" ]]; then
+        if is_external_pg && [[ "${MIGRATE_KEYCLOAK}" == "true" ]] && ! is_external_keycloak; then
         echo "║                                                                        ║"
         echo "║  Keycloak + external PG:                                               ║"
         echo "║  • Keycloak Operator IS still deployed (no managed KC service exists)   ║"
         echo "║  • Set CUSTOM_KEYCLOAK_CONFIG_FILE to a CR pointing to external PG     ║"
+        fi
+        if is_external_keycloak; then
+        echo "║                                                                        ║"
+        echo "║  KEYCLOAK_TARGET_MODE=external (data-only)                             ║"
+        echo "║  • Keycloak Operator will NOT be deployed                              ║"
+        echo "║  • Realm database is migrated to the external Keycloak PG instance     ║"
+        echo "║  • Caller must perform the Helm upgrade pointing at this Keycloak      ║"
         fi
         echo "╚══════════════════════════════════════════════════════════════════════════╝"
         echo ""
@@ -745,11 +752,11 @@ validate_external_keycloak_config() {
         errs=1
     fi
 
-    if [[ -z "${EXTERNAL_KEYCLOAK_ADMIN_SECRET:-}" ]]; then
-        log_error "EXTERNAL_KEYCLOAK_ADMIN_SECRET must be set when KEYCLOAK_TARGET_MODE=external"
-        errs=1
-    elif ! kubectl get secret "${EXTERNAL_KEYCLOAK_ADMIN_SECRET}" -n "${NAMESPACE}" &>/dev/null; then
-        log_error "Secret '${EXTERNAL_KEYCLOAK_ADMIN_SECRET}' not found in namespace ${NAMESPACE}"
+    if [[ "${SKIP_HELM_UPGRADE:-false}" != "true" ]]; then
+        log_error "KEYCLOAK_TARGET_MODE=external requires SKIP_HELM_UPGRADE=true"
+        log_error "  External Keycloak mode is data-only: the scripts migrate the realm database"
+        log_error "  and then exit. The caller must perform the Helm upgrade, wiring Camunda at"
+        log_error "  the external Keycloak (global.identity.keycloak.url + auth credentials)."
         errs=1
     fi
 

--- a/generic/kubernetes/migration/lib.sh
+++ b/generic/kubernetes/migration/lib.sh
@@ -1392,6 +1392,16 @@ deploy_keycloak() {
 # we must update the operator secret to match the restored DB credentials.
 # Also generates a Helm override file to set the correct adminUser.
 sync_keycloak_admin_credentials() {
+    # Operator-only reconcile: it updates the operator's "keycloak-initial-admin"
+    # secret and renders an admin override for the Helm upgrade. In external mode
+    # there is no operator secret, the external Keycloak's admin comes from the
+    # restored realm database, and the caller wires Camunda's admin credentials
+    # (and, with SKIP_HELM_UPGRADE, owns the upgrade and its values). So skip it.
+    if is_external_keycloak; then
+        log_info "External Keycloak — skipping operator admin-credential sync"
+        return 0
+    fi
+
     log_info "Syncing Keycloak admin credentials from Bitnami → operator ..."
 
     local release="${RELEASE:-${CAMUNDA_RELEASE_NAME:-camunda}}"

--- a/generic/kubernetes/migration/lib.sh
+++ b/generic/kubernetes/migration/lib.sh
@@ -766,30 +766,6 @@ validate_external_keycloak_config() {
     return "$errs"
 }
 
-# Generate Camunda Helm values that point at an EXTERNAL Keycloak instance.
-# Used during cutover instead of the operator keycloak values. Disables the
-# bundled Bitnami subchart and wires global.identity.keycloak.url at the
-# external endpoint. The admin user override (client tokens + adminUser) is
-# applied separately by sync_keycloak_admin_credentials.
-generate_external_keycloak_values() {
-    local out="${STATE_DIR}/keycloak-external-values.yml"
-    cat > "$out" <<EOF
-global:
-    identity:
-        keycloak:
-            internal: false
-            url:
-                protocol: ${EXTERNAL_KEYCLOAK_PROTOCOL:-http}
-                host: ${EXTERNAL_KEYCLOAK_HOST}
-                port: "${EXTERNAL_KEYCLOAK_PORT:-80}"
-            contextPath: ${EXTERNAL_KEYCLOAK_CONTEXT_PATH:-/auth}
-            realm: ${EXTERNAL_KEYCLOAK_REALM:-/realms/camunda-platform}
-identityKeycloak:
-    enabled: false
-EOF
-    echo "$out"
-}
-
 # Validate that external PG configuration is complete for a component.
 # Usage: validate_external_pg_config <component>
 validate_external_pg_config() {


### PR DESCRIPTION
## Motivation

The Bitnami → external-infrastructure migration scripts (`generic/kubernetes/migration`) already support routing **PostgreSQL** and **Elasticsearch** to external (non-operator) targets via `PG_TARGET_MODE=external` / `ES_TARGET_MODE=external`. **Keycloak**, however, was always deployed as a Keycloak Operator `Keycloak` CR — there was no way to migrate a bundled Bitnami Keycloak onto a Keycloak that is managed, standalone, or deployed via a Helm chart.

This matters for two audiences:

- **Customers** who run (or want to run) Keycloak as a managed/standalone/Helm instance rather than via the Keycloak Operator.
- **CI**: the Camunda Helm test suites need to stand up **arbitrary versions** of Keycloak / PostgreSQL / Elasticsearch to mimic the spread of real customer environments — which operators don't make easy, but external (companion) instances do. Exercising these scripts in `external` mode is how we prove a Bitnami-8.9 customer can reach 8.10.

## What this PR does

Adds `KEYCLOAK_TARGET_MODE=external`:

- **`env.sh`** — `KEYCLOAK_TARGET_MODE` toggle + `EXTERNAL_KEYCLOAK_*` connection vars (protocol/host/port/context-path/realm/admin-secret).
- **`lib.sh`** — `is_external_keycloak`, `validate_external_keycloak_config`, and `generate_external_keycloak_values` (wires `global.identity.keycloak.url` at the external instance and sets `identityKeycloak.enabled: false`); `sync_keycloak_admin_credentials` skips the operator-only `keycloak-initial-admin` reconcile in external mode while still generating the admin/client-token override.
- **`1-deploy-targets.sh`** — skips Keycloak Operator deployment in external mode.
- **`3-cutover.sh`** — applies the external Keycloak helm values during the cutover Helm switch.
- **`4-validate.sh` / `5-cleanup-bitnami.sh`** — skip the operator `Keycloak` CR readiness check in external mode.
- **`README.md`** — documents the new flag, the `EXTERNAL_KEYCLOAK_*` variables, and when to use them.

The realm itself still migrates via the external Keycloak **PostgreSQL database** (`EXTERNAL_PG_KEYCLOAK_*`), so `KEYCLOAK_TARGET_MODE=external` requires `PG_TARGET_MODE=external`. The scripts do not deploy or manage the Keycloak instance — only the realm DB is migrated and Camunda is rewired to it.

## Status / validation

- `bash -n` clean on all changed scripts.
- **Not yet validated on a live cluster.** `shellcheck`/`pre-commit` were not available in my environment — please run `pre-commit run --all-files`.
- Follow-ups: a kind-based migration test case for `external` Keycloak (the existing matrix covers operator targets only), and a companion docs PR in [camunda-docs](https://github.com/camunda/camunda-docs) `migration-from-bitnami/` once this lands.

## Related

This unblocks Helm CI work in `camunda/camunda-platform-helm` to drive these scripts (install 8.9 + bundled Bitnami → migrate to companion external infra in `external` mode → upgrade to 8.10 → verify). That CI PR will reference this one.
