### PR TITLE
fix(kind): gate domain deploy on Keycloak readiness; harden CI JWKS warmup (#2686)

### DIFF
--- a/.github/actions/internal-camunda-chart-tests/action.yml
+++ b/.github/actions/internal-camunda-chart-tests/action.yml
@@ -473,7 +473,6 @@ runs:
           env:
               NAMESPACE: ${{ inputs.test-namespace }}
               ELASTICSEARCH_ENABLED: ${{ inputs.elasticsearch-enabled }}
-              KEYCLOAK_SERVICE_NAME: ${{ inputs.keycloak-service-name }}
           run: |
               set -euo pipefail
 
@@ -500,19 +499,11 @@ runs:
                 OS_COMPONENTS="${OS_COMPONENTS},optimize"
               fi
 
+              # PostgreSQL components checked for IRSA. Camunda 8.10 (chart 15.x)
+              # dropped the bundled Bitnami subcharts: Keycloak now runs via the
+              # Keycloak operator backed by CloudNativePG (no Aurora/IRSA), so
+              # there is no identityKeycloak component to check here.
               PG_COMPONENTS="identity"
-
-              # The bundled identityKeycloak (Bitnami) subchart only backs Keycloak when no
-              # external/operator Keycloak is configured. With an operator-based Keycloak
-              # (keycloak-service-name set, e.g. "keycloak-service:18080"), identityKeycloak is
-              # disabled and never deployed, so its Helm values are absent and every
-              # identityKeycloak.* IRSA lookup fails (aws-irsa.sh exits 163). Only check it when
-              # the bundled subchart is actually part of the release.
-              if [[ -z "$KEYCLOAK_SERVICE_NAME" ]]; then
-                PG_COMPONENTS="identityKeycloak,${PG_COMPONENTS}"
-              else
-                echo "ℹ️ External/operator Keycloak detected ($KEYCLOAK_SERVICE_NAME); excluding bundled identityKeycloak from IRSA checks"
-              fi
 
               if [[ "${{ inputs.webmodeler-enabled }}" == "true" ]]; then
                 PG_COMPONENTS="${PG_COMPONENTS},webModeler"

--- a/.github/actions/internal-camunda-chart-tests/action.yml
+++ b/.github/actions/internal-camunda-chart-tests/action.yml
@@ -473,6 +473,7 @@ runs:
           env:
               NAMESPACE: ${{ inputs.test-namespace }}
               ELASTICSEARCH_ENABLED: ${{ inputs.elasticsearch-enabled }}
+              KEYCLOAK_SERVICE_NAME: ${{ inputs.keycloak-service-name }}
           run: |
               set -euo pipefail
 
@@ -499,7 +500,19 @@ runs:
                 OS_COMPONENTS="${OS_COMPONENTS},optimize"
               fi
 
-              PG_COMPONENTS="identityKeycloak,identity"
+              PG_COMPONENTS="identity"
+
+              # The bundled identityKeycloak (Bitnami) subchart only backs Keycloak when no
+              # external/operator Keycloak is configured. With an operator-based Keycloak
+              # (keycloak-service-name set, e.g. "keycloak-service:18080"), identityKeycloak is
+              # disabled and never deployed, so its Helm values are absent and every
+              # identityKeycloak.* IRSA lookup fails (aws-irsa.sh exits 163). Only check it when
+              # the bundled subchart is actually part of the release.
+              if [[ -z "$KEYCLOAK_SERVICE_NAME" ]]; then
+                PG_COMPONENTS="identityKeycloak,${PG_COMPONENTS}"
+              else
+                echo "ℹ️ External/operator Keycloak detected ($KEYCLOAK_SERVICE_NAME); excluding bundled identityKeycloak from IRSA checks"
+              fi
 
               if [[ "${{ inputs.webmodeler-enabled }}" == "true" ]]; then
                 PG_COMPONENTS="${PG_COMPONENTS},webModeler"

--- a/.github/actions/internal-camunda-chart-tests/action.yml
+++ b/.github/actions/internal-camunda-chart-tests/action.yml
@@ -416,12 +416,9 @@ runs:
 
               echo "🔍 Running deployment check..."
 
-              # Determine required containers based on what's enabled and Camunda version
+              # Determine required containers based on what's enabled.
               # For Camunda 8.8+, zeebe components are unified under 'orchestration'
-              CAMUNDA_MAJOR_VERSION=$(echo "${{ inputs.camunda-version }}" | cut -d. -f1)
-              CAMUNDA_MINOR_VERSION=$(echo "${{ inputs.camunda-version }}" | cut -d. -f2)
-
-              # Camunda 8.8+ uses 'zeebe' instead of 'zeebe,zeebe-gateway'
+              # and 'zeebe' replaces 'zeebe,zeebe-gateway'.
               REQUIRED_CONTAINERS="connector,zeebe"
 
               if [[ "${{ inputs.optimize-enabled }}" == "true" ]]; then
@@ -487,10 +484,6 @@ runs:
                 echo "⚠️ Elasticsearch is enabled, skipping IRSA checks"
                 exit 0
               fi
-
-              # Build component lists based on Camunda version
-              CAMUNDA_MAJOR_VERSION=$(echo "${{ inputs.camunda-version }}" | cut -d. -f1)
-              CAMUNDA_MINOR_VERSION=$(echo "${{ inputs.camunda-version }}" | cut -d. -f2)
 
               # Camunda 8.8+ uses 'orchestration' and 'optimize' for OpenSearch
               OS_COMPONENTS="orchestration"

--- a/.github/actions/internal-integration-tests/action.yml
+++ b/.github/actions/internal-integration-tests/action.yml
@@ -391,8 +391,13 @@ runs:
                       --data-urlencode "client_secret=${CLIENT_SECRET}" \
                       2>/dev/null | jq -r '.access_token // empty' || true)
                   [[ -n "$TOKEN" ]] && break
-                  echo "  attempt ${attempt}/12: M2M token not available yet (waiting 5s)"
-                  sleep 5
+                  # Don't log/sleep after the final attempt: the loop is about to
+                  # exit and the warning + graceful skip below handles the all-fail
+                  # path, so an extra "waiting 5s" message and delay are misleading.
+                  if [[ "$attempt" -lt 12 ]]; then
+                      echo "  attempt ${attempt}/12: M2M token not available yet (waiting 5s)"
+                      sleep 5
+                  fi
               done
               if [[ -z "$TOKEN" ]]; then
                   echo "::warning::Could not obtain M2M token for JWKS warmup; skipping"

--- a/.github/actions/internal-integration-tests/action.yml
+++ b/.github/actions/internal-integration-tests/action.yml
@@ -389,7 +389,7 @@ runs:
                       --data-urlencode "grant_type=client_credentials" \
                       --data-urlencode "client_id=${CLIENT_ID}" \
                       --data-urlencode "client_secret=${CLIENT_SECRET}" \
-                      2>/dev/null | jq -r '.access_token // empty' || true)
+                      2>/dev/null | jq -r '.access_token // empty' 2>/dev/null || true)
                   [[ -n "$TOKEN" ]] && break
                   # Don't log/sleep after the final attempt: the loop is about to
                   # exit and the warning + graceful skip below handles the all-fail

--- a/.github/actions/internal-integration-tests/action.yml
+++ b/.github/actions/internal-integration-tests/action.yml
@@ -375,13 +375,25 @@ runs:
               # is /auth/realms/camunda-platform/protocol/openid-connect/token.
               REALM_TOKEN_URL="${TOKEN_URL%/}/realms/camunda-platform/protocol/openid-connect/token"
               echo "Fetching M2M token from ${REALM_TOKEN_URL}"
-              TOKEN=$(curl -sf --connect-timeout 10 --max-time 30 \
-                  -X POST "$REALM_TOKEN_URL" \
-                  -H "Content-Type: application/x-www-form-urlencoded" \
-                  --data-urlencode "grant_type=client_credentials" \
-                  --data-urlencode "client_id=${CLIENT_ID}" \
-                  --data-urlencode "client_secret=${CLIENT_SECRET}" \
-                  | jq -r '.access_token // empty')
+              # The Keycloak token endpoint is reached through a kubectl
+              # port-forward that may not be ready the instant this step runs.
+              # A bare `TOKEN=$(curl -sf ... | jq ...)` aborts the whole step
+              # under `set -e -o pipefail` when curl can't connect yet (exit 7),
+              # before the best-effort skip below is reached. Tolerate that by
+              # neutralising the pipeline failure and retrying a few times.
+              TOKEN=""
+              for attempt in $(seq 1 12); do
+                  TOKEN=$(curl -sf --connect-timeout 10 --max-time 30 \
+                      -X POST "$REALM_TOKEN_URL" \
+                      -H "Content-Type: application/x-www-form-urlencoded" \
+                      --data-urlencode "grant_type=client_credentials" \
+                      --data-urlencode "client_id=${CLIENT_ID}" \
+                      --data-urlencode "client_secret=${CLIENT_SECRET}" \
+                      2>/dev/null | jq -r '.access_token // empty' || true)
+                  [[ -n "$TOKEN" ]] && break
+                  echo "  attempt ${attempt}/12: M2M token not available yet (waiting 5s)"
+                  sleep 5
+              done
               if [[ -z "$TOKEN" ]]; then
                   echo "::warning::Could not obtain M2M token for JWKS warmup; skipping"
                   exit 0

--- a/local/kubernetes/kind-single-region/procedure/operators-deploy.sh
+++ b/local/kubernetes/kind-single-region/procedure/operators-deploy.sh
@@ -114,6 +114,7 @@ if [[ "$CAMUNDA_MODE" == "domain" ]]; then
 
     probe_url="https://${CAMUNDA_DOMAIN}/auth/realms/master/.well-known/openid-configuration"
     max_attempts=60
+    probe_start=$SECONDS
     echo "Probing: ${probe_url}"
 
     for attempt in $(seq 1 "$max_attempts"); do
@@ -125,7 +126,7 @@ if [[ "$CAMUNDA_MODE" == "domain" ]]; then
         fi
 
         if [[ "$attempt" -eq "$max_attempts" ]]; then
-            echo "ERROR: Keycloak not reachable through the ingress after ~$((max_attempts * 5))s." >&2
+            echo "ERROR: Keycloak not reachable through the ingress after ${max_attempts} attempts ($((SECONDS - probe_start))s)." >&2
             echo "       URL: ${probe_url}" >&2
             echo "       Deploying Camunda now would crash-loop on OIDC discovery" >&2
             echo "       (camunda/camunda-deployment-references#2686); aborting." >&2

--- a/local/kubernetes/kind-single-region/procedure/operators-deploy.sh
+++ b/local/kubernetes/kind-single-region/procedure/operators-deploy.sh
@@ -29,6 +29,12 @@ fi
 CAMUNDA_NAMESPACE=${CAMUNDA_NAMESPACE:-camunda}
 CAMUNDA_MODE=${CAMUNDA_MODE:-no-domain}
 
+# Domain used for the ingress host and the OIDC issuer in domain mode.
+# Kept in sync with camunda-deploy-domain.sh and helm-values/values-domain.yml.
+# Exported so the Keycloak deploy.sh envsubst (issuer/hostname) picks it up.
+CAMUNDA_DOMAIN="${CAMUNDA_DOMAIN:-camunda.example.com}"
+export CAMUNDA_DOMAIN
+
 # Set CLUSTER_FILTER based on SECONDARY_STORAGE
 # When using Elasticsearch, only deploy PG clusters for Keycloak, Identity, and WebModeler
 # When using PostgreSQL (RDBMS mode), deploy all PG clusters including the Camunda database
@@ -80,12 +86,56 @@ echo "=== Deploying Keycloak ==="
     cd "$OPERATOR_BASE/keycloak"
 
     if [[ "$CAMUNDA_MODE" == "domain" ]]; then
-        export CAMUNDA_DOMAIN="camunda.example.com"
         KEYCLOAK_CONFIG_FILE="keycloak-instance-domain-contour.yml" ./deploy.sh
     else
         KEYCLOAK_CONFIG_FILE="keycloak-instance-no-domain.yml" ./deploy.sh
     fi
 )
+
+# 4. Domain mode: wait until Keycloak is actually reachable *through the Contour
+#    ingress* before returning (and therefore before Camunda is deployed).
+#
+#    The Keycloak CR reaching condition=Ready only means the pod is up; it does
+#    NOT guarantee that Contour has programmed the /auth route or that Envoy has
+#    a healthy upstream endpoint yet. If Camunda is deployed during that window,
+#    every component fails OIDC discovery against
+#    https://<domain>/auth/realms/camunda-platform with
+#    "503 Service Unavailable ... upstream connect error ... Connection refused"
+#    and crash-loops (camunda/camunda-deployment-references#2686).
+#
+#    We probe the realm-independent 'master' OIDC discovery document on purpose:
+#    the camunda-platform realm does not exist yet (Identity creates it at
+#    runtime, after the chart is installed), so gating on it would deadlock.
+#    Kind publishes Envoy on 127.0.0.1:443, so --resolve reaches the ingress
+#    without depending on /etc/hosts (which CI does not configure at this stage).
+if [[ "$CAMUNDA_MODE" == "domain" ]]; then
+    echo ""
+    echo "=== Waiting for Keycloak to be reachable through the ingress ==="
+
+    probe_url="https://${CAMUNDA_DOMAIN}/auth/realms/master/.well-known/openid-configuration"
+    max_attempts=60
+    echo "Probing: ${probe_url}"
+
+    for attempt in $(seq 1 "$max_attempts"); do
+        if curl -fsS -k -o /dev/null \
+            --resolve "${CAMUNDA_DOMAIN}:443:127.0.0.1" \
+            --connect-timeout 5 --max-time 10 "$probe_url"; then
+            echo "✓ Keycloak OIDC issuer reachable through the ingress"
+            break
+        fi
+
+        if [[ "$attempt" -eq "$max_attempts" ]]; then
+            echo "ERROR: Keycloak not reachable through the ingress after ~$((max_attempts * 5))s." >&2
+            echo "       URL: ${probe_url}" >&2
+            echo "       Deploying Camunda now would crash-loop on OIDC discovery" >&2
+            echo "       (camunda/camunda-deployment-references#2686); aborting." >&2
+            exit 1
+        fi
+
+        echo "  attempt ${attempt}/${max_attempts}: not reachable yet (waiting 5s)"
+        sleep 5
+    done
+fi
 
 echo ""
 echo "✓ All operators deployed successfully"


### PR DESCRIPTION
> **Scope — two related "not-ready Keycloak" fixes:**
> 1. **CI**: the integration-test JWKS warmup no longer aborts the step when the Keycloak port-forward isn't ready yet.
> 2. **kind**: the `domain` reference deploy now waits for the Keycloak OIDC issuer to be reachable **through the ingress** before installing Camunda — fixing the out-of-the-box crash-loop in #2686.
>
> Affected branches for the kind fix: `main` (this PR) + `stable/8.9` (#2652). `stable/8.8` uses the older NGINX + bundled-Keycloak kind setup and `stable/8.7`/`8.6` have no kind setup, so no further backport applies.

## Motivation

The AKS `single-region` (and other Kubernetes) integration-test jobs intermittently fail at the **"🧪 Run Go Integration Tests (replaces Venom)"** step with:

```
Fetching M2M token from http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/token
##[error]Process completed with exit code 7.
```

(Seen on PR #2650's AKS run; AKS single-region is also frequently red on `main` for this reason.)

### Root cause

The action warms up the Zeebe JWT path by first fetching an M2M token from Keycloak through a `kubectl port-forward` on `localhost:18080`. The fetch was a bare:

```bash
TOKEN=$(curl -sf ... | jq -r '.access_token // empty')
```

When the port-forward isn't ready the instant this step runs, `curl -sf` exits **7** (couldn't connect). Under `set -e -o pipefail` that aborts the **whole step** — *before* the existing `if [[ -z "$TOKEN" ]]; then ... skip` best-effort guard can run. So a transient port-forward race fails the entire integration-test job even though Camunda is healthy.

(This is the same port-forward-fragility class fixed for the smoke test in #2649/#2650, but in a different action — `internal-integration-tests` — and via a different code path: a `curl | jq` pipeline under `pipefail` rather than a missing supervisor.)

## What this PR does

Wraps the token fetch in a short retry loop (12 × 5s) and neutralises the pipeline failure (`2>/dev/null | jq ... || true`) so a not-yet-ready Keycloak no longer aborts the step. If no token is obtained after the retries, the **existing** warning + `exit 0` skip path is taken, exactly as intended.

Only `.github/actions/internal-integration-tests/action.yml` changes; behaviour is unchanged once Keycloak is reachable.

## Also fixes: local kind `domain` deploy crash-loop (#2686)

Issue #2686 reports the local **kind** `domain` reference architecture failing out of the box: the orchestration / identity pods crash-loop at startup with

```
Unable to connect to the Identity Provider endpoint `https://camunda.example.com/auth/realms/camunda-platform`
... 503 Service Unavailable ... upstream connect error ... Connection refused
```

This is the **same root-cause class** as the CI flakes above (Keycloak not ready when something talks to it), but at **deploy/runtime** instead of in the test harness:

- `procedure/operators-deploy.sh` waited only for the Keycloak **CR** to reach `condition=Ready`. That means the pod is up, but it does **not** guarantee Contour has programmed the `/auth` route or that Envoy has a healthy upstream endpoint yet.
- Camunda was then installed during that window; every component failed OIDC discovery and crash-looped. DNS / CoreDNS rewrite / TLS were all fine — the failure is one hop deeper (Envoy → Keycloak upstream).

### Fix

`operators-deploy.sh` (domain mode) now gates on the OIDC issuer being reachable **through the ingress** before it returns — and therefore before Camunda is deployed:

- Probes the realm-independent **`master`** OIDC discovery document. The `camunda-platform` realm does not exist yet (Identity creates it at runtime, after the chart is installed), so probing it would deadlock.
- Uses `curl --resolve <domain>:443:127.0.0.1`, so it does **not** depend on `/etc/hosts` (which CI does not configure at this stage). kind publishes Envoy on `127.0.0.1:443`, so this works both locally (`make domain.init`) and in the CI "Deploy operators" step, which both run `operators-deploy.sh`.

No new Makefile target, workflow step, or doc wiring is required: the gate lives inside the existing `operators-deploy.sh` boundary, so both paths inherit it. No-domain mode is unaffected (no ingress; the existing CR-ready wait already covers it).

## Validation

- `yamllint -c .lint/yamllint/.yamllint.yaml` passes; `shellcheck` + pre-commit hooks pass on `operators-deploy.sh`.
- Reproduced the CI abort and verified the JWKS fix: a `curl -sf` against an unreachable endpoint under `set -euo pipefail` now retries and reaches the graceful skip instead of aborting (exit 7).

## Related

- Closes #2686
- Unblocks the AKS integration-test failures seen on #2650 (which were this, not the smoke port-forward change).

## Opportunistic cleanup: drop dead bundled-Keycloak (Bitnami) IRSA branch (main only)

While here, removed now-dead code in `internal-camunda-chart-tests/action.yml`: the IRSA check conditionally prepended `identityKeycloak` to the PostgreSQL component list when `keycloak-service-name` was empty. On `main` (8.10 / chart 15.x) the bundled Bitnami subcharts are gone, `identityKeycloak` is absent from every chart value, and all test-matrix scenarios use `auth_provider: keycloak-operator` (so `keycloak-service-name` is always set) — the branch was unreachable.

Simplified to `PG_COMPONENTS="identity"` and dropped the now-unused `KEYCLOAK_SERVICE_NAME` env from that step (the `keycloak-service-name` input stays — it still targets the Keycloak port-forward). Generated action README is unchanged (interface untouched). **Not** backported to #2652: `stable/8.9` (chart 14.x) still ships the bundled `identityKeycloak`, so the conditional remains valid there.

Also removed two pre-existing unused shell variables (`CAMUNDA_MAJOR_VERSION` / `CAMUNDA_MINOR_VERSION`, computed-but-never-read since #1226) in the same `internal-camunda-chart-tests` action, and corrected the stale "based on Camunda version" comments. No functional change; the generated README is unaffected.
