### PR TITLE
fix(ci): make smoke-test port-forwards self-healing

### DIFF
--- a/.github/actions/camunda-smoke-test/action.yml
+++ b/.github/actions/camunda-smoke-test/action.yml
@@ -133,17 +133,24 @@ runs:
               SVC="${RELEASE}-zeebe-gateway"
 
               echo "Starting port-forward to ${SVC}..."
-              # Detach from the step's bash via setsid + nohup so the PF
-              # survives the composite-action step boundary (otherwise the
-              # GHA runner reaps the child shell's process group between
-              # steps and the next step gets connection-refused on :8080).
+              # Run the forward through a resilient supervisor that restarts
+              # kubectl whenever its SPDY stream is reaped (managed LBs / CNIs
+              # drop idle port-forwards after ~30-60s, which otherwise leaves
+              # the next step with connection-refused / HTTP 000 on :8080).
+              # setsid + nohup detaches it so it survives the composite-action
+              # step boundary and becomes its own process-group leader.
               mkdir -p /tmp/smoke-pf
-              setsid nohup kubectl port-forward "svc/${SVC}" 8080:8080 \
-                  -n "$NS" </dev/null \
-                  >/tmp/smoke-pf/zeebe.log 2>&1 &
-              PF_PID=$!
-              disown "$PF_PID" || true
-              echo "pf_zeebe_pid=${PF_PID}" >> "$GITHUB_OUTPUT"
+              SUPERVISOR="${{ github.action_path }}/scripts/port-forward.sh"
+              setsid nohup bash "$SUPERVISOR" \
+                  "$NS" "svc/${SVC}" 8080:8080 /tmp/smoke-pf/zeebe \
+                  </dev/null >/dev/null 2>&1 &
+              disown || true
+              # Wait for the supervisor to record its PID before continuing.
+              for _ in $(seq 1 10); do
+                  [[ -s /tmp/smoke-pf/zeebe.pid ]] && break
+                  sleep 0.2
+              done
+              echo "pf_zeebe_base=/tmp/smoke-pf/zeebe" >> "$GITHUB_OUTPUT"
 
               for i in $(seq 1 30); do
                   CODE=$(curl -s -o /dev/null \
@@ -231,16 +238,21 @@ runs:
               LOCAL_KC_PORT=18080
 
               echo "Port-forwarding ${KC_HOST}..."
-              # Same setsid/nohup detachment as the Zeebe PF above so the
-              # Keycloak forward survives the composite-action step boundary.
+              # Same resilient supervisor as the Zeebe forward above, so the
+              # Keycloak port-forward also survives SPDY-stream reaping and
+              # the composite-action step boundary.
               mkdir -p /tmp/smoke-pf
-              setsid nohup kubectl port-forward "svc/${KC_HOST}" \
-                  "${LOCAL_KC_PORT}:${KC_REMOTE_PORT}" \
-                  -n "$NS" </dev/null \
-                  >/tmp/smoke-pf/keycloak.log 2>&1 &
-              PF_KC_PID=$!
-              disown "$PF_KC_PID" || true
-              echo "pf_kc_pid=${PF_KC_PID}" >> "$GITHUB_OUTPUT"
+              SUPERVISOR="${{ github.action_path }}/scripts/port-forward.sh"
+              setsid nohup bash "$SUPERVISOR" \
+                  "$NS" "svc/${KC_HOST}" "${LOCAL_KC_PORT}:${KC_REMOTE_PORT}" \
+                  /tmp/smoke-pf/keycloak \
+                  </dev/null >/dev/null 2>&1 &
+              disown || true
+              for _ in $(seq 1 10); do
+                  [[ -s /tmp/smoke-pf/keycloak.pid ]] && break
+                  sleep 0.2
+              done
+              echo "pf_kc_base=/tmp/smoke-pf/keycloak" >> "$GITHUB_OUTPUT"
 
               for i in $(seq 1 30); do
                   CODE=$(curl -s -o /dev/null \
@@ -308,10 +320,19 @@ runs:
           shell: bash
           run: |
               set -euo pipefail
-              for PID in \
-                  "${{ steps.port-forward.outputs.pf_zeebe_pid }}" \
-                  "${{ steps.oidc-setup.outputs.pf_kc_pid }}"; do
-                  if [[ -n "$PID" ]]; then
-                      kill "$PID" 2>/dev/null || true
+              for BASE in \
+                  "${{ steps.port-forward.outputs.pf_zeebe_base }}" \
+                  "${{ steps.oidc-setup.outputs.pf_kc_base }}"; do
+                  [[ -z "$BASE" ]] && continue
+                  # Drop the stop sentinel first so the supervisor does not
+                  # restart kubectl after we kill it.
+                  touch "${BASE}.stop" 2>/dev/null || true
+                  if [[ -s "${BASE}.pid" ]]; then
+                      SPID=$(cat "${BASE}.pid")
+                      # Kill the whole process group (setsid made the
+                      # supervisor the group leader) so its kubectl child
+                      # dies with it.
+                      kill -- "-${SPID}" 2>/dev/null || true
+                      kill "$SPID" 2>/dev/null || true
                   fi
               done

--- a/.github/actions/camunda-smoke-test/action.yml
+++ b/.github/actions/camunda-smoke-test/action.yml
@@ -141,15 +141,25 @@ runs:
               # step boundary and becomes its own process-group leader.
               mkdir -p /tmp/smoke-pf
               SUPERVISOR="${{ github.action_path }}/scripts/port-forward.sh"
+              # Clear any stale pid/stop/log left by an earlier job on this
+              # (self-hosted) runner, so the wait below can't be satisfied by a
+              # leftover PID and cleanup can't later kill an unrelated process.
+              rm -f /tmp/smoke-pf/zeebe.pid /tmp/smoke-pf/zeebe.stop /tmp/smoke-pf/zeebe.log
               setsid nohup bash "$SUPERVISOR" \
                   "$NS" "svc/${SVC}" 8080:8080 /tmp/smoke-pf/zeebe \
                   </dev/null >/dev/null 2>&1 &
               disown || true
-              # Wait for the supervisor to record its PID before continuing.
-              for _ in $(seq 1 10); do
+              # Wait for the supervisor to record its fresh PID before
+              # continuing; fail fast if it never starts.
+              for _ in $(seq 1 25); do
                   [[ -s /tmp/smoke-pf/zeebe.pid ]] && break
                   sleep 0.2
               done
+              if [[ ! -s /tmp/smoke-pf/zeebe.pid ]]; then
+                  echo "::error::Zeebe port-forward supervisor did not start (no PID written)"
+                  cat /tmp/smoke-pf/zeebe.log 2>/dev/null || true
+                  exit 1
+              fi
               echo "pf_zeebe_base=/tmp/smoke-pf/zeebe" >> "$GITHUB_OUTPUT"
 
               for i in $(seq 1 30); do
@@ -243,15 +253,24 @@ runs:
               # the composite-action step boundary.
               mkdir -p /tmp/smoke-pf
               SUPERVISOR="${{ github.action_path }}/scripts/port-forward.sh"
+              # Clear any stale pid/stop/log left by an earlier job on this
+              # (self-hosted) runner, so the wait below can't be satisfied by a
+              # leftover PID and cleanup can't later kill an unrelated process.
+              rm -f /tmp/smoke-pf/keycloak.pid /tmp/smoke-pf/keycloak.stop /tmp/smoke-pf/keycloak.log
               setsid nohup bash "$SUPERVISOR" \
                   "$NS" "svc/${KC_HOST}" "${LOCAL_KC_PORT}:${KC_REMOTE_PORT}" \
                   /tmp/smoke-pf/keycloak \
                   </dev/null >/dev/null 2>&1 &
               disown || true
-              for _ in $(seq 1 10); do
+              for _ in $(seq 1 25); do
                   [[ -s /tmp/smoke-pf/keycloak.pid ]] && break
                   sleep 0.2
               done
+              if [[ ! -s /tmp/smoke-pf/keycloak.pid ]]; then
+                  echo "::error::Keycloak port-forward supervisor did not start (no PID written)"
+                  cat /tmp/smoke-pf/keycloak.log 2>/dev/null || true
+                  exit 1
+              fi
               echo "pf_kc_base=/tmp/smoke-pf/keycloak" >> "$GITHUB_OUTPUT"
 
               for i in $(seq 1 30); do

--- a/.github/actions/camunda-smoke-test/scripts/port-forward.sh
+++ b/.github/actions/camunda-smoke-test/scripts/port-forward.sh
@@ -17,7 +17,10 @@
 # Derived from <base>:
 #   <base>.log   kubectl + supervisor output
 #   <base>.pid   supervisor PID (also its process-group id, via setsid)
-#   <base>.stop  stop sentinel — `touch` it to make the supervisor exit
+#   <base>.stop  stop sentinel — `touch` it to stop restarting. The
+#                supervisor stops relaunching kubectl and exits once the
+#                running kubectl invocation ends; the cleanup step also
+#                kills the process group directly for prompt teardown.
 #
 # Example:
 #   port-forward.sh camunda svc/camunda-zeebe-gateway 8080:8080 \
@@ -26,6 +29,11 @@
 # Intentionally no `set -e`: a dropped port-forward must restart, not
 # abort the supervisor.
 set -uo pipefail
+
+if [[ "$#" -ne 4 ]]; then
+    echo "usage: port-forward.sh <namespace> <target> <ports> <base>" >&2
+    exit 2
+fi
 
 NS="$1"
 TARGET="$2"

--- a/.github/actions/camunda-smoke-test/scripts/port-forward.sh
+++ b/.github/actions/camunda-smoke-test/scripts/port-forward.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Resilient kubectl port-forward supervisor for the smoke test.
+#
+# kubectl port-forward tunnels through a single SPDY/TCP stream. Managed
+# cloud load balancers and some CNIs (EKS, AKS ILB, ...) reap that stream
+# after a short idle window (as low as ~30-60s). A bare one-shot
+# `kubectl port-forward` then exits and is never restarted, so every
+# subsequent request returns HTTP 000 even though Camunda is healthy
+# (observed on EKS single-region: 0/30 verify attempts reached the
+# search API). This wrapper restarts the forward whenever it exits, until
+# the caller drops the stop sentinel, keeping the local port usable for
+# the whole smoke test.
+#
+# Usage:
+#   port-forward.sh <namespace> <target> <ports> <base>
+#
+# Derived from <base>:
+#   <base>.log   kubectl + supervisor output
+#   <base>.pid   supervisor PID (also its process-group id, via setsid)
+#   <base>.stop  stop sentinel — `touch` it to make the supervisor exit
+#
+# Example:
+#   port-forward.sh camunda svc/camunda-zeebe-gateway 8080:8080 \
+#       /tmp/smoke-pf/zeebe
+#
+# Intentionally no `set -e`: a dropped port-forward must restart, not
+# abort the supervisor.
+set -uo pipefail
+
+NS="$1"
+TARGET="$2"
+PORTS="$3"
+BASE="$4"
+
+LOG="${BASE}.log"
+PIDFILE="${BASE}.pid"
+STOP="${BASE}.stop"
+
+# Record our own PID so the cleanup step can kill this supervisor and its
+# kubectl child as a process group (setsid makes this PID the group lead).
+echo "$$" >"$PIDFILE"
+
+# Clear any stale sentinel from a previous run on the same runner.
+rm -f "$STOP"
+
+restart=0
+while [[ ! -f "$STOP" ]]; do
+    if [[ "$restart" -gt 0 ]]; then
+        echo "[pf-supervisor] $(date -u +%H:%M:%S) restart #${restart}: kubectl port-forward ${TARGET} ${PORTS} -n ${NS}" >>"$LOG"
+    else
+        echo "[pf-supervisor] $(date -u +%H:%M:%S) starting: kubectl port-forward ${TARGET} ${PORTS} -n ${NS}" >>"$LOG"
+    fi
+
+    kubectl port-forward "$TARGET" "$PORTS" -n "$NS" </dev/null >>"$LOG" 2>&1 || true
+
+    # Asked to stop while kubectl was running: exit without restarting.
+    [[ -f "$STOP" ]] && break
+
+    restart=$((restart + 1))
+    echo "[pf-supervisor] $(date -u +%H:%M:%S) port-forward exited; restarting in 1s" >>"$LOG"
+    sleep 1
+done
+
+echo "[pf-supervisor] $(date -u +%H:%M:%S) stop sentinel found; exiting after ${restart} restart(s)" >>"$LOG"

--- a/.github/actions/camunda-smoke-test/scripts/port-forward.sh
+++ b/.github/actions/camunda-smoke-test/scripts/port-forward.sh
@@ -48,7 +48,9 @@ STOP="${BASE}.stop"
 # kubectl child as a process group (setsid makes this PID the group lead).
 echo "$$" >"$PIDFILE"
 
-# Clear any stale sentinel from a previous run on the same runner.
+# Start each run with a clean log and no stale stop sentinel, so reused
+# (self-hosted) runners don't mix output from previous runs.
+: >"$LOG"
 rm -f "$STOP"
 
 restart=0


### PR DESCRIPTION
## Motivation

The Camunda smoke test (`.github/actions/camunda-smoke-test`) fails intermittently on Kubernetes targets — reproducibly on EKS single-region (`domain` and `irsa` legs) — at the verification phase:

```
Attempt 1..30/30: HTTP 000000, found 0 (need >= 10)
FAIL: Found 0 process instances (expected >= 10)
```

Only `146/1485` process instances got created, and all 30 verify attempts returned `HTTP 000000` (a client-side connection failure, not a Camunda error — the empty-filter diagnostic probe is also `000`).

### Root cause

The action reaches Zeebe and Keycloak through a single `kubectl port-forward` each. kubectl tunnels over **one SPDY/TCP stream**, and managed cloud load balancers / some CNIs reap that stream after ~30-60s of low activity. The one-shot port-forward then **exits and was never restarted**, so the local port goes dead mid-test. The smoke script already documents that it can't restart the forward itself (the forward is owned by `action.yml`).

## What this PR does

Adds a small supervisor `scripts/port-forward.sh` that restarts `kubectl port-forward` whenever it exits, until a stop sentinel file is dropped. Both the Zeebe and Keycloak forwards now run through it (still detached via `setsid nohup` so they survive the composite-action step boundary). The cleanup step drops the sentinel and kills the supervisor's **process group**, so kubectl dies with it (no orphaned forwards).

- `scripts/port-forward.sh` — new resilient supervisor (`namespace target ports base` → `<base>.log` / `.pid` / `.stop`).
- `action.yml` — Zeebe + Keycloak port-forwards routed through the supervisor; cleanup uses sentinel + process-group kill.

No behavior change for non-Kubernetes callers (ECS/EC2 use a direct address and skip the port-forward steps).

## Validation

- `shellcheck` + `bash -n` clean on the new script; `yamllint` clean on `action.yml`.
- pre-commit hooks pass (incl. `check that scripts with shebangs are executable`; the script is committed `100755`).
- Functional test with a stub `kubectl` that exits after 1s: supervisor auto-restarts the forward and exits cleanly once the stop sentinel is dropped.

## Related

Unblocks the EKS-single-region smoke failures seen on #2641 (those were this port-forward drop, unrelated to that PR's matrix change).
