### PR TITLE
fix(ci): exclude weekly_schedule_only distros from regular PR runs (backport stable/8.6)

### DIFF
--- a/.github/actions/internal-tests-matrix/action.yml
+++ b/.github/actions/internal-tests-matrix/action.yml
@@ -62,7 +62,11 @@ runs:
                 echo "This PR is scheduled or coming from renovate, we test all scenarios without filtering."
                 platform_matrix="$(yq '.matrix' --indent=0 --output-format json "${{ inputs.ci_matrix_file }}")"
               else
-                platform_matrix="$(yq '(.matrix |= (.distro |= map(select(.schedule_only == null or .schedule_only == false)))) | .matrix' \
+                echo "This is a regular PR, we exclude schedule_only and weekly_schedule_only scenarios."
+                platform_matrix="$(yq '(.matrix |= (.distro |= map(select(
+                    (.schedule_only == null or .schedule_only == false)
+                    and (.weekly_schedule_only == null or .weekly_schedule_only == false)
+                  )))) | .matrix' \
                   --indent=0 --output-format json "${{ inputs.ci_matrix_file }}")"
               fi
 


### PR DESCRIPTION
## Backport of #2641 to `stable/8.6`

Backports the shared `internal-tests-matrix` action fix from #2641 (which targets `stable/8.9`).

### What it does

Aligns the **regular-PR** matrix filter with the **renovate-PR** one: distros flagged `weekly_schedule_only: true` are now excluded on regular PRs as well (the `else` branch previously filtered only `schedule_only`). Single `select` with both conditions, matching the existing style.

### Why backport to this branch

`internal-tests-matrix/action.yml` is a **shared** action used by every cloud test workflow. This branch currently has **no** `weekly_schedule_only` distro (only `stable/8.9` does, via the migration matrix), so the change is a **behavioral no-op here today** — but backporting keeps the shared action's filtering logic in sync across all maintained branches and avoids drift, so any future `weekly_schedule_only` distro behaves consistently.

### Validation

- `yamllint -c .lint/yamllint/.yamllint.yaml` passes (lines under the 175 limit).
- Cherry-picked cleanly from #2641 (`1a515004`); diff is byte-identical.

Backport stack: #2641 (`stable/8.9`) → `main` / `stable/8.8` / `stable/8.7` / `stable/8.6`.
