### PR TITLE
ci(openshift-dual-region): raise health-check timeout for slow cross-region Zeebe quorum (backport 8.7)

### DIFF
--- a/.github/workflows/aws_openshift_rosa_hcp_dual_region_tests.yml
+++ b/.github/workflows/aws_openshift_rosa_hcp_dual_region_tests.yml
@@ -630,7 +630,10 @@ jobs:
                   ./generic/openshift/dual-region/procedure/verify-exported-services.sh
 
             - name: 👀⏳ Wait for the deployment to be healthy using generic/openshift/dual-region
-              timeout-minutes: 10
+              # Cross-region Zeebe brokers stay 0/1 (Running, not Ready) until they
+              # form quorum over Submariner, which can take longer than 10 min on
+              # slow ROSA HCP runs and intermittently times out this step.
+              timeout-minutes: 20
               run: |
                   set -euo pipefail
 


### PR DESCRIPTION
## Description

Backport to `stable/8.7` of #2627.

Fixes intermittent CI failures in the **OpenShift ROSA HCP dual-region** integration tests, where the job failed at the `👀⏳ Wait for the deployment to be healthy` step.

### Root cause

The step runs `check-deployment-ready.sh`, which polls until every pod in both clusters is `Running` **and** `Ready`. On cluster 1, the cross-region Zeebe brokers (`camunda-zeebe-1`, `camunda-zeebe-3`) stay `0/1 Running` (not Ready) until they form quorum with cluster 0 over the Submariner tunnel. On slow ROSA HCP runs this takes longer than the step's `timeout-minutes: 10`, so the step is killed mid-convergence and the whole job fails — even though Submariner itself is connected and the brokers are healthy, just not yet in quorum.

### Fix

Raise `timeout-minutes` on the health-check step from `10` to `20` and document why. No script logic changes; non-transient failures still surface (pods that never become ready will still fail once they hit the new bound).

## Related

Backport of #2627 (main).
