### PR TITLE
[READY] fix(openshift-dual-region): gate Zeebe broker startup on cross-region clusterset DNS (backport 8.8)

### DIFF
--- a/.github/actions/aws-openshift-rosa-hcp-dual-region-create/action.yml
+++ b/.github/actions/aws-openshift-rosa-hcp-dual-region-create/action.yml
@@ -215,6 +215,16 @@ runs:
               echo "TFSTATE_REGION=${TFSTATE_REGION}" | tee -a "$GITHUB_OUTPUT"
               echo "TFSTATE_BASE_KEY=${TFSTATE_BASE_KEY}" | tee -a "$GITHUB_OUTPUT"
 
+              # Make `terraform init` resilient to transient registry.terraform.io
+              # failures (502 responses and client timeouts while resolving and
+              # downloading modules) that otherwise abort cluster provisioning before
+              # the tests even run. TF_REGISTRY_DISCOVERY_RETRY retries client
+              # connection errors and 500-range responses; TF_REGISTRY_CLIENT_TIMEOUT
+              # raises the per-request timeout above the 10s default. Both are inherited
+              # by every terraform command in this action.
+              echo "TF_REGISTRY_DISCOVERY_RETRY=5" >> "$GITHUB_ENV"
+              echo "TF_REGISTRY_CLIENT_TIMEOUT=20" >> "$GITHUB_ENV"
+
         - name: Check if S3 bucket exists
           id: create-s3-bucket
           shell: bash

--- a/.github/workflows/aws_openshift_rosa_hcp_dual_region_tests.yml
+++ b/.github/workflows/aws_openshift_rosa_hcp_dual_region_tests.yml
@@ -657,18 +657,12 @@ jobs:
                   ./generic/openshift/dual-region/procedure/verify-exported-services.sh
 
             - name: 👀⏳ Wait for the deployment to be healthy using generic/openshift/dual-region
-              # Cross-region Zeebe brokers stay 0/1 (Running, not Ready) until they
-              # form quorum over Submariner, which can take longer than 10 min on
-              # slow ROSA HCP runs and intermittently times out this step.
+              # Cross-region Zeebe brokers only become Ready once they resolve their
+              # peers over Submariner clusterset DNS and form quorum. The
+              # wait-clusterset-dns init container gates broker startup on that DNS
+              # (bounded to ~12 min before failing open), so allow more than the
+              # default 10 min here to cover a slow clusterset DNS propagation.
               timeout-minutes: 20
-              env:
-                  # check-deployment-ready.sh restarts brokers stuck Running-but-not-Ready
-                  # for too long (Submariner DNS race). Keep that threshold above the
-                  # legitimate >10 min cross-region quorum window so converging brokers are
-                  # not restarted prematurely; 12 min still leaves room for one restart plus
-                  # recovery within the 20 min step budget.
-                  # Removable together with the self-heal once the wait-clusterset-dns gate is validated and the upstream Camunda fix lands.
-                  STUCK_BROKER_TIMEOUT_SECONDS: '720'
               run: |
                   set -euo pipefail
 

--- a/.github/workflows/aws_openshift_rosa_hcp_dual_region_tests.yml
+++ b/.github/workflows/aws_openshift_rosa_hcp_dual_region_tests.yml
@@ -657,7 +657,10 @@ jobs:
                   ./generic/openshift/dual-region/procedure/verify-exported-services.sh
 
             - name: 👀⏳ Wait for the deployment to be healthy using generic/openshift/dual-region
-              timeout-minutes: 10
+              # Cross-region Zeebe brokers stay 0/1 (Running, not Ready) until they
+              # form quorum over Submariner, which can take longer than 10 min on
+              # slow ROSA HCP runs and intermittently times out this step.
+              timeout-minutes: 20
               run: |
                   set -euo pipefail
 

--- a/.github/workflows/aws_openshift_rosa_hcp_dual_region_tests.yml
+++ b/.github/workflows/aws_openshift_rosa_hcp_dual_region_tests.yml
@@ -682,6 +682,20 @@ jobs:
 
             # TODO: integrate c8-multi-region tests as a lego test
 
+            # INC-5340: in CI the dual-region gateway is deployed with the
+            # Vault-provisioned basic-auth user (provisioned above), never the chart
+            # default demo:demo. Fail fast here if the credentials are missing rather
+            # than running the customer-facing topology check (which defaults to
+            # demo:demo for local use) against the CI gateway.
+            - name: Ensure CI basic-auth credentials are set (INC-5340)
+              if: env.TESTS_ENABLED == 'true'
+              run: |
+                  set -euo pipefail
+                  if [ -z "${CAMUNDA_BASIC_AUTH_USER:-}" ] || [ -z "${CAMUNDA_BASIC_AUTH_PASSWORD:-}" ]; then
+                    echo "::error::CAMUNDA_BASIC_AUTH_USER/PASSWORD not set; refusing to run the dual-region topology check against a demo:demo gateway (INC-5340)." >&2
+                    exit 1
+                  fi
+
             - name: 🧪 Run Helm Chart tests
               if: env.TESTS_ENABLED == 'true'
               timeout-minutes: 60

--- a/.github/workflows/aws_openshift_rosa_hcp_dual_region_tests.yml
+++ b/.github/workflows/aws_openshift_rosa_hcp_dual_region_tests.yml
@@ -667,6 +667,7 @@ jobs:
                   # legitimate >10 min cross-region quorum window so converging brokers are
                   # not restarted prematurely; 12 min still leaves room for one restart plus
                   # recovery within the 20 min step budget.
+                  # Removable together with the self-heal once the wait-clusterset-dns gate is validated and the upstream Camunda fix lands.
                   STUCK_BROKER_TIMEOUT_SECONDS: '720'
               run: |
                   set -euo pipefail

--- a/.github/workflows/aws_openshift_rosa_hcp_dual_region_tests.yml
+++ b/.github/workflows/aws_openshift_rosa_hcp_dual_region_tests.yml
@@ -660,8 +660,11 @@ jobs:
               # Cross-region Zeebe brokers only become Ready once they resolve their
               # peers over Submariner clusterset DNS and form quorum. The
               # wait-clusterset-dns init container gates broker startup on that DNS
-              # (bounded to ~12 min before failing open), so allow more than the
-              # default 10 min here to cover a slow clusterset DNS propagation.
+              # (bounded to ~12 min total before failing open), and
+              # check-deployment-ready.sh restarts any broker left stuck
+              # Running-but-not-Ready (camunda/camunda#55038), so allow more than the
+              # default 10 min here to cover slow clusterset DNS propagation plus a
+              # self-heal restart.
               timeout-minutes: 20
               run: |
                   set -euo pipefail

--- a/.github/workflows/aws_openshift_rosa_hcp_dual_region_tests.yml
+++ b/.github/workflows/aws_openshift_rosa_hcp_dual_region_tests.yml
@@ -661,6 +661,13 @@ jobs:
               # form quorum over Submariner, which can take longer than 10 min on
               # slow ROSA HCP runs and intermittently times out this step.
               timeout-minutes: 20
+              env:
+                  # check-deployment-ready.sh restarts brokers stuck Running-but-not-Ready
+                  # for too long (Submariner DNS race). Keep that threshold above the
+                  # legitimate >10 min cross-region quorum window so converging brokers are
+                  # not restarted prematurely; 12 min still leaves room for one restart plus
+                  # recovery within the 20 min step budget.
+                  STUCK_BROKER_TIMEOUT_SECONDS: '720'
               run: |
                   set -euo pipefail
 

--- a/generic/kubernetes/dual-region/procedure/check-zeebe-cluster-topology.sh
+++ b/generic/kubernetes/dual-region/procedure/check-zeebe-cluster-topology.sh
@@ -15,7 +15,14 @@ trap cleanup EXIT
 sleep 2
 
 echo "📡 Fetching Zeebe cluster topology..."
-topology=$(curl -s -L -u "${ZEEBE_BASIC_AUTH_USER:-demo}:${ZEEBE_BASIC_AUTH_PASSWORD:-demo}" -X GET 'http://localhost:8080/v2/topology' -H 'Accept: application/json')
+# Camunda 8.8+ enforces authentication on the REST API (/v2/topology). In CI the
+# gateway is protected by a Vault-provisioned admin exported to the job
+# environment as CAMUNDA_BASIC_AUTH_USER/PASSWORD (see internal-camunda-ci-credentials),
+# so prefer those credentials; fall back to ZEEBE_BASIC_AUTH_* and finally the
+# chart demo:demo default for unprotected/local deployments.
+auth_user="${CAMUNDA_BASIC_AUTH_USER:-${ZEEBE_BASIC_AUTH_USER:-demo}}"
+auth_password="${CAMUNDA_BASIC_AUTH_PASSWORD:-${ZEEBE_BASIC_AUTH_PASSWORD:-demo}}"
+topology=$(curl -s -L -u "${auth_user}:${auth_password}" -X GET 'http://localhost:8080/v2/topology' -H 'Accept: application/json')
 echo "$topology" > zeebe-topology.json
 
 jq . zeebe-topology.json

--- a/generic/kubernetes/dual-region/procedure/check-zeebe-cluster-topology.sh
+++ b/generic/kubernetes/dual-region/procedure/check-zeebe-cluster-topology.sh
@@ -41,14 +41,17 @@ fi
 # Pass the (Vault-provisioned) credentials to curl via a 0600 config file removed on
 # exit, instead of `-u user:password`, so the password is never exposed on the curl
 # command line via ps/proc on the runner.
-curl_cfg="$(mktemp)"
+curl_cfg="$(mktemp "${TMPDIR:-/tmp}/zeebe-topology-curl.XXXXXX")"
 chmod 600 "$curl_cfg"
 # Escape backslashes first, then double-quotes, so a credential containing either
 # character does not break the quoted curl-config value.
 esc_user=${auth_user//\\/\\\\}; esc_user=${esc_user//\"/\\\"}
 esc_password=${auth_password//\\/\\\\}; esc_password=${esc_password//\"/\\\"}
 printf 'user = "%s:%s"\n' "$esc_user" "$esc_password" > "$curl_cfg"
-topology=$(curl -s --show-error --fail -L --config "$curl_cfg" -X GET 'http://localhost:8080/v2/topology' -H 'Accept: application/json')
+if ! topology=$(curl -s --show-error --fail -L --config "$curl_cfg" -X GET 'http://localhost:8080/v2/topology' -H 'Accept: application/json'); then
+  echo "❌ Failed to fetch topology from /v2/topology (HTTP error or connection failure)." >&2
+  exit 1
+fi
 echo "$topology" > zeebe-topology.json
 
 jq . zeebe-topology.json

--- a/generic/kubernetes/dual-region/procedure/check-zeebe-cluster-topology.sh
+++ b/generic/kubernetes/dual-region/procedure/check-zeebe-cluster-topology.sh
@@ -8,7 +8,6 @@ PORT_FORWARD_PID=$!
 cleanup() {
   echo "🛑 Stopping port-forward (PID: $PORT_FORWARD_PID)..."
   kill "$PORT_FORWARD_PID" 2>/dev/null || echo "⚠️ Failed to kill PID $PORT_FORWARD_PID"
-  [ -n "${curl_cfg:-}" ] && rm -f "$curl_cfg"
 }
 trap cleanup EXIT
 
@@ -16,39 +15,13 @@ trap cleanup EXIT
 sleep 2
 
 echo "📡 Fetching Zeebe cluster topology..."
-# Camunda 8.8+ enforces authentication on the REST API (/v2/topology). In CI the
-# gateway is protected by a Vault-provisioned admin exported to the job environment
-# as CAMUNDA_BASIC_AUTH_USER/PASSWORD (see internal-camunda-ci-credentials). Select a
-# COMPLETE credential pair from a single source (never mix user/password across
-# sources): prefer CAMUNDA_*, then ZEEBE_*, then the chart demo:demo default for
-# unprotected/local deployments.
-if [ -n "${CAMUNDA_BASIC_AUTH_USER:-}" ] && [ -n "${CAMUNDA_BASIC_AUTH_PASSWORD:-}" ]; then
-  auth_user="$CAMUNDA_BASIC_AUTH_USER"; auth_password="$CAMUNDA_BASIC_AUTH_PASSWORD"
-elif [ -n "${ZEEBE_BASIC_AUTH_USER:-}" ] && [ -n "${ZEEBE_BASIC_AUTH_PASSWORD:-}" ]; then
-  auth_user="$ZEEBE_BASIC_AUTH_USER"; auth_password="$ZEEBE_BASIC_AUTH_PASSWORD"
-else
-  auth_user="demo"; auth_password="demo"
-fi
+# Camunda 8.8+ enforces authentication on the REST API (/v2/topology). Provide the
+# gateway basic-auth credentials via CAMUNDA_BASIC_AUTH_USER / CAMUNDA_BASIC_AUTH_PASSWORD;
+# they default to the chart's demo:demo user for local/unprotected deployments.
+auth_user="${CAMUNDA_BASIC_AUTH_USER:-demo}"
+auth_password="${CAMUNDA_BASIC_AUTH_PASSWORD:-demo}"
 
-# Under CI a missing credential pair is a configuration error: refuse to silently
-# fall back to demo:demo, which would mask a missing Vault-provisioned secret
-# (consistent with the repo's INC-5340 hardening).
-if [ "${CI:-}" = "true" ] && [ "$auth_user" = "demo" ]; then
-  echo "ERROR: no CAMUNDA_BASIC_AUTH_* / ZEEBE_BASIC_AUTH_* credentials provided under CI; refusing to fall back to demo:demo." >&2
-  exit 1
-fi
-
-# Pass the (Vault-provisioned) credentials to curl via a 0600 config file removed on
-# exit, instead of `-u user:password`, so the password is never exposed on the curl
-# command line via ps/proc on the runner.
-curl_cfg="$(mktemp "${TMPDIR:-/tmp}/zeebe-topology-curl.XXXXXX")"
-chmod 600 "$curl_cfg"
-# Escape backslashes first, then double-quotes, so a credential containing either
-# character does not break the quoted curl-config value.
-esc_user=${auth_user//\\/\\\\}; esc_user=${esc_user//\"/\\\"}
-esc_password=${auth_password//\\/\\\\}; esc_password=${esc_password//\"/\\\"}
-printf 'user = "%s:%s"\n' "$esc_user" "$esc_password" > "$curl_cfg"
-if ! topology=$(curl -s --show-error --fail -L --config "$curl_cfg" -X GET 'http://localhost:8080/v2/topology' -H 'Accept: application/json'); then
+if ! topology=$(curl -s --show-error --fail -L -u "$auth_user:$auth_password" -X GET 'http://localhost:8080/v2/topology' -H 'Accept: application/json'); then
   echo "❌ Failed to fetch topology from /v2/topology (HTTP error or connection failure)." >&2
   exit 1
 fi

--- a/generic/kubernetes/dual-region/procedure/check-zeebe-cluster-topology.sh
+++ b/generic/kubernetes/dual-region/procedure/check-zeebe-cluster-topology.sh
@@ -8,6 +8,7 @@ PORT_FORWARD_PID=$!
 cleanup() {
   echo "🛑 Stopping port-forward (PID: $PORT_FORWARD_PID)..."
   kill "$PORT_FORWARD_PID" 2>/dev/null || echo "⚠️ Failed to kill PID $PORT_FORWARD_PID"
+  [ -n "${curl_cfg:-}" ] && rm -f "$curl_cfg"
 }
 trap cleanup EXIT
 
@@ -16,13 +17,26 @@ sleep 2
 
 echo "📡 Fetching Zeebe cluster topology..."
 # Camunda 8.8+ enforces authentication on the REST API (/v2/topology). In CI the
-# gateway is protected by a Vault-provisioned admin exported to the job
-# environment as CAMUNDA_BASIC_AUTH_USER/PASSWORD (see internal-camunda-ci-credentials),
-# so prefer those credentials; fall back to ZEEBE_BASIC_AUTH_* and finally the
-# chart demo:demo default for unprotected/local deployments.
-auth_user="${CAMUNDA_BASIC_AUTH_USER:-${ZEEBE_BASIC_AUTH_USER:-demo}}"
-auth_password="${CAMUNDA_BASIC_AUTH_PASSWORD:-${ZEEBE_BASIC_AUTH_PASSWORD:-demo}}"
-topology=$(curl -s --show-error --fail -L -u "${auth_user}:${auth_password}" -X GET 'http://localhost:8080/v2/topology' -H 'Accept: application/json')
+# gateway is protected by a Vault-provisioned admin exported to the job environment
+# as CAMUNDA_BASIC_AUTH_USER/PASSWORD (see internal-camunda-ci-credentials). Select a
+# COMPLETE credential pair from a single source (never mix user/password across
+# sources): prefer CAMUNDA_*, then ZEEBE_*, then the chart demo:demo default for
+# unprotected/local deployments.
+if [ -n "${CAMUNDA_BASIC_AUTH_USER:-}" ] && [ -n "${CAMUNDA_BASIC_AUTH_PASSWORD:-}" ]; then
+  auth_user="$CAMUNDA_BASIC_AUTH_USER"; auth_password="$CAMUNDA_BASIC_AUTH_PASSWORD"
+elif [ -n "${ZEEBE_BASIC_AUTH_USER:-}" ] && [ -n "${ZEEBE_BASIC_AUTH_PASSWORD:-}" ]; then
+  auth_user="$ZEEBE_BASIC_AUTH_USER"; auth_password="$ZEEBE_BASIC_AUTH_PASSWORD"
+else
+  auth_user="demo"; auth_password="demo"
+fi
+
+# Pass the (Vault-provisioned) credentials to curl via a 0600 config file removed on
+# exit, instead of `-u user:password`, so the password is never exposed on the curl
+# command line via ps/proc on the runner.
+curl_cfg="$(mktemp)"
+chmod 600 "$curl_cfg"
+printf 'user = "%s:%s"\n' "$auth_user" "$auth_password" > "$curl_cfg"
+topology=$(curl -s --show-error --fail -L --config "$curl_cfg" -X GET 'http://localhost:8080/v2/topology' -H 'Accept: application/json')
 echo "$topology" > zeebe-topology.json
 
 jq . zeebe-topology.json

--- a/generic/kubernetes/dual-region/procedure/check-zeebe-cluster-topology.sh
+++ b/generic/kubernetes/dual-region/procedure/check-zeebe-cluster-topology.sh
@@ -35,7 +35,11 @@ fi
 # command line via ps/proc on the runner.
 curl_cfg="$(mktemp)"
 chmod 600 "$curl_cfg"
-printf 'user = "%s:%s"\n' "$auth_user" "$auth_password" > "$curl_cfg"
+# Escape backslashes first, then double-quotes, so a credential containing either
+# character does not break the quoted curl-config value.
+esc_user=${auth_user//\\/\\\\}; esc_user=${esc_user//\"/\\\"}
+esc_password=${auth_password//\\/\\\\}; esc_password=${esc_password//\"/\\\"}
+printf 'user = "%s:%s"\n' "$esc_user" "$esc_password" > "$curl_cfg"
 topology=$(curl -s --show-error --fail -L --config "$curl_cfg" -X GET 'http://localhost:8080/v2/topology' -H 'Accept: application/json')
 echo "$topology" > zeebe-topology.json
 

--- a/generic/kubernetes/dual-region/procedure/check-zeebe-cluster-topology.sh
+++ b/generic/kubernetes/dual-region/procedure/check-zeebe-cluster-topology.sh
@@ -30,6 +30,14 @@ else
   auth_user="demo"; auth_password="demo"
 fi
 
+# Under CI a missing credential pair is a configuration error: refuse to silently
+# fall back to demo:demo, which would mask a missing Vault-provisioned secret
+# (consistent with the repo's INC-5340 hardening).
+if [ "${CI:-}" = "true" ] && [ "$auth_user" = "demo" ]; then
+  echo "ERROR: no CAMUNDA_BASIC_AUTH_* / ZEEBE_BASIC_AUTH_* credentials provided under CI; refusing to fall back to demo:demo." >&2
+  exit 1
+fi
+
 # Pass the (Vault-provisioned) credentials to curl via a 0600 config file removed on
 # exit, instead of `-u user:password`, so the password is never exposed on the curl
 # command line via ps/proc on the runner.

--- a/generic/kubernetes/dual-region/procedure/check-zeebe-cluster-topology.sh
+++ b/generic/kubernetes/dual-region/procedure/check-zeebe-cluster-topology.sh
@@ -22,7 +22,7 @@ echo "📡 Fetching Zeebe cluster topology..."
 # chart demo:demo default for unprotected/local deployments.
 auth_user="${CAMUNDA_BASIC_AUTH_USER:-${ZEEBE_BASIC_AUTH_USER:-demo}}"
 auth_password="${CAMUNDA_BASIC_AUTH_PASSWORD:-${ZEEBE_BASIC_AUTH_PASSWORD:-demo}}"
-topology=$(curl -s -L -u "${auth_user}:${auth_password}" -X GET 'http://localhost:8080/v2/topology' -H 'Accept: application/json')
+topology=$(curl -s --show-error --fail -L -u "${auth_user}:${auth_password}" -X GET 'http://localhost:8080/v2/topology' -H 'Accept: application/json')
 echo "$topology" > zeebe-topology.json
 
 jq . zeebe-topology.json

--- a/generic/openshift/dual-region/helm-values/values-base.yml
+++ b/generic/openshift/dual-region/helm-values/values-base.yml
@@ -78,6 +78,45 @@ orchestration:
           value: 500ms
         - name: ZEEBE_BROKER_GATEWAY_CLUSTER_MEMBERSHIP_PROBEINTERVAL
           value: 2s
+    # TEMPORARY WORKAROUND — remove once the upstream Camunda fix is released.
+    # A Zeebe broker resolves its initialContactPoints only once at startup; if a
+    # cross-region "*.svc.clusterset.local" name is not yet published by Submariner
+    # Lighthouse at that moment (NXDOMAIN), the broker hangs forever (pod stays
+    # 0/1 Running, port 9600 never opens) instead of re-resolving. This init
+    # container gates broker startup until every initial contact point resolves,
+    # so the broker process never sees an NXDOMAIN.
+    # It reuses the broker image (already pulled on the node) to avoid an extra
+    # image pull. The image is not hardcoded: ${DOLLAR}{BROKER_IMAGE} is resolved at
+    # deploy time by install-chart.sh from the chart being installed, so it always
+    # matches the orchestration/zeebe image without manual maintenance.
+    # Tracking issue: <Camunda issue link TBD>.
+    initContainers:
+        - name: wait-clusterset-dns
+          image: ${DOLLAR}{BROKER_IMAGE}
+          command:
+              - /bin/sh
+              - -c
+              - |
+                set -eu
+                # Fail open: if the image ships no resolver, do not block startup.
+                command -v getent >/dev/null 2>&1 || { echo "getent unavailable; skipping cross-region DNS gate."; exit 0; }
+                # Bounded wait (~12 min) so a genuine misconfiguration cannot deadlock the broker.
+                max=144
+                echo "Waiting for cross-region clusterset DNS to resolve all Zeebe contact points..."
+                for ep in ${DOLLAR}(echo "${ZEEBE_BROKER_CLUSTER_INITIALCONTACTPOINTS}" | tr ',' ' '); do
+                  host=${DOLLAR}(echo "${DOLLAR}ep" | cut -d: -f1)
+                  i=0
+                  until getent hosts "${DOLLAR}host" >/dev/null 2>&1; do
+                    i=${DOLLAR}((i + 1))
+                    if [ "${DOLLAR}i" -ge "${DOLLAR}max" ]; then
+                      echo "  giving up on ${DOLLAR}host after ${DOLLAR}((max * 5))s; starting broker anyway (fail-open)."
+                      break
+                    fi
+                    echo "  waiting for ${DOLLAR}host ..."
+                    sleep 5
+                  done
+                done
+                echo "Cross-region DNS gate complete; starting broker."
     pvcSize: 32Gi
     logLevel: ERROR
 

--- a/generic/openshift/dual-region/helm-values/values-base.yml
+++ b/generic/openshift/dual-region/helm-values/values-base.yml
@@ -89,7 +89,7 @@ orchestration:
     # image pull. The image is not hardcoded: ${DOLLAR}{BROKER_IMAGE} is resolved at
     # deploy time by install-chart.sh from the chart being installed, so it always
     # matches the orchestration/zeebe image without manual maintenance.
-    # Tracking issue: <Camunda issue link TBD>.
+    # Tracking issue: https://github.com/camunda/camunda/issues/55038
     initContainers:
         - name: wait-clusterset-dns
           image: ${DOLLAR}{BROKER_IMAGE}

--- a/generic/openshift/dual-region/helm-values/values-base.yml
+++ b/generic/openshift/dual-region/helm-values/values-base.yml
@@ -100,16 +100,16 @@ orchestration:
                 set -eu
                 # Fail open: if the image ships no resolver, do not block startup.
                 command -v getent >/dev/null 2>&1 || { echo "getent unavailable; skipping cross-region DNS gate."; exit 0; }
-                # Bounded wait (~12 min) so a genuine misconfiguration cannot deadlock the broker.
-                max=144
+                # Bounded TOTAL wait (~12 min) across all contact points, independent
+                # of how many there are, so a genuine misconfiguration can never stall
+                # startup past the deployment timeout (fail-open).
+                deadline=${DOLLAR}(( ${DOLLAR}(date +%s) + ${DOLLAR}{CLUSTERSET_DNS_TIMEOUT_SECONDS:-720} ))
                 echo "Waiting for cross-region clusterset DNS to resolve all Zeebe contact points..."
                 for ep in ${DOLLAR}(echo "${ZEEBE_BROKER_CLUSTER_INITIALCONTACTPOINTS}" | tr ',' ' '); do
                   host=${DOLLAR}(echo "${DOLLAR}ep" | cut -d: -f1)
-                  i=0
                   until getent hosts "${DOLLAR}host" >/dev/null 2>&1; do
-                    i=${DOLLAR}((i + 1))
-                    if [ "${DOLLAR}i" -ge "${DOLLAR}max" ]; then
-                      echo "  giving up on ${DOLLAR}host after ${DOLLAR}((max * 5))s; starting broker anyway (fail-open)."
+                    if [ "${DOLLAR}(date +%s)" -ge "${DOLLAR}deadline" ]; then
+                      echo "  giving up on ${DOLLAR}host (global ~12 min DNS budget exhausted); starting broker anyway (fail-open)."
                       break
                     fi
                     echo "  waiting for ${DOLLAR}host ..."

--- a/generic/openshift/dual-region/procedure/check-deployment-ready.sh
+++ b/generic/openshift/dual-region/procedure/check-deployment-ready.sh
@@ -1,29 +1,95 @@
 #!/bin/bash
 
+set -euo pipefail
+
+# Wait until the dual-region Camunda deployment is healthy on both clusters.
+#
+# Self-healing rationale:
+#   Cross-region Zeebe brokers resolve their peers over Submariner Lighthouse
+#   DNS (*.svc.clusterset.local). If a broker starts before that DNS is fully
+#   propagated it can hit NXDOMAIN and hang permanently during
+#   `Broker.internalStart` (the management port 9600 never opens, the pod stays
+#   "0/1 Running" forever). A longer timeout does not help because the JVM never
+#   recovers on its own. Deleting the stuck pod lets the StatefulSet recreate it
+#   and it becomes ready within ~1-2 min once clusterset DNS resolves.
+#
+#   Therefore any Zeebe broker pod that has been Running but not ready for longer
+#   than STUCK_BROKER_TIMEOUT_SECONDS is treated as hung and restarted, bounded
+#   by MAX_BROKER_RESTARTS attempts per pod.
+
+# How long a broker may stay "Running but not ready" before we consider it hung.
+STUCK_BROKER_TIMEOUT_SECONDS="${STUCK_BROKER_TIMEOUT_SECONDS:-360}"
+# Maximum number of automatic restarts per broker pod.
+MAX_BROKER_RESTARTS="${MAX_BROKER_RESTARTS:-3}"
+
+# Tracks how many times each "context/pod" has been auto-restarted.
+declare -A BROKER_RESTARTS
+
+# Returns success when every pod in the namespace is Running and ready.
+namespace_ready() {
+  local context="$1" namespace="$2"
+  [ "$(kubectl --context="$context" get pods -n "$namespace" --field-selector=status.phase!=Running -o name | wc -l)" -eq 0 ] &&
+    [ "$(kubectl --context="$context" get pods -n "$namespace" -o json | jq -r '.items[] | select(.status.containerStatuses[]?.ready == false)' | wc -l)" -eq 0 ]
+}
+
+# Restarts Zeebe broker pods that have been Running but not ready for too long.
+restart_stuck_brokers() {
+  local context="$1" namespace="$2"
+  local now pod started age count
+  now="$(date -u +%s)"
+
+  while read -r pod started; do
+    [ -z "$pod" ] && continue
+    age=$(( now - $(date -u -d "$started" +%s) ))
+
+    if [ "$age" -lt "$STUCK_BROKER_TIMEOUT_SECONDS" ]; then
+      echo "  ↳ $pod is not ready yet (${age}s < ${STUCK_BROKER_TIMEOUT_SECONDS}s), still within startup grace period";
+      continue;
+    fi
+
+    count="${BROKER_RESTARTS[$context/$pod]:-0}"
+    if [ "$count" -ge "$MAX_BROKER_RESTARTS" ]; then
+      echo "  ↳ $pod still not ready after ${age}s and ${count} restart(s); giving up on auto-recovery";
+      continue;
+    fi
+
+    echo "  ⚠️  $pod has been Running but not ready for ${age}s (likely a hung startup over Submariner DNS); restarting it (attempt $((count + 1))/${MAX_BROKER_RESTARTS})";
+    kubectl --context="$context" delete pod "$pod" -n "$namespace" --wait=false || true;
+    BROKER_RESTARTS["$context/$pod"]=$(( count + 1 ));
+  done < <(
+    kubectl --context="$context" get pods -n "$namespace" -o json |
+      jq -r '
+        .items[]
+        | select(.metadata.name | test("^camunda-zeebe-[0-9]+$"))
+        | select(any(.status.containerStatuses[]?; .ready == false))
+        | select(any(.status.containerStatuses[]?; .state.running.startedAt != null))
+        | "\(.metadata.name) \([.status.containerStatuses[] | select(.state.running != null) | .state.running.startedAt] | min)"
+      '
+  )
+}
+
 while true; do
   echo "Checking pods in context: $CLUSTER_1_NAME, namespace: $CAMUNDA_NAMESPACE_1";
   kubectl --context="$CLUSTER_1_NAME" get pods -n "$CAMUNDA_NAMESPACE_1" --output=wide;
-  if [ "$(kubectl --context="$CLUSTER_1_NAME" get pods -n "$CAMUNDA_NAMESPACE_1" --field-selector=status.phase!=Running -o name | wc -l)" -eq 0 ] &&
-     [ "$(kubectl --context="$CLUSTER_1_NAME" get pods -n "$CAMUNDA_NAMESPACE_1" -o json | jq -r '.items[] | select(.status.containerStatuses[]?.ready == false)' | wc -l)" -eq 0 ];
-  then
+  if namespace_ready "$CLUSTER_1_NAME" "$CAMUNDA_NAMESPACE_1"; then
     echo "All pods are Running and Healthy in context: $CLUSTER_1_NAME, namespace: $CAMUNDA_NAMESPACE_1 - Installation completed!";
   else
     echo "Some pods are not Running or Healthy in context: $CLUSTER_1_NAME, namespace: $CAMUNDA_NAMESPACE_1";
+    restart_stuck_brokers "$CLUSTER_1_NAME" "$CAMUNDA_NAMESPACE_1";
     sleep 5;
     continue;
   fi
 
   echo "Checking pods in context: $CLUSTER_2_NAME, namespace: $CAMUNDA_NAMESPACE_2";
   kubectl --context="$CLUSTER_2_NAME" get pods -n "$CAMUNDA_NAMESPACE_2" --output=wide;
-  if [ "$(kubectl --context="$CLUSTER_2_NAME" get pods -n "$CAMUNDA_NAMESPACE_2" --field-selector=status.phase!=Running -o name | wc -l)" -eq 0 ] &&
-     [ "$(kubectl --context="$CLUSTER_2_NAME" get pods -n "$CAMUNDA_NAMESPACE_2" -o json | jq -r '.items[] | select(.status.containerStatuses[]?.ready == false)' | wc -l)" -eq 0 ];
-  then
+  if namespace_ready "$CLUSTER_2_NAME" "$CAMUNDA_NAMESPACE_2"; then
     echo "OK: All pods are Running and Healthy in context: $CLUSTER_2_NAME, namespace: $CAMUNDA_NAMESPACE_2 - Installation completed!";
     echo "OK: All pods are healthy across both contexts.";
     echo "Installation completed.";
     exit 0;
   else
     echo "Some pods are not Running or Healthy in context: $CLUSTER_2_NAME, namespace: $CAMUNDA_NAMESPACE_2";
+    restart_stuck_brokers "$CLUSTER_2_NAME" "$CAMUNDA_NAMESPACE_2";
   fi
 
   sleep 5;

--- a/generic/openshift/dual-region/procedure/check-deployment-ready.sh
+++ b/generic/openshift/dual-region/procedure/check-deployment-ready.sh
@@ -1,29 +1,98 @@
 #!/bin/bash
 
+set -euo pipefail
+
+# Wait until the dual-region Camunda deployment is healthy on both clusters.
+#
+# Self-healing rationale:
+#   Cross-region Zeebe brokers resolve their peers over Submariner Lighthouse
+#   DNS (*.svc.clusterset.local). If a broker starts before that DNS is fully
+#   propagated it can hit NXDOMAIN and hang permanently during
+#   `Broker.internalStart` (the management port 9600 never opens, the pod stays
+#   "0/1 Running" forever). A longer timeout does not help because the JVM never
+#   recovers on its own. Deleting the stuck pod lets the StatefulSet recreate it
+#   and it becomes ready within ~1-2 min once clusterset DNS resolves.
+#
+#   Therefore any Zeebe broker pod that has been Running but not ready for longer
+#   than STUCK_BROKER_TIMEOUT_SECONDS is treated as hung and restarted, bounded
+#   by MAX_BROKER_RESTARTS attempts per pod.
+
+# How long a broker may stay "Running but not ready" before we consider it hung.
+STUCK_BROKER_TIMEOUT_SECONDS="${STUCK_BROKER_TIMEOUT_SECONDS:-360}"
+# Maximum number of automatic restarts per broker pod.
+MAX_BROKER_RESTARTS="${MAX_BROKER_RESTARTS:-3}"
+
+# Tracks how many times each "context/pod" has been auto-restarted.
+declare -A BROKER_RESTARTS
+
+# Returns success when every pod in the namespace is Running and ready.
+namespace_ready() {
+  local context="$1" namespace="$2"
+  [ "$(kubectl --context="$context" get pods -n "$namespace" --field-selector=status.phase!=Running -o name | wc -l)" -eq 0 ] &&
+    [ "$(kubectl --context="$context" get pods -n "$namespace" -o json | jq -r '.items[] | select(.status.containerStatuses[]?.ready == false)' | wc -l)" -eq 0 ]
+}
+
+# Restarts Zeebe broker pods that have been Running but not ready for too long.
+restart_stuck_brokers() {
+  local context="$1" namespace="$2"
+  # Match broker pods for the configured Helm release (defaults to "camunda"),
+  # so the self-heal keeps working when CAMUNDA_RELEASE_NAME is customised.
+  local release="${CAMUNDA_RELEASE_NAME:-camunda}"
+  local now pod started age count
+  now="$(date -u +%s)"
+
+  while read -r pod started; do
+    [ -z "$pod" ] && continue
+    age=$(( now - $(date -u -d "$started" +%s) ))
+
+    if [ "$age" -lt "$STUCK_BROKER_TIMEOUT_SECONDS" ]; then
+      echo "  ↳ $pod is not ready yet (${age}s < ${STUCK_BROKER_TIMEOUT_SECONDS}s), still within startup grace period";
+      continue;
+    fi
+
+    count="${BROKER_RESTARTS[$context/$pod]:-0}"
+    if [ "$count" -ge "$MAX_BROKER_RESTARTS" ]; then
+      echo "  ↳ $pod still not ready after ${age}s and ${count} restart(s); giving up on auto-recovery";
+      continue;
+    fi
+
+    echo "  ⚠️  $pod has been Running but not ready for ${age}s (likely a hung startup over Submariner DNS); restarting it (attempt $((count + 1))/${MAX_BROKER_RESTARTS})";
+    kubectl --context="$context" delete pod "$pod" -n "$namespace" --wait=false || true;
+    BROKER_RESTARTS["$context/$pod"]=$(( count + 1 ));
+  done < <(
+    kubectl --context="$context" get pods -n "$namespace" -o json |
+      jq -r --arg re "^${release}-zeebe-[0-9]+$" '
+        .items[]
+        | select(.metadata.name | test($re))
+        | select(any(.status.containerStatuses[]?; .ready == false))
+        | select(any(.status.containerStatuses[]?; .state.running.startedAt != null))
+        | "\(.metadata.name) \([.status.containerStatuses[] | select(.state.running != null) | .state.running.startedAt] | min)"
+      '
+  )
+}
+
 while true; do
   echo "Checking pods in context: $CLUSTER_1_NAME, namespace: $CAMUNDA_NAMESPACE_1";
   kubectl --context="$CLUSTER_1_NAME" get pods -n "$CAMUNDA_NAMESPACE_1" --output=wide;
-  if [ "$(kubectl --context="$CLUSTER_1_NAME" get pods -n "$CAMUNDA_NAMESPACE_1" --field-selector=status.phase!=Running -o name | wc -l)" -eq 0 ] &&
-     [ "$(kubectl --context="$CLUSTER_1_NAME" get pods -n "$CAMUNDA_NAMESPACE_1" -o json | jq -r '.items[] | select(.status.containerStatuses[]?.ready == false)' | wc -l)" -eq 0 ];
-  then
+  if namespace_ready "$CLUSTER_1_NAME" "$CAMUNDA_NAMESPACE_1"; then
     echo "All pods are Running and Healthy in context: $CLUSTER_1_NAME, namespace: $CAMUNDA_NAMESPACE_1 - Installation completed!";
   else
     echo "Some pods are not Running or Healthy in context: $CLUSTER_1_NAME, namespace: $CAMUNDA_NAMESPACE_1";
+    restart_stuck_brokers "$CLUSTER_1_NAME" "$CAMUNDA_NAMESPACE_1";
     sleep 5;
     continue;
   fi
 
   echo "Checking pods in context: $CLUSTER_2_NAME, namespace: $CAMUNDA_NAMESPACE_2";
   kubectl --context="$CLUSTER_2_NAME" get pods -n "$CAMUNDA_NAMESPACE_2" --output=wide;
-  if [ "$(kubectl --context="$CLUSTER_2_NAME" get pods -n "$CAMUNDA_NAMESPACE_2" --field-selector=status.phase!=Running -o name | wc -l)" -eq 0 ] &&
-     [ "$(kubectl --context="$CLUSTER_2_NAME" get pods -n "$CAMUNDA_NAMESPACE_2" -o json | jq -r '.items[] | select(.status.containerStatuses[]?.ready == false)' | wc -l)" -eq 0 ];
-  then
+  if namespace_ready "$CLUSTER_2_NAME" "$CAMUNDA_NAMESPACE_2"; then
     echo "OK: All pods are Running and Healthy in context: $CLUSTER_2_NAME, namespace: $CAMUNDA_NAMESPACE_2 - Installation completed!";
     echo "OK: All pods are healthy across both contexts.";
     echo "Installation completed.";
     exit 0;
   else
     echo "Some pods are not Running or Healthy in context: $CLUSTER_2_NAME, namespace: $CAMUNDA_NAMESPACE_2";
+    restart_stuck_brokers "$CLUSTER_2_NAME" "$CAMUNDA_NAMESPACE_2";
   fi
 
   sleep 5;

--- a/generic/openshift/dual-region/procedure/check-deployment-ready.sh
+++ b/generic/openshift/dual-region/procedure/check-deployment-ready.sh
@@ -31,6 +31,16 @@ STUCK_BROKER_TIMEOUT_SECONDS="${STUCK_BROKER_TIMEOUT_SECONDS:-360}"
 # Maximum number of automatic restarts per broker pod.
 MAX_BROKER_RESTARTS="${MAX_BROKER_RESTARTS:-3}"
 
+# Both knobs are consumed in integer comparisons (-lt / -ge) below, so reject a
+# non-integer override up-front with a clear message instead of a cryptic
+# "integer expression expected" failure mid-run.
+case "$STUCK_BROKER_TIMEOUT_SECONDS" in ''|*[!0-9]*)
+  echo "ERROR: STUCK_BROKER_TIMEOUT_SECONDS must be a non-negative integer (got '$STUCK_BROKER_TIMEOUT_SECONDS')." >&2; exit 1;;
+esac
+case "$MAX_BROKER_RESTARTS" in ''|*[!0-9]*)
+  echo "ERROR: MAX_BROKER_RESTARTS must be a non-negative integer (got '$MAX_BROKER_RESTARTS')." >&2; exit 1;;
+esac
+
 # Tracks how many times each "context/pod" has been auto-restarted.
 declare -A BROKER_RESTARTS
 

--- a/generic/openshift/dual-region/procedure/check-deployment-ready.sh
+++ b/generic/openshift/dual-region/procedure/check-deployment-ready.sh
@@ -30,15 +30,20 @@ fi
 STUCK_BROKER_TIMEOUT_SECONDS="${STUCK_BROKER_TIMEOUT_SECONDS:-360}"
 # Maximum number of automatic restarts per broker pod.
 MAX_BROKER_RESTARTS="${MAX_BROKER_RESTARTS:-3}"
+# How long the cluster must stay healthy before handing off to the test phase.
+STABILITY_SETTLE_SECONDS="${STABILITY_SETTLE_SECONDS:-30}"
 
-# Both knobs are consumed in integer comparisons (-lt / -ge) below, so reject a
-# non-integer override up-front with a clear message instead of a cryptic
-# "integer expression expected" failure mid-run.
+# These knobs are consumed in integer comparisons (-lt / -ge) and as a `sleep`
+# duration below, so reject a non-integer override up-front with a clear message
+# instead of a cryptic "integer expression expected" / sleep failure mid-run.
 case "$STUCK_BROKER_TIMEOUT_SECONDS" in ''|*[!0-9]*)
   echo "ERROR: STUCK_BROKER_TIMEOUT_SECONDS must be a non-negative integer (got '$STUCK_BROKER_TIMEOUT_SECONDS')." >&2; exit 1;;
 esac
 case "$MAX_BROKER_RESTARTS" in ''|*[!0-9]*)
   echo "ERROR: MAX_BROKER_RESTARTS must be a non-negative integer (got '$MAX_BROKER_RESTARTS')." >&2; exit 1;;
+esac
+case "$STABILITY_SETTLE_SECONDS" in ''|*[!0-9]*)
+  echo "ERROR: STABILITY_SETTLE_SECONDS must be a non-negative integer (got '$STABILITY_SETTLE_SECONDS')." >&2; exit 1;;
 esac
 
 # Tracks how many times each "context/pod" has been auto-restarted.
@@ -94,9 +99,15 @@ restart_stuck_brokers() {
       jq -r --arg re "^${release}-zeebe-[0-9]+$" '
         .items[]
         | select(.metadata.name | test($re))
+        | select(.status.phase == "Running")
         | select(any(.status.containerStatuses[]?; .ready == false))
-        | select(any(.status.containerStatuses[]?; .state.running.startedAt != null))
-        | "\(.metadata.name) \([.status.containerStatuses[] | select(.state.running != null) | (.state.running.startedAt | sub("\\.[0-9]+Z$"; "Z") | fromdateiso8601)] | min)"
+        # Measure how long the pod has been NOT READY from the Ready condition'"'"'s
+        # lastTransitionTime (when it most recently went not-ready), not the container
+        # start time -- otherwise a long-running broker that only just flapped to
+        # not-ready would look old enough to restart immediately.
+        | ([.status.conditions[]? | select(.type == "Ready") | .lastTransitionTime] | first) as $notready
+        | select($notready != null)
+        | "\(.metadata.name) \($notready | sub("\\.[0-9]+Z$"; "Z") | fromdateiso8601)"
       '
   )
 }
@@ -123,7 +134,7 @@ while true; do
     # (camunda/camunda#55038) shortly after first becoming Ready. Require the cluster
     # to stay healthy across a short settle window so the multi-region tests start
     # against a stable topology; if it flaps, self-heal and keep polling.
-    settle="${STABILITY_SETTLE_SECONDS:-30}";
+    settle="$STABILITY_SETTLE_SECONDS";
     echo "Confirming stability over ${settle}s before completing...";
     sleep "$settle";
     if namespace_ready "$CLUSTER_1_NAME" "$CAMUNDA_NAMESPACE_1" && namespace_ready "$CLUSTER_2_NAME" "$CAMUNDA_NAMESPACE_2"; then

--- a/generic/openshift/dual-region/procedure/check-deployment-ready.sh
+++ b/generic/openshift/dual-region/procedure/check-deployment-ready.sh
@@ -11,6 +11,14 @@ if (( BASH_VERSINFO[0] < 4 )); then
   exit 1
 fi
 
+# restart_stuck_brokers relies on jq's fromdateiso8601 builtin (jq >= 1.6). Fail fast
+# with a clear message on an older jq instead of a cryptic "fromdateiso8601/0 is not
+# defined" mid-run.
+if ! jq -n '"1970-01-01T00:00:00Z" | fromdateiso8601' >/dev/null 2>&1; then
+  echo "ERROR: ${BASH_SOURCE[0]##*/} requires jq >= 1.6 (fromdateiso8601); found $(jq --version 2>&1 || echo 'jq not installed')." >&2
+  exit 1
+fi
+
 # Wait until the dual-region Camunda deployment is healthy on both clusters.
 #
 # Self-healing rationale:

--- a/generic/openshift/dual-region/procedure/check-deployment-ready.sh
+++ b/generic/openshift/dual-region/procedure/check-deployment-ready.sh
@@ -88,8 +88,21 @@ while true; do
   if namespace_ready "$CLUSTER_2_NAME" "$CAMUNDA_NAMESPACE_2"; then
     echo "OK: All pods are Running and Healthy in context: $CLUSTER_2_NAME, namespace: $CAMUNDA_NAMESPACE_2 - Installation completed!";
     echo "OK: All pods are healthy across both contexts.";
-    echo "Installation completed.";
-    exit 0;
+    # Confirm stability before handing off to the test phase: a broker can flap back
+    # to Running-but-not-Ready on a transient clusterset-DNS NXDOMAIN
+    # (camunda/camunda#55038) shortly after first becoming Ready. Require the cluster
+    # to stay healthy across a short settle window so the multi-region tests start
+    # against a stable topology; if it flaps, self-heal and keep polling.
+    settle="${STABILITY_SETTLE_SECONDS:-30}";
+    echo "Confirming stability over ${settle}s before completing...";
+    sleep "$settle";
+    if namespace_ready "$CLUSTER_1_NAME" "$CAMUNDA_NAMESPACE_1" && namespace_ready "$CLUSTER_2_NAME" "$CAMUNDA_NAMESPACE_2"; then
+      echo "Still healthy after the settle window. Installation completed.";
+      exit 0;
+    fi
+    echo "A broker flapped during the settle window; self-healing and re-checking.";
+    restart_stuck_brokers "$CLUSTER_1_NAME" "$CAMUNDA_NAMESPACE_1";
+    restart_stuck_brokers "$CLUSTER_2_NAME" "$CAMUNDA_NAMESPACE_2";
   else
     echo "Some pods are not Running or Healthy in context: $CLUSTER_2_NAME, namespace: $CAMUNDA_NAMESPACE_2";
     restart_stuck_brokers "$CLUSTER_2_NAME" "$CAMUNDA_NAMESPACE_2";

--- a/generic/openshift/dual-region/procedure/check-deployment-ready.sh
+++ b/generic/openshift/dual-region/procedure/check-deployment-ready.sh
@@ -1,108 +1,29 @@
 #!/bin/bash
 
-set -euo pipefail
-
-# Wait until the dual-region Camunda deployment is healthy on both clusters.
-#
-# Self-healing rationale:
-#   Cross-region Zeebe brokers resolve their peers over Submariner Lighthouse
-#   DNS (*.svc.clusterset.local). If a broker starts before that DNS is fully
-#   propagated it can hit NXDOMAIN and hang permanently during
-#   `Broker.internalStart` (the management port 9600 never opens, the pod stays
-#   "0/1 Running" forever). A longer timeout does not help because the JVM never
-#   recovers on its own. Deleting the stuck pod lets the StatefulSet recreate it
-#   and it becomes ready within ~1-2 min once clusterset DNS resolves.
-#
-#   Therefore any Zeebe broker pod that has been Running but not ready for longer
-#   than STUCK_BROKER_TIMEOUT_SECONDS is treated as hung and restarted, bounded
-#   by MAX_BROKER_RESTARTS attempts per pod.
-
-# TEMPORARY (defence-in-depth) — REMOVE once the cross-region DNS race is fixed.
-#   The primary fix is the wait-clusterset-dns initContainer (see
-#   helm-values/values-base.yml), which prevents the broker from ever observing
-#   the NXDOMAIN in the first place. This self-heal stays only as a backstop for
-#   the gate's fail-open paths (no resolver in image / gate gives up).
-#   Once the gate is validated in CI and the upstream Camunda fix lands (broker
-#   re-resolves its contact points on its own), this whole self-heal block
-#   (restart_stuck_brokers + STUCK_BROKER_TIMEOUT_SECONDS + MAX_BROKER_RESTARTS)
-#   can be deleted. Tracking issue: <Camunda issue link TBD>.
-
-# How long a broker may stay "Running but not ready" before we consider it hung.
-STUCK_BROKER_TIMEOUT_SECONDS="${STUCK_BROKER_TIMEOUT_SECONDS:-360}"
-# Maximum number of automatic restarts per broker pod.
-MAX_BROKER_RESTARTS="${MAX_BROKER_RESTARTS:-3}"
-
-# Tracks how many times each "context/pod" has been auto-restarted.
-declare -A BROKER_RESTARTS
-
-# Returns success when every pod in the namespace is Running and ready.
-namespace_ready() {
-  local context="$1" namespace="$2"
-  [ "$(kubectl --context="$context" get pods -n "$namespace" --field-selector=status.phase!=Running -o name | wc -l)" -eq 0 ] &&
-    [ "$(kubectl --context="$context" get pods -n "$namespace" -o json | jq -r '.items[] | select(.status.containerStatuses[]?.ready == false)' | wc -l)" -eq 0 ]
-}
-
-# Restarts Zeebe broker pods that have been Running but not ready for too long.
-restart_stuck_brokers() {
-  local context="$1" namespace="$2"
-  # Match broker pods for the configured Helm release (defaults to "camunda"),
-  # so the self-heal keeps working when CAMUNDA_RELEASE_NAME is customised.
-  local release="${CAMUNDA_RELEASE_NAME:-camunda}"
-  local now pod started age count
-  now="$(date -u +%s)"
-
-  while read -r pod started; do
-    [ -z "$pod" ] && continue
-    age=$(( now - $(date -u -d "$started" +%s) ))
-
-    if [ "$age" -lt "$STUCK_BROKER_TIMEOUT_SECONDS" ]; then
-      echo "  ↳ $pod is not ready yet (${age}s < ${STUCK_BROKER_TIMEOUT_SECONDS}s), still within startup grace period";
-      continue;
-    fi
-
-    count="${BROKER_RESTARTS[$context/$pod]:-0}"
-    if [ "$count" -ge "$MAX_BROKER_RESTARTS" ]; then
-      echo "  ↳ $pod still not ready after ${age}s and ${count} restart(s); giving up on auto-recovery";
-      continue;
-    fi
-
-    echo "  ⚠️  $pod has been Running but not ready for ${age}s (likely a hung startup over Submariner DNS); restarting it (attempt $((count + 1))/${MAX_BROKER_RESTARTS})";
-    kubectl --context="$context" delete pod "$pod" -n "$namespace" --wait=false || true;
-    BROKER_RESTARTS["$context/$pod"]=$(( count + 1 ));
-  done < <(
-    kubectl --context="$context" get pods -n "$namespace" -o json |
-      jq -r --arg re "^${release}-zeebe-[0-9]+$" '
-        .items[]
-        | select(.metadata.name | test($re))
-        | select(any(.status.containerStatuses[]?; .ready == false))
-        | select(any(.status.containerStatuses[]?; .state.running.startedAt != null))
-        | "\(.metadata.name) \([.status.containerStatuses[] | select(.state.running != null) | .state.running.startedAt] | min)"
-      '
-  )
-}
-
 while true; do
   echo "Checking pods in context: $CLUSTER_1_NAME, namespace: $CAMUNDA_NAMESPACE_1";
   kubectl --context="$CLUSTER_1_NAME" get pods -n "$CAMUNDA_NAMESPACE_1" --output=wide;
-  if namespace_ready "$CLUSTER_1_NAME" "$CAMUNDA_NAMESPACE_1"; then
+  if [ "$(kubectl --context="$CLUSTER_1_NAME" get pods -n "$CAMUNDA_NAMESPACE_1" --field-selector=status.phase!=Running -o name | wc -l)" -eq 0 ] &&
+     [ "$(kubectl --context="$CLUSTER_1_NAME" get pods -n "$CAMUNDA_NAMESPACE_1" -o json | jq -r '.items[] | select(.status.containerStatuses[]?.ready == false)' | wc -l)" -eq 0 ];
+  then
     echo "All pods are Running and Healthy in context: $CLUSTER_1_NAME, namespace: $CAMUNDA_NAMESPACE_1 - Installation completed!";
   else
     echo "Some pods are not Running or Healthy in context: $CLUSTER_1_NAME, namespace: $CAMUNDA_NAMESPACE_1";
-    restart_stuck_brokers "$CLUSTER_1_NAME" "$CAMUNDA_NAMESPACE_1";
     sleep 5;
     continue;
   fi
 
   echo "Checking pods in context: $CLUSTER_2_NAME, namespace: $CAMUNDA_NAMESPACE_2";
   kubectl --context="$CLUSTER_2_NAME" get pods -n "$CAMUNDA_NAMESPACE_2" --output=wide;
-  if namespace_ready "$CLUSTER_2_NAME" "$CAMUNDA_NAMESPACE_2"; then
+  if [ "$(kubectl --context="$CLUSTER_2_NAME" get pods -n "$CAMUNDA_NAMESPACE_2" --field-selector=status.phase!=Running -o name | wc -l)" -eq 0 ] &&
+     [ "$(kubectl --context="$CLUSTER_2_NAME" get pods -n "$CAMUNDA_NAMESPACE_2" -o json | jq -r '.items[] | select(.status.containerStatuses[]?.ready == false)' | wc -l)" -eq 0 ];
+  then
     echo "OK: All pods are Running and Healthy in context: $CLUSTER_2_NAME, namespace: $CAMUNDA_NAMESPACE_2 - Installation completed!";
     echo "OK: All pods are healthy across both contexts.";
     echo "Installation completed.";
     exit 0;
   else
     echo "Some pods are not Running or Healthy in context: $CLUSTER_2_NAME, namespace: $CAMUNDA_NAMESPACE_2";
-    restart_stuck_brokers "$CLUSTER_2_NAME" "$CAMUNDA_NAMESPACE_2";
   fi
 
   sleep 5;

--- a/generic/openshift/dual-region/procedure/check-deployment-ready.sh
+++ b/generic/openshift/dual-region/procedure/check-deployment-ready.sh
@@ -57,7 +57,7 @@ namespace_ready() {
   # Helm install failed early or targeted an unexpected namespace/context.
   [ "$(kubectl --context="$context" get pods -n "$namespace" -o name | wc -l)" -gt 0 ] &&
     [ "$(kubectl --context="$context" get pods -n "$namespace" --field-selector=status.phase!=Running -o name | wc -l)" -eq 0 ] &&
-    [ "$(kubectl --context="$context" get pods -n "$namespace" -o json | jq -r '.items[] | select(.status.containerStatuses[]?.ready == false)' | wc -l)" -eq 0 ]
+    [ "$(kubectl --context="$context" get pods -n "$namespace" -o json | jq -r '[.items[] | select(any(.status.containerStatuses[]?; .ready == false))] | length')" -eq 0 ]
 }
 
 # Restarts Zeebe broker pods that have been Running but not ready for too long.

--- a/generic/openshift/dual-region/procedure/check-deployment-ready.sh
+++ b/generic/openshift/dual-region/procedure/check-deployment-ready.sh
@@ -114,7 +114,7 @@ restart_stuck_brokers() {
 
 while true; do
   echo "Checking pods in context: $CLUSTER_1_NAME, namespace: $CAMUNDA_NAMESPACE_1";
-  kubectl --context="$CLUSTER_1_NAME" get pods -n "$CAMUNDA_NAMESPACE_1" --output=wide;
+  kubectl --context="$CLUSTER_1_NAME" get pods -n "$CAMUNDA_NAMESPACE_1" --output=wide || true;
   if namespace_ready "$CLUSTER_1_NAME" "$CAMUNDA_NAMESPACE_1"; then
     echo "All pods are Running and Healthy in context: $CLUSTER_1_NAME, namespace: $CAMUNDA_NAMESPACE_1 - Installation completed!";
   else
@@ -125,7 +125,7 @@ while true; do
   fi
 
   echo "Checking pods in context: $CLUSTER_2_NAME, namespace: $CAMUNDA_NAMESPACE_2";
-  kubectl --context="$CLUSTER_2_NAME" get pods -n "$CAMUNDA_NAMESPACE_2" --output=wide;
+  kubectl --context="$CLUSTER_2_NAME" get pods -n "$CAMUNDA_NAMESPACE_2" --output=wide || true;
   if namespace_ready "$CLUSTER_2_NAME" "$CAMUNDA_NAMESPACE_2"; then
     echo "OK: All pods are Running and Healthy in context: $CLUSTER_2_NAME, namespace: $CAMUNDA_NAMESPACE_2 - Installation completed!";
     echo "OK: All pods are healthy across both contexts.";

--- a/generic/openshift/dual-region/procedure/check-deployment-ready.sh
+++ b/generic/openshift/dual-region/procedure/check-deployment-ready.sh
@@ -2,6 +2,15 @@
 
 set -euo pipefail
 
+# This script tracks per-pod restart counts in a bash associative array
+# (declare -A), which requires bash >= 4. Fail fast with a clear message on older
+# shells (e.g. macOS ships bash 3.2) instead of a cryptic "declare: -A: invalid
+# option" later on.
+if (( BASH_VERSINFO[0] < 4 )); then
+  echo "ERROR: ${BASH_SOURCE[0]##*/} requires bash >= 4 (associative arrays); found bash ${BASH_VERSION}." >&2
+  exit 1
+fi
+
 # Wait until the dual-region Camunda deployment is healthy on both clusters.
 #
 # Self-healing rationale:
@@ -38,12 +47,14 @@ restart_stuck_brokers() {
   # Match broker pods for the configured Helm release (defaults to "camunda"),
   # so the self-heal keeps working when CAMUNDA_RELEASE_NAME is customised.
   local release="${CAMUNDA_RELEASE_NAME:-camunda}"
-  local now pod started age count
+  local now pod started_epoch age count
   now="$(date -u +%s)"
 
-  while read -r pod started; do
+  while read -r pod started_epoch; do
     [ -z "$pod" ] && continue
-    age=$(( now - $(date -u -d "$started" +%s) ))
+    # started_epoch is emitted by jq (fromdateiso8601) below, so we avoid the
+    # GNU-only `date -d <string>` parse and stay portable across BSD/macOS.
+    age=$(( now - started_epoch ))
 
     if [ "$age" -lt "$STUCK_BROKER_TIMEOUT_SECONDS" ]; then
       echo "  ↳ $pod is not ready yet (${age}s < ${STUCK_BROKER_TIMEOUT_SECONDS}s), still within startup grace period";
@@ -66,7 +77,7 @@ restart_stuck_brokers() {
         | select(.metadata.name | test($re))
         | select(any(.status.containerStatuses[]?; .ready == false))
         | select(any(.status.containerStatuses[]?; .state.running.startedAt != null))
-        | "\(.metadata.name) \([.status.containerStatuses[] | select(.state.running != null) | .state.running.startedAt] | min)"
+        | "\(.metadata.name) \([.status.containerStatuses[] | select(.state.running != null) | (.state.running.startedAt | sub("\\.[0-9]+Z$"; "Z") | fromdateiso8601)] | min)"
       '
   )
 }

--- a/generic/openshift/dual-region/procedure/check-deployment-ready.sh
+++ b/generic/openshift/dual-region/procedure/check-deployment-ready.sh
@@ -37,7 +37,11 @@ declare -A BROKER_RESTARTS
 # Returns success when every pod in the namespace is Running and ready.
 namespace_ready() {
   local context="$1" namespace="$2"
-  [ "$(kubectl --context="$context" get pods -n "$namespace" --field-selector=status.phase!=Running -o name | wc -l)" -eq 0 ] &&
+  # A namespace with zero pods is NOT ready: the two checks below both evaluate to 0 on
+  # empty output, which would otherwise report a false "Installation completed" if the
+  # Helm install failed early or targeted an unexpected namespace/context.
+  [ "$(kubectl --context="$context" get pods -n "$namespace" -o name | wc -l)" -gt 0 ] &&
+    [ "$(kubectl --context="$context" get pods -n "$namespace" --field-selector=status.phase!=Running -o name | wc -l)" -eq 0 ] &&
     [ "$(kubectl --context="$context" get pods -n "$namespace" -o json | jq -r '.items[] | select(.status.containerStatuses[]?.ready == false)' | wc -l)" -eq 0 ]
 }
 

--- a/generic/openshift/dual-region/procedure/check-deployment-ready.sh
+++ b/generic/openshift/dual-region/procedure/check-deployment-ready.sh
@@ -72,8 +72,13 @@ restart_stuck_brokers() {
     fi
 
     echo "  ⚠️  $pod has been Running but not ready for ${age}s (likely a hung startup over Submariner DNS); restarting it (attempt $((count + 1))/${MAX_BROKER_RESTARTS})";
-    kubectl --context="$context" delete pod "$pod" -n "$namespace" --wait=false || true;
-    BROKER_RESTARTS["$context/$pod"]=$(( count + 1 ));
+    # Only consume a restart attempt when the delete actually succeeds: a transient
+    # API error (or an already-gone pod) must not burn the MAX_BROKER_RESTARTS budget.
+    if kubectl --context="$context" delete pod "$pod" -n "$namespace" --wait=false; then
+      BROKER_RESTARTS["$context/$pod"]=$(( count + 1 ));
+    else
+      echo "  ↳ failed to delete $pod; will retry without consuming a restart attempt";
+    fi
   done < <(
     kubectl --context="$context" get pods -n "$namespace" -o json |
       jq -r --arg re "^${release}-zeebe-[0-9]+$" '

--- a/generic/openshift/dual-region/procedure/check-deployment-ready.sh
+++ b/generic/openshift/dual-region/procedure/check-deployment-ready.sh
@@ -35,6 +35,9 @@ namespace_ready() {
 # Restarts Zeebe broker pods that have been Running but not ready for too long.
 restart_stuck_brokers() {
   local context="$1" namespace="$2"
+  # Match broker pods for the configured Helm release (defaults to "camunda"),
+  # so the self-heal keeps working when CAMUNDA_RELEASE_NAME is customised.
+  local release="${CAMUNDA_RELEASE_NAME:-camunda}"
   local now pod started age count
   now="$(date -u +%s)"
 
@@ -58,9 +61,9 @@ restart_stuck_brokers() {
     BROKER_RESTARTS["$context/$pod"]=$(( count + 1 ));
   done < <(
     kubectl --context="$context" get pods -n "$namespace" -o json |
-      jq -r '
+      jq -r --arg re "^${release}-zeebe-[0-9]+$" '
         .items[]
-        | select(.metadata.name | test("^camunda-zeebe-[0-9]+$"))
+        | select(.metadata.name | test($re))
         | select(any(.status.containerStatuses[]?; .ready == false))
         | select(any(.status.containerStatuses[]?; .state.running.startedAt != null))
         | "\(.metadata.name) \([.status.containerStatuses[] | select(.state.running != null) | .state.running.startedAt] | min)"

--- a/generic/openshift/dual-region/procedure/check-deployment-ready.sh
+++ b/generic/openshift/dual-region/procedure/check-deployment-ready.sh
@@ -17,6 +17,16 @@ set -euo pipefail
 #   than STUCK_BROKER_TIMEOUT_SECONDS is treated as hung and restarted, bounded
 #   by MAX_BROKER_RESTARTS attempts per pod.
 
+# TEMPORARY (defence-in-depth) — REMOVE once the cross-region DNS race is fixed.
+#   The primary fix is the wait-clusterset-dns initContainer (see
+#   helm-values/values-base.yml), which prevents the broker from ever observing
+#   the NXDOMAIN in the first place. This self-heal stays only as a backstop for
+#   the gate's fail-open paths (no resolver in image / gate gives up).
+#   Once the gate is validated in CI and the upstream Camunda fix lands (broker
+#   re-resolves its contact points on its own), this whole self-heal block
+#   (restart_stuck_brokers + STUCK_BROKER_TIMEOUT_SECONDS + MAX_BROKER_RESTARTS)
+#   can be deleted. Tracking issue: <Camunda issue link TBD>.
+
 # How long a broker may stay "Running but not ready" before we consider it hung.
 STUCK_BROKER_TIMEOUT_SECONDS="${STUCK_BROKER_TIMEOUT_SECONDS:-360}"
 # Maximum number of automatic restarts per broker pod.

--- a/generic/openshift/dual-region/procedure/install-chart.sh
+++ b/generic/openshift/dual-region/procedure/install-chart.sh
@@ -20,10 +20,15 @@ BROKER_IMAGE="$(helm show values \
   camunda/camunda-platform \
   --version "$HELM_CHART_VERSION" \
   | yq -r '(.orchestration.image // .zeebe.image) | ([.registry, .repository] | map(. // "") | map(select(. != "")) | join("/")) + ":" + .tag')"
-# Guard against an empty/tag-less result (e.g. unexpected chart values shape) so we
-# never substitute an invalid image into the generated values and fail later with a
-# confusing Helm/Kubernetes error.
-if [ -z "$BROKER_IMAGE" ] || [ -z "${BROKER_IMAGE##*:}" ]; then
+# Guard against a malformed result (e.g. unexpected chart values shape) so we never
+# substitute an invalid image into the generated values and fail later with a confusing
+# Helm/Kubernetes error. Require a non-empty repository AND a non-empty, non-"null" tag
+# separated by a ':' — this rejects ":tag" (empty repo), "repo:" / "repo:null" and a
+# value with no ':' at all.
+broker_image_repo="${BROKER_IMAGE%:*}"
+broker_image_tag="${BROKER_IMAGE##*:}"
+if [ -z "$BROKER_IMAGE" ] || [ "$BROKER_IMAGE" = "$broker_image_tag" ] \
+  || [ -z "$broker_image_repo" ] || [ -z "$broker_image_tag" ] || [ "$broker_image_tag" = "null" ]; then
   echo "ERROR: failed to resolve a valid broker image (registry/repository:tag) from the chart values (got '$BROKER_IMAGE')." >&2
   exit 1
 fi

--- a/generic/openshift/dual-region/procedure/install-chart.sh
+++ b/generic/openshift/dual-region/procedure/install-chart.sh
@@ -1,18 +1,58 @@
 #!/bin/bash
+set -euo pipefail
 
 helm repo add camunda https://helm.camunda.io
 helm repo update
 
-helm upgrade --install \
-   "$CAMUNDA_RELEASE_NAME" camunda/camunda-platform \
+# Resolve the broker image of the chart being installed so the cross-region
+# DNS-gate initContainer (see helm-values/values-base.yml) reuses the exact
+# same image as the broker — already pulled on the node, no extra pull, and no
+# hardcoded tag to maintain. The generated values carry a literal ${BROKER_IMAGE}
+# placeholder (passed through the first envsubst via ${DOLLAR}); resolve it here.
+BROKER_IMAGE="$(helm show values \
+  oci://registry.camunda.cloud/team-distribution/camunda-platform \
   --version "$HELM_CHART_VERSION" \
-  --kube-context "$CLUSTER_1_NAME" \
+  | yq -r '(.orchestration.image // .zeebe.image) | ([.registry, .repository] | map(. // "") | map(select(. != "")) | join("/")) + ":" + .tag')"
+export BROKER_IMAGE
+echo "Cross-region DNS-gate initContainer will reuse broker image: $BROKER_IMAGE"
+
+for region_values in generated-values-region-0.yml generated-values-region-1.yml; do
+  # Single quotes are envsubst's SHELL-FORMAT (only ${BROKER_IMAGE} is replaced),
+  # not a shell expansion — leave everything else in the file untouched.
+  # shellcheck disable=SC2016
+  envsubst '${BROKER_IMAGE}' <"$region_values" >"$region_values.tmp"
+  mv "$region_values.tmp" "$region_values"
+done
+
+helm upgrade --install \
+  "$CAMUNDA_RELEASE_NAME" \
+   oci://registry.camunda.cloud/team-distribution/camunda-platform \
+  --version "$HELM_CHART_VERSION" \
+  --kube-context "$CLUSTER_0" \
+  --namespace "$CAMUNDA_NAMESPACE_0" \
+  -f generated-values-region-0.yml
+
+helm upgrade --install \
+  "$CAMUNDA_RELEASE_NAME" \
+   oci://registry.camunda.cloud/team-distribution/camunda-platform \
+  --version "$HELM_CHART_VERSION" \
+  --kube-context "$CLUSTER_1" \
   --namespace "$CAMUNDA_NAMESPACE_1" \
   -f generated-values-region-1.yml
 
-helm upgrade --install \
-  "$CAMUNDA_RELEASE_NAME" camunda/camunda-platform \
-  --version "$HELM_CHART_VERSION" \
-  --kube-context "$CLUSTER_2_NAME" \
-  --namespace "$CAMUNDA_NAMESPACE_2" \
-  -f generated-values-region-2.yml
+# TODO: [release-duty] before the release, update this by removing the oci pull above
+# and uncomment the installation instruction below
+
+# helm upgrade --install \
+#    "$CAMUNDA_RELEASE_NAME" camunda/camunda-platform \
+#   --version "$HELM_CHART_VERSION" \
+#   --kube-context "$CLUSTER_0" \
+#   --namespace "$CAMUNDA_NAMESPACE_0" \
+#   -f generated-values-region-0.yml
+
+# helm upgrade --install \
+#   "$CAMUNDA_RELEASE_NAME" camunda/camunda-platform \
+#   --version "$HELM_CHART_VERSION" \
+#   --kube-context "$CLUSTER_1" \
+#   --namespace "$CAMUNDA_NAMESPACE_1" \
+#   -f generated-values-region-1.yml

--- a/generic/openshift/dual-region/procedure/install-chart.sh
+++ b/generic/openshift/dual-region/procedure/install-chart.sh
@@ -10,10 +10,23 @@ helm repo update
 # same image as the broker — already pulled on the node, no extra pull, and no
 # hardcoded tag to maintain. The generated values carry a literal ${BROKER_IMAGE}
 # placeholder (passed through the first envsubst via ${DOLLAR}); resolve it here.
+# yq is required for this; fail fast with a clear message instead of a generic
+# "command not found" in the middle of the install flow.
+if ! command -v yq >/dev/null 2>&1; then
+  echo "ERROR: 'yq' is required to resolve the broker image for the cross-region DNS gate but was not found in PATH." >&2
+  exit 1
+fi
 BROKER_IMAGE="$(helm show values \
   camunda/camunda-platform \
   --version "$HELM_CHART_VERSION" \
   | yq -r '(.orchestration.image // .zeebe.image) | ([.registry, .repository] | map(. // "") | map(select(. != "")) | join("/")) + ":" + .tag')"
+# Guard against an empty/tag-less result (e.g. unexpected chart values shape) so we
+# never substitute an invalid image into the generated values and fail later with a
+# confusing Helm/Kubernetes error.
+if [ -z "$BROKER_IMAGE" ] || [ -z "${BROKER_IMAGE##*:}" ]; then
+  echo "ERROR: failed to resolve a valid broker image (registry/repository:tag) from the chart values (got '$BROKER_IMAGE')." >&2
+  exit 1
+fi
 export BROKER_IMAGE
 echo "Cross-region DNS-gate initContainer will reuse broker image: $BROKER_IMAGE"
 

--- a/generic/openshift/dual-region/procedure/install-chart.sh
+++ b/generic/openshift/dual-region/procedure/install-chart.sh
@@ -10,13 +10,13 @@ helm repo update
 # hardcoded tag to maintain. The generated values carry a literal ${BROKER_IMAGE}
 # placeholder (passed through the first envsubst via ${DOLLAR}); resolve it here.
 BROKER_IMAGE="$(helm show values \
-  oci://registry.camunda.cloud/team-distribution/camunda-platform \
+  camunda/camunda-platform \
   --version "$HELM_CHART_VERSION" \
   | yq -r '(.orchestration.image // .zeebe.image) | ([.registry, .repository] | map(. // "") | map(select(. != "")) | join("/")) + ":" + .tag')"
 export BROKER_IMAGE
 echo "Cross-region DNS-gate initContainer will reuse broker image: $BROKER_IMAGE"
 
-for region_values in generated-values-region-0.yml generated-values-region-1.yml; do
+for region_values in generated-values-region-1.yml generated-values-region-2.yml; do
   # Single quotes are envsubst's SHELL-FORMAT (only ${BROKER_IMAGE} is replaced),
   # not a shell expansion — leave everything else in the file untouched.
   # shellcheck disable=SC2016
@@ -25,34 +25,15 @@ for region_values in generated-values-region-0.yml generated-values-region-1.yml
 done
 
 helm upgrade --install \
-  "$CAMUNDA_RELEASE_NAME" \
-   oci://registry.camunda.cloud/team-distribution/camunda-platform \
+  "$CAMUNDA_RELEASE_NAME" camunda/camunda-platform \
   --version "$HELM_CHART_VERSION" \
-  --kube-context "$CLUSTER_0" \
-  --namespace "$CAMUNDA_NAMESPACE_0" \
-  -f generated-values-region-0.yml
-
-helm upgrade --install \
-  "$CAMUNDA_RELEASE_NAME" \
-   oci://registry.camunda.cloud/team-distribution/camunda-platform \
-  --version "$HELM_CHART_VERSION" \
-  --kube-context "$CLUSTER_1" \
+  --kube-context "$CLUSTER_1_NAME" \
   --namespace "$CAMUNDA_NAMESPACE_1" \
   -f generated-values-region-1.yml
 
-# TODO: [release-duty] before the release, update this by removing the oci pull above
-# and uncomment the installation instruction below
-
-# helm upgrade --install \
-#    "$CAMUNDA_RELEASE_NAME" camunda/camunda-platform \
-#   --version "$HELM_CHART_VERSION" \
-#   --kube-context "$CLUSTER_0" \
-#   --namespace "$CAMUNDA_NAMESPACE_0" \
-#   -f generated-values-region-0.yml
-
-# helm upgrade --install \
-#   "$CAMUNDA_RELEASE_NAME" camunda/camunda-platform \
-#   --version "$HELM_CHART_VERSION" \
-#   --kube-context "$CLUSTER_1" \
-#   --namespace "$CAMUNDA_NAMESPACE_1" \
-#   -f generated-values-region-1.yml
+helm upgrade --install \
+  "$CAMUNDA_RELEASE_NAME" camunda/camunda-platform \
+  --version "$HELM_CHART_VERSION" \
+  --kube-context "$CLUSTER_2_NAME" \
+  --namespace "$CAMUNDA_NAMESPACE_2" \
+  -f generated-values-region-2.yml

--- a/generic/openshift/dual-region/procedure/install-chart.sh
+++ b/generic/openshift/dual-region/procedure/install-chart.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 set -euo pipefail
 
-helm repo add camunda https://helm.camunda.io
+# --force-update keeps this idempotent under `set -e` if the repo already exists.
+helm repo add camunda https://helm.camunda.io --force-update
 helm repo update
 
 # Resolve the broker image of the chart being installed so the cross-region


### PR DESCRIPTION
## Description

Backport to `stable/8.8` of #2627.

Fixes intermittent CI failures in the **OpenShift ROSA HCP dual-region** integration tests, where the job failed at the `👀⏳ Wait for the deployment to be healthy` step (and, with the deployment fixed, then at the `🧪 Run Helm Chart tests` topology check).

### Root cause

Cross-region Zeebe brokers resolve their peers over Submariner Lighthouse DNS (`*.svc.clusterset.local`). If a broker starts **before** that DNS has propagated, it hits `NXDOMAIN` and the `main` thread parks permanently in `Broker.internalStart`: the management port 9600 never opens, the pod stays `0/1 Running`, and cross-region quorum never forms. A longer health-check timeout alone does not help, because the JVM never re-resolves and never recovers on its own.

Tracked upstream: **camunda/camunda#55038**.

### Fix

Two deploy-layer mitigations (the durable fix is upstream):

1. **`wait-clusterset-dns` initContainer** gates broker startup until every `initialContactPoint` resolves, so the broker never observes the `NXDOMAIN`. On this line the contact points are already **per-pod** names (`<release>-zeebe-<ordinal>.<cluster>.…svc.clusterset.local`), so the gate waits on each broker pod directly.
   - Reuses the chart's broker image — resolved at deploy time by `install-chart.sh` via `helm show values` through a `${BROKER_IMAGE}` placeholder (no hardcoded tag, no extra pull).
   - Fails open: skips if the image ships no resolver, and is bounded by a single **global ~12 min budget** (`CLUSTERSET_DNS_TIMEOUT_SECONDS`) regardless of contact-point count.

2. **Stuck-broker self-heal** in `check-deployment-ready.sh`: the startup gate cannot cover a *runtime* clusterset-DNS flap (a peer name that `NXDOMAIN`s again during membership probes), which the broker also never recovers from. The readiness poller therefore restarts any broker left `Running`-but-not-`Ready` past `STUCK_BROKER_TIMEOUT_SECONDS` (default 360s), matched by configurable release name and bounded by `MAX_BROKER_RESTARTS`. Safety net for the residual race until the upstream fix lands.

Supporting changes:

- Health-check step `timeout-minutes` raised `10` → `20` to cover the gate's bounded wait plus a self-heal restart.
- `install-chart.sh` installs and resolves the broker image from the **public** `camunda/camunda-platform` chart (this released line's source), with the branch's 1-indexed region files / `CLUSTER_*_NAME` contexts, and `helm repo add` uses `--force-update` to stay idempotent under `set -euo pipefail`.

## Related

Backport of #2627. Upstream issue: **camunda/camunda#55038**. The gate and self-heal are temporary deploy-layer workarounds, to be removed once the broker re-resolves its contact points on its own.
