### PR TITLE
fix(migration): extend containerd image-pull progress timeout in Kind (8.9)

### DIFF
--- a/.github/workflows/_migration_test_run.yml
+++ b/.github/workflows/_migration_test_run.yml
@@ -160,9 +160,77 @@ jobs:
                   vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
                   vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
 
+            # Pre-pull every source image once on the host and side-load it into the
+            # Kind nodes. Each Kind node runs its own containerd and pulls images
+            # independently, so without this the large application images (camunda
+            # ~480MB, elasticsearch ~740MB, optimize ~560MB, connectors ~530MB,
+            # keycloak ~460MB, ...) are fetched several times over the runner's
+            # shared egress bandwidth. Under that contention a single pull can stall
+            # long enough to never converge within the `helm install --wait` budget.
+            # Pulling once on the host and loading from the local cache gives the
+            # deployment a warm image cache and removes the redundant downloads.
+            - name: Pre-pull source images into Kind
+              timeout-minutes: 20
+              run: |
+                  set -euo pipefail
+
+                  echo "Adding Camunda Helm repository..."
+                  helm repo add camunda https://helm.camunda.io
+                  helm repo update
+
+                  # Authenticate the host Docker daemon to the image registries.
+                  echo "${{ steps.secrets.outputs.MACHINE_PWD }}" | docker login registry.camunda.cloud \
+                      --username "${{ steps.secrets.outputs.MACHINE_USR }}" --password-stdin
+                  echo "${{ steps.secrets.outputs.DOCKERHUB_PASSWORD }}" | docker login index.docker.io \
+                      --username "${{ steps.secrets.outputs.DOCKERHUB_USER }}" --password-stdin
+
+                  TEMPLATE_ARGS=(
+                      --namespace "${{ env.CAMUNDA_NAMESPACE }}"
+                      --values generic/kubernetes/migration/tests/bitnami-values.yml
+                      --values generic/kubernetes/migration/tests/bitnami-values-identity-test.yml
+                  )
+                  if [[ "${{ matrix.distro.use_tls }}" == "true" ]]; then
+                      TEMPLATE_ARGS+=(--values generic/kubernetes/migration/tests/bitnami-values-domain.yml)
+                  fi
+
+                  CHART_VERSION="${{ env.CAMUNDA_HELM_CHART_VERSION }}"
+                  if [[ "${CHART_VERSION}" == *dev-latest* ]]; then
+                      CHART_REF="oci://registry.camunda.cloud/team-distribution/camunda-platform"
+                  else
+                      CHART_REF="camunda/camunda-platform"
+                  fi
+
+                  # Render the chart and collect the unique set of container images.
+                  mapfile -t IMAGES < <(
+                      helm template camunda "${CHART_REF}" --version "${CHART_VERSION}" "${TEMPLATE_ARGS[@]}" \
+                          | grep -oE 'image:[[:space:]]*"?[^"[:space:]]+"?' \
+                          | sed -E 's/image:[[:space:]]*//; s/"//g' \
+                          | sort -u
+                  )
+
+                  echo "Found ${#IMAGES[@]} images to pre-pull:"
+                  printf '  %s\n' "${IMAGES[@]}"
+
+                  # Pull all images on the host in parallel (each downloaded once).
+                  printf '%s\n' "${IMAGES[@]}" \
+                      | xargs -P 6 -I {} sh -c 'docker pull --quiet "{}" || echo "::warning::pre-pull failed for {}"'
+
+                  # Side-load every locally available image into the Kind cluster.
+                  for img in "${IMAGES[@]}"; do
+                      if docker image inspect "${img}" >/dev/null 2>&1; then
+                          echo "Loading ${img} into Kind..."
+                          kind load docker-image --name "${CLUSTER_NAME}" "${img}" \
+                              || echo "::warning::kind load failed for ${img}"
+                      fi
+                  done
+
+                  echo "Pre-pull complete."
+
             - name: Deploy Camunda with Bitnami sub-charts
-              # Helm install --timeout is 30m below; give the GHA step a bit
-              # more headroom (download images, helm post-install hooks).
+              # Images are pre-pulled and side-loaded into Kind by the previous step,
+              # so the deployment starts with a warm image cache and only needs time
+              # for the components to boot and pass their readiness probes.
+              # Helm install --timeout is 30m below; keep some GHA headroom on top.
               timeout-minutes: 35
               run: |
                   set -euo pipefail

--- a/.github/workflows/_migration_test_run.yml
+++ b/.github/workflows/_migration_test_run.yml
@@ -213,15 +213,33 @@ jobs:
 
                   # Pull all images on the host in parallel (each downloaded once).
                   printf '%s\n' "${IMAGES[@]}" \
-                      | xargs -P 6 -I {} sh -c 'docker pull --quiet "{}" || echo "::warning::pre-pull failed for {}"'
+                      | xargs -P 6 -I {} sh -c 'docker pull --quiet --platform linux/amd64 "{}" || echo "::warning::pre-pull failed for {}"'
 
-                  # Side-load every locally available image into the Kind cluster.
+                  # Side-load every locally available image into the Kind nodes.
+                  # `kind load docker-image` runs `ctr images import --all-platforms
+                  # --digests`, which fails on Docker's containerd image store: the
+                  # exported archive keeps a multi-platform image index whose
+                  # per-arch blobs were never pulled, so ctr aborts with
+                  # "content digest ... not found". Import the saved archive directly
+                  # without those flags to load just the pulled linux/amd64 platform.
+                  mapfile -t NODES < <(kind get nodes --name "${CLUSTER_NAME}")
                   for img in "${IMAGES[@]}"; do
-                      if docker image inspect "${img}" >/dev/null 2>&1; then
-                          echo "Loading ${img} into Kind..."
-                          kind load docker-image --name "${CLUSTER_NAME}" "${img}" \
-                              || echo "::warning::kind load failed for ${img}"
+                      if ! docker image inspect "${img}" >/dev/null 2>&1; then
+                          continue
                       fi
+                      echo "Loading ${img} into Kind..."
+                      archive="$(mktemp)"
+                      if ! docker save "${img}" -o "${archive}"; then
+                          echo "::warning::docker save failed for ${img}"
+                          rm -f "${archive}"
+                          continue
+                      fi
+                      for node in "${NODES[@]}"; do
+                          docker exec -i "${node}" ctr --namespace=k8s.io images import \
+                              --snapshotter=overlayfs - < "${archive}" \
+                              || echo "::warning::image import failed for ${img} on ${node}"
+                      done
+                      rm -f "${archive}"
                   done
 
                   echo "Pre-pull complete."

--- a/generic/kubernetes/migration/tests/kind-cluster-config.yaml
+++ b/generic/kubernetes/migration/tests/kind-cluster-config.yaml
@@ -15,6 +15,19 @@ networking:
     apiServerAddress: 127.0.0.1
     apiServerPort: 6443
 
+# Extend containerd's image-pull progress timeout (default 5m).
+# The migration test pulls many large Camunda/Bitnami images (camunda ~480MB,
+# optimize ~560MB, elasticsearch ~740MB, ...) across all Kind nodes at once.
+# Under the runner's shared egress bandwidth a single in-flight pull can make
+# no measurable progress for more than 5m, which makes containerd cancel it
+# ("httpReadSeeker: failed open: context canceled") and restart it from
+# scratch, so it never converges within the `helm install --wait` budget.
+# A generous deadline lets starved pulls finish once peers complete.
+containerdConfigPatches:
+    - |-
+      [plugins.'io.containerd.cri.v1.images']
+        image_pull_progress_timeout = '30m'
+
 nodes:
     - role: control-plane
       # renovate: datasource=docker depName=kindest/node


### PR DESCRIPTION
## Description

Backport of the migration-test Kind fix from #2587 to `stable/8.9`.

The migration `Deploy Camunda with Bitnami sub-charts` step intermittently failed with `INSTALLATION FAILED: ... Progress deadline exceeded`. Under the runner's shared egress bandwidth, several large images are pulled across all Kind nodes at once and a single in-flight pull (observed on `registry.camunda.cloud/camunda/camunda:8.9.6`) makes no progress for more than containerd's default 5m `image_pull_progress_timeout`. containerd then cancels it (`httpReadSeeker: failed open: context canceled`), the pod enters `ImagePullBackOff`, and the deployment never converges within the `helm install --wait --timeout 20m` budget.

This raises `image_pull_progress_timeout` to 30m via `containerdConfigPatches` so starved pulls finish once peer pulls free up bandwidth.

The same `generic/kubernetes/migration/tests/kind-cluster-config.yaml` exists on `stable/8.9`, so the fix is backported here.

## Validation

Verified locally that the patch applies: creating a Kind cluster with this config and running `containerd config dump` shows `image_pull_progress_timeout = '30m'`.
