### PR TITLE
fix(ci): exclude weekly_schedule_only distros from regular PR runs

### DIFF
--- a/.github/actions/internal-tests-matrix/action.yml
+++ b/.github/actions/internal-tests-matrix/action.yml
@@ -66,7 +66,11 @@ runs:
                 platform_matrix="$(yq '(.matrix |= (.distro |= map(select(.weekly_schedule_only == null or .weekly_schedule_only == false)))) | .matrix' \
                   --indent=0 --output-format json "${{ inputs.ci_matrix_file }}")"
               else
-                platform_matrix="$(yq '(.matrix |= (.distro |= map(select(.schedule_only == null or .schedule_only == false)))) | .matrix' \
+                echo "This is a regular PR, we exclude schedule_only and weekly_schedule_only scenarios."
+                platform_matrix="$(yq '(.matrix |= (.distro |= map(select(
+                    (.schedule_only == null or .schedule_only == false)
+                    and (.weekly_schedule_only == null or .weekly_schedule_only == false)
+                  )))) | .matrix' \
                   --indent=0 --output-format json "${{ inputs.ci_matrix_file }}")"
               fi
 


### PR DESCRIPTION
## Motivation

The `Tests - Integration - Generic Migration from Bitnami` workflow fails on **every regular pull request** at the data-seeding step, before any migration logic runs. This currently blocks functional PRs such as #2620.

### Root cause

The two heavy benchmark legs in the migration matrix are flagged `weekly_schedule_only: true`:

- `Kind-Heavy-Domain`
- `Kind-Heavy-WarmReindex-Domain`

But `internal-tests-matrix/action.yml` only excluded `schedule_only` on regular PRs — **not** `weekly_schedule_only`. So the heavy legs ran on every PR, even though they are meant to run only on the weekly Tuesday cron.

The heavy benchmark (`benchmark-job-heavy.yml`: 150 PI/s for 30 min, ~20 GB of Elasticsearch data) saturates the self-hosted runner that hosts the kind cluster. The runner runs out of CPU/memory and drops its connection mid-run:

> The self-hosted runner lost communication with the server. … Anything in your workflow that terminates the runner process, **starves it for CPU/Memory**, or blocks its network access can cause this error.

The job is killed during step *"Run benchmark to generate Zeebe data"* (~70% backpressure, runner dies), so the migration phases never even execute.

## What this PR does

Aligns the regular-PR filter with the intent of `weekly_schedule_only`: distros flagged `weekly_schedule_only: true` are now excluded on regular PRs (same as they already are for renovate PRs). They still run on the weekly schedule.

| Trigger | Heavy legs run? |
| --- | --- |
| Scheduled (Tuesday cron) | ✅ yes (unchanged) |
| Regular PR | ❌ no (**fixed** — was incorrectly yes) |
| Renovate PR | ❌ no (unchanged) |

Only the migration matrix uses `weekly_schedule_only`, so no other workflow is affected.

## Validation

- `yamllint -c .lint/yamllint/.yamllint.yaml` passes (lines stay under the 175 limit).
- Verified the `yq` filter against the real matrix file:
  - Regular PR → `Kind-NoDomain`, `Kind-Domain` only.
  - Renovate PR → `Kind-NoDomain`, `Kind-Domain` (unchanged).
  - Scheduled → all four legs including both heavy (unchanged).
- pre-commit hooks (yamllint, yamlfmt, action README) pass.

## Related

- Unblocks #2620 (the heavy-leg failure there is this infra issue, not a defect in that PR).
