### PR TITLE
feat(cleanup): alert on ROSA clusters stuck in deletion >24h

### DIFF
--- a/.github/actions/aws-generic-terraform-cleanup/README.md
+++ b/.github/actions/aws-generic-terraform-cleanup/README.md
@@ -22,6 +22,13 @@ This GitHub Action automates the deletion of generic terraform resources using a
 | `delete-ghost-rosa-clusters` | <p>Specify whether to delete ghost rosa clusters (true or false)</p> | `false` | `false` |
 
 
+## Outputs
+
+| name | description |
+| --- | --- |
+| `stuck-rosa-clusters` | <p>Comma-separated list of ROSA clusters stuck in a deletion/error state for longer than the configured threshold (24h by default), reported so a dedicated alert can be raised without failing the cleanup. Empty when no cluster is stuck.</p> |
+
+
 ## Runs
 
 This action is a `composite` action.

--- a/.github/actions/aws-generic-terraform-cleanup/action.yml
+++ b/.github/actions/aws-generic-terraform-cleanup/action.yml
@@ -50,6 +50,14 @@ inputs:
         description: Specify whether to delete ghost rosa clusters (true or false)
         default: 'false'
 
+outputs:
+    stuck-rosa-clusters:
+        description: >-
+            Comma-separated list of ROSA clusters stuck in a deletion/error state for longer than the configured
+            threshold (24h by default), reported so a dedicated alert can be raised without failing the cleanup.
+            Empty when no cluster is stuck.
+        value: ${{ steps.delete_resources.outputs.stuck_clusters }}
+
 runs:
     using: composite
     steps:
@@ -98,6 +106,10 @@ runs:
           env:
               OPENSHIFT: ${{ inputs.openshift }}   # as an indicator in the script whether EKS vs ROSA
               DISABLE_TELEMETRY: true # Disable telemetry for cloud-nuke
+              # S3-persisted state used by cleanup-ghost-rosa-clusters.sh to track,
+              # across runs, how long each ghost cluster has been stuck in deletion.
+              STUCK_STATE_BUCKET: ${{ inputs.tf-bucket }}
+              STUCK_STATE_KEY: ${{ inputs.tf-bucket-key-prefix }}ghost-rosa-cluster-deletion-state.json
           run: |
               set -euo pipefail
 

--- a/.github/actions/aws-generic-terraform-cleanup/scripts/cleanup-ghost-rosa-clusters.sh
+++ b/.github/actions/aws-generic-terraform-cleanup/scripts/cleanup-ghost-rosa-clusters.sh
@@ -28,6 +28,61 @@ fi
 MIN_AGE_HOURS=$1
 CURRENT_TIME=$($date_command +%s)
 
+# Number of hours after which a cluster still observed in a deletion/error state
+# (no node pools, no AWS resources) is considered "stuck on the Red Hat side".
+# Such clusters are no longer retried for deletion: instead they are reported via
+# a dedicated alert so the cleanup itself is NOT marked as failed.
+STUCK_DELETION_THRESHOLD_HOURS="${STUCK_DELETION_THRESHOLD_HOURS:-24}"
+
+# Region used for the S3 state bucket operations (falls back to AWS_REGION).
+AWS_S3_REGION="${AWS_S3_REGION:-${AWS_REGION:-}}"
+
+# Optional S3 location used to persist, across runs, the first time each cluster
+# was observed stuck. OCM exposes no deletion-start timestamp, so this external
+# state is what lets us measure the ">= STUCK_DELETION_THRESHOLD_HOURS" window.
+# When unset, stuck tracking still works within a single run but cannot span runs.
+STUCK_STATE_BUCKET="${STUCK_STATE_BUCKET:-}"
+STUCK_STATE_KEY="${STUCK_STATE_KEY:-}"
+
+# Local working copy of the persisted state file.
+STUCK_STATE_FILE="$(mktemp)"
+
+# load_stuck_state downloads the persisted first-seen state from S3 into
+# STUCK_STATE_FILE, defaulting to an empty object when missing or invalid.
+load_stuck_state() {
+  if [[ -n "$STUCK_STATE_BUCKET" && -n "$STUCK_STATE_KEY" ]]; then
+    local src="s3://${STUCK_STATE_BUCKET}/${STUCK_STATE_KEY}"
+    if [[ -n "$AWS_S3_REGION" ]]; then
+      aws s3 cp "$src" "$STUCK_STATE_FILE" --region "$AWS_S3_REGION" >/dev/null 2>&1 || true
+    else
+      aws s3 cp "$src" "$STUCK_STATE_FILE" >/dev/null 2>&1 || true
+    fi
+  fi
+  if ! jq empty "$STUCK_STATE_FILE" >/dev/null 2>&1; then
+    echo '{}' > "$STUCK_STATE_FILE"
+  fi
+}
+
+# save_stuck_state writes the given JSON state back to S3 (best-effort).
+save_stuck_state() {
+  local new_state="$1"
+  printf '%s' "$new_state" > "$STUCK_STATE_FILE"
+  if [[ -n "$STUCK_STATE_BUCKET" && -n "$STUCK_STATE_KEY" ]]; then
+    local dst="s3://${STUCK_STATE_BUCKET}/${STUCK_STATE_KEY}"
+    local copied=true
+    if [[ -n "$AWS_S3_REGION" ]]; then
+      aws s3 cp "$STUCK_STATE_FILE" "$dst" --region "$AWS_S3_REGION" >/dev/null 2>&1 || copied=false
+    else
+      aws s3 cp "$STUCK_STATE_FILE" "$dst" >/dev/null 2>&1 || copied=false
+    fi
+    if [[ "$copied" == true ]]; then
+      echo "💾 Persisted stuck-cluster state to $dst"
+    else
+      echo "⚠️ Failed to persist stuck-cluster state to $dst (continuing)"
+    fi
+  fi
+}
+
 
 # cleanup_iam_roles_with_prefix removes all IAM roles whose name starts with the
 # given prefix, including detaching/deleting their policies first.
@@ -68,34 +123,104 @@ rosa create account-roles --mode auto --yes
 echo "📦 Ensuring ocm-role exists..."
 rosa create ocm-role --mode auto --yes
 
-# Fetch clusters matching the criteria (if no node pool and error reported)
-raw_clusters=$(rosa list cluster --output json | jq '[.[] | select((.node_pools.items | length == 0) and .status.limited_support_reason_count == 1 or .status.state == "error")]')
+# Fetch clusters matching the criteria: no node pools left and either reported in
+# limited support, in "error" state, or already "uninstalling" (deletion in
+# progress / potentially stuck on the Red Hat side).
+raw_clusters=$(rosa list cluster --output json | jq '[.[] | select((.node_pools.items | length == 0) and ((.status.limited_support_reason_count == 1) or (.status.state == "error") or (.status.state == "uninstalling")))]')
 
 # Check if there are any clusters
 cluster_count=$(echo "$raw_clusters" | jq 'length')
+echo "🔎 Found ${cluster_count} candidate cluster(s) in a stuck/error/uninstalling state."
 
-if [ "$cluster_count" -eq 0 ]; then
-  echo "✅ No clusters to delete. Exiting."
-  exit 0
-fi
+# Load the cross-run first-seen state so we can measure how long each cluster has
+# been stuck.
+load_stuck_state
+NOW_ISO=$($date_command -u +%Y-%m-%dT%H:%M:%SZ)
 
-echo "$raw_clusters" | jq -c '.[]' | while read -r cluster; do
+# new_state is rebuilt from the clusters seen this run, so entries for clusters
+# that disappeared (successfully deleted) are pruned automatically.
+new_state='{}'
+clusters_to_delete=()
+stuck_cluster_names=()
+
+# Pass 1: classify every candidate cluster. This pass performs no destructive
+# action, so the refreshed state and the stuck list can be persisted/emitted
+# before any deletion is attempted (a later deletion failure must not lose them).
+while read -r cluster; do
   cluster_id=$(echo "$cluster" | jq -r '.id')
   cluster_name=$(echo "$cluster" | jq -r '.name')
-  region_id=$(echo "$cluster" | jq -r '.region.id')
-  oidc_config_id=$(echo "$cluster" | jq -r '.aws.sts.oidc_config.id')
+  cluster_state=$(echo "$cluster" | jq -r '.status.state')
   creation_timestamp=$(echo "$cluster" | jq -r '.creation_timestamp')
 
   # Convert creation timestamp to UNIX time
   cluster_created_time=$($date_command -d "$creation_timestamp" +%s)
   cluster_age_hours=$(( (CURRENT_TIME - cluster_created_time) / 3600 ))
 
+  # First time this cluster was observed stuck (carried over from previous runs).
+  first_seen=$(jq -r --arg id "$cluster_id" '.[$id].first_seen // ""' "$STUCK_STATE_FILE")
+  if [[ -z "$first_seen" ]]; then
+    first_seen="$NOW_ISO"
+  fi
+  first_seen_epoch=$($date_command -d "$first_seen" +%s 2>/dev/null || echo "$CURRENT_TIME")
+  stuck_hours=$(( (CURRENT_TIME - first_seen_epoch) / 3600 ))
+
+  # Carry the (possibly newly recorded) first_seen forward into the new state.
+  new_state=$(echo "$new_state" | jq --arg id "$cluster_id" --arg name "$cluster_name" --arg ts "$first_seen" '.[$id] = {name: $name, first_seen: $ts}')
+
+  echo "----------------------------------------"
+  echo "🔍 Cluster: $cluster_name ($cluster_id) — state=$cluster_state, age=${cluster_age_hours}h, stuck_for=${stuck_hours}h"
+
+  # 1. Stuck for too long → stop retrying, flag for a dedicated alert. Do NOT fail.
+  if [ "$stuck_hours" -ge "$STUCK_DELETION_THRESHOLD_HOURS" ]; then
+    echo "🚨 Cluster $cluster_name has been stuck for ${stuck_hours}h (>= ${STUCK_DELETION_THRESHOLD_HOURS}h). Skipping deletion and flagging for a dedicated alert."
+    stuck_cluster_names+=("$cluster_name")
+    continue
+  fi
+
+  # 2. Deletion already in progress at Red Hat → let it run, re-check next time.
+  #    Re-issuing "rosa delete cluster" here would error and fail the whole cleanup.
+  if [ "$cluster_state" == "uninstalling" ]; then
+    echo "⏳ Cluster $cluster_name is already uninstalling (${stuck_hours}h < ${STUCK_DELETION_THRESHOLD_HOURS}h). Letting Red Hat finish; will re-check next run."
+    continue
+  fi
+
+  # 3. Too recent ghost cluster → skip for now (existing safety check).
   if [ "$cluster_age_hours" -lt "$MIN_AGE_HOURS" ]; then
     echo "⏳ Cluster $cluster_name is too recent (${cluster_age_hours}h < ${MIN_AGE_HOURS}h). Skipping."
     continue
   fi
 
+  # 4. Genuine ghost cluster to delete in pass 2.
+  clusters_to_delete+=("$cluster")
+done < <(echo "$raw_clusters" | jq -c '.[]')
 
+# Persist refreshed state and emit the stuck list BEFORE any destructive action.
+save_stuck_state "$new_state"
+
+stuck_joined=""
+if [ "${#stuck_cluster_names[@]}" -gt 0 ]; then
+  stuck_joined=$(printf '%s, ' "${stuck_cluster_names[@]}")
+  stuck_joined=${stuck_joined%, }
+  echo "🚨 Clusters stuck in deletion for >= ${STUCK_DELETION_THRESHOLD_HOURS}h: ${stuck_joined}"
+fi
+# Surface the stuck list to the calling GitHub Action step so the workflow can
+# raise a dedicated Slack alert without failing the cleanup.
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  echo "stuck_clusters=${stuck_joined}" >> "$GITHUB_OUTPUT"
+fi
+
+if [ "${#clusters_to_delete[@]}" -eq 0 ]; then
+  echo "✅ No ghost clusters require deletion."
+  exit 0
+fi
+
+# Pass 2: delete the genuine ghost clusters. Failures here keep the existing
+# semantics (the script exits non-zero and the cleanup is retried/alerted).
+for cluster in "${clusters_to_delete[@]}"; do
+  cluster_id=$(echo "$cluster" | jq -r '.id')
+  cluster_name=$(echo "$cluster" | jq -r '.name')
+  region_id=$(echo "$cluster" | jq -r '.region.id')
+  oidc_config_id=$(echo "$cluster" | jq -r '.aws.sts.oidc_config.id')
 
   echo "----------------------------------------"
   echo "🔧 Cluster ID: $cluster_id"
@@ -201,4 +326,4 @@ echo "$raw_clusters" | jq -c '.[]' | while read -r cluster; do
 
 done
 
-echo "✅ All clusters have been deleted!"
+echo "✅ Ghost ROSA cluster cleanup completed."

--- a/.github/workflows/aws_rosa_hcp_dual_region_daily_cleanup.yml
+++ b/.github/workflows/aws_rosa_hcp_dual_region_daily_cleanup.yml
@@ -87,6 +87,7 @@ jobs:
                   exportEnv: false
                   secrets: |
                       secret/data/products/infrastructure-experience/ci/common RH_OPENSHIFT_TOKEN;
+                      secret/data/products/infrastructure-experience/ci/common SLACK_BOT_TOKEN;
 
 
             - name: Configure AWS CLI
@@ -113,6 +114,8 @@ jobs:
                   max-age-hours: ${{ env.MAX_AGE_HOURS_CLUSTER }}
                   tf-bucket-key-prefix: ${{ env.S3_BACKEND_BUCKET_PREFIX }}${{ steps.target-branch.outputs.TARGET_BRANCH }}/
                   modules-order: backup_bucket,peering,clusters
+                  openshift: 'true'
+                  delete-ghost-rosa-clusters: 'true'
 
             # The previous step has a continue-on-error set to true in case of schedule run.
             # This means that the workflow is not marked as failed, but the step is.
@@ -138,6 +141,64 @@ jobs:
                   openshift: 'true'
                   delete-ghost-rosa-clusters: 'true'
                   modules-order: backup_bucket,peering,clusters
+
+            # Clusters that have been stuck in a deletion/error state for more than
+            # 24h are not a cleanup failure: Red Hat still owns their teardown. We
+            # surface them through a dedicated Slack alert without failing the job.
+            - name: Detect stuck ROSA clusters
+              id: stuck_clusters
+              if: always()
+              env:
+                  STUCK_LIST: ${{ steps.retry_delete_clusters.outputs.stuck-rosa-clusters || steps.delete_clusters.outputs.stuck-rosa-clusters }}
+                  RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                  MENTION: ${{ env.IS_SCHEDULE == 'true' && ' (cc @infraex-medic)' || '' }}
+              run: |
+                  set -euo pipefail
+                  if [ -z "${STUCK_LIST}" ]; then
+                    echo "found=false" | tee -a "$GITHUB_OUTPUT"
+                    exit 0
+                  fi
+                  echo "found=true" | tee -a "$GITHUB_OUTPUT"
+
+                  TEXT_PLAIN="ROSA HCP dual region: cluster(s) stuck in deletion for >24h: ${STUCK_LIST}."
+                  TEXT_PLAIN="${TEXT_PLAIN} Still owned by Red Hat, skipped to avoid failing the cleanup. This is NOT a cleanup failure."
+                  TEXT_PLAIN="${TEXT_PLAIN} See ${RUN_URL}${MENTION}"
+
+                  TEXT_BLOCK=":hourglass_flowing_sand: *ROSA HCP dual region* — cluster(s) stuck in deletion for >24h: \`${STUCK_LIST}\`."
+                  TEXT_BLOCK="${TEXT_BLOCK} Still owned by Red Hat and skipped to avoid failing the cleanup; a manual check on the Red Hat console may be required."
+                  TEXT_BLOCK="${TEXT_BLOCK} :link: <${RUN_URL}|Cleanup run>${MENTION}"
+
+                  {
+                    echo "text_plain<<EOF_TP"
+                    printf '%s\n' "$TEXT_PLAIN"
+                    echo "EOF_TP"
+                    echo "text_block<<EOF_TB"
+                    printf '%s\n' "$TEXT_BLOCK"
+                    echo "EOF_TB"
+                  } >> "$GITHUB_OUTPUT"
+
+            - name: Notify in Slack about stuck ROSA clusters
+              if: ${{ steps.stuck_clusters.outputs.found == 'true' }}
+              uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
+              with:
+                  method: chat.postMessage
+                  token: ${{ steps.secrets.outputs.SLACK_BOT_TOKEN }}
+                  payload: |
+                      {
+                        "channel": ${{ toJSON(env.IS_SCHEDULE == 'true' && 'C076N4G1162' || 'C07E4FF6YMB') }},
+                        "unfurl_links": false,
+                        "unfurl_media": false,
+                        "text": ${{ toJSON(steps.stuck_clusters.outputs.text_plain) }},
+                        "blocks": [
+                          {
+                            "type": "section",
+                            "text": {
+                              "type": "mrkdwn",
+                              "text": ${{ toJSON(steps.stuck_clusters.outputs.text_block) }}
+                            }
+                          }
+                        ]
+                      }
 
             - name: Notify in Slack in case of failure
               id: slack-notification

--- a/.github/workflows/aws_rosa_hcp_single_region_daily_cleanup.yml
+++ b/.github/workflows/aws_rosa_hcp_single_region_daily_cleanup.yml
@@ -86,6 +86,7 @@ jobs:
                   exportEnv: false
                   secrets: |
                       secret/data/products/infrastructure-experience/ci/common RH_OPENSHIFT_TOKEN;
+                      secret/data/products/infrastructure-experience/ci/common SLACK_BOT_TOKEN;
 
             - name: Configure AWS CLI
               uses: ./.github/actions/aws-configure-cli
@@ -134,6 +135,64 @@ jobs:
                   modules-order: vpn,cluster
                   openshift: 'true'
                   delete-ghost-rosa-clusters: 'true'
+
+            # Clusters that have been stuck in a deletion/error state for more than
+            # 24h are not a cleanup failure: Red Hat still owns their teardown. We
+            # surface them through a dedicated Slack alert without failing the job.
+            - name: Detect stuck ROSA clusters
+              id: stuck_clusters
+              if: always()
+              env:
+                  STUCK_LIST: ${{ steps.retry_delete_clusters.outputs.stuck-rosa-clusters || steps.delete_clusters.outputs.stuck-rosa-clusters }}
+                  RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                  MENTION: ${{ env.IS_SCHEDULE == 'true' && ' (cc @infraex-medic)' || '' }}
+              run: |
+                  set -euo pipefail
+                  if [ -z "${STUCK_LIST}" ]; then
+                    echo "found=false" | tee -a "$GITHUB_OUTPUT"
+                    exit 0
+                  fi
+                  echo "found=true" | tee -a "$GITHUB_OUTPUT"
+
+                  TEXT_PLAIN="ROSA HCP single region: cluster(s) stuck in deletion for >24h: ${STUCK_LIST}."
+                  TEXT_PLAIN="${TEXT_PLAIN} Still owned by Red Hat, skipped to avoid failing the cleanup. This is NOT a cleanup failure."
+                  TEXT_PLAIN="${TEXT_PLAIN} See ${RUN_URL}${MENTION}"
+
+                  TEXT_BLOCK=":hourglass_flowing_sand: *ROSA HCP single region* — cluster(s) stuck in deletion for >24h: \`${STUCK_LIST}\`."
+                  TEXT_BLOCK="${TEXT_BLOCK} Still owned by Red Hat and skipped to avoid failing the cleanup; a manual check on the Red Hat console may be required."
+                  TEXT_BLOCK="${TEXT_BLOCK} :link: <${RUN_URL}|Cleanup run>${MENTION}"
+
+                  {
+                    echo "text_plain<<EOF_TP"
+                    printf '%s\n' "$TEXT_PLAIN"
+                    echo "EOF_TP"
+                    echo "text_block<<EOF_TB"
+                    printf '%s\n' "$TEXT_BLOCK"
+                    echo "EOF_TB"
+                  } >> "$GITHUB_OUTPUT"
+
+            - name: Notify in Slack about stuck ROSA clusters
+              if: ${{ steps.stuck_clusters.outputs.found == 'true' }}
+              uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
+              with:
+                  method: chat.postMessage
+                  token: ${{ steps.secrets.outputs.SLACK_BOT_TOKEN }}
+                  payload: |
+                      {
+                        "channel": ${{ toJSON(env.IS_SCHEDULE == 'true' && 'C076N4G1162' || 'C07E4FF6YMB') }},
+                        "unfurl_links": false,
+                        "unfurl_media": false,
+                        "text": ${{ toJSON(steps.stuck_clusters.outputs.text_plain) }},
+                        "blocks": [
+                          {
+                            "type": "section",
+                            "text": {
+                              "type": "mrkdwn",
+                              "text": ${{ toJSON(steps.stuck_clusters.outputs.text_block) }}
+                            }
+                          }
+                        ]
+                      }
 
             - name: Notify in Slack in case of failure
               id: slack-notification


### PR DESCRIPTION
Detect ROSA HCP clusters with no node pools that are uninstalling or in error/limited-support state, and track how long each has been stuck via a first-seen-deleting map persisted in the S3 backend bucket (OCM exposes no deletion-start timestamp).

Clusters stuck for more than 24h are skipped instead of being re-deleted (which previously errored and failed the whole cleanup) and are surfaced through a new dedicated Slack alert naming the cluster(s), without triggering the global cleanup-failure notification. The alert reuses the schedule/non-schedule channel split and mentions @infraex-medic on scheduled runs only.

## TODO: 

- [ ] backport