### PR TITLE
fix(migration): exclude transient JGROUPS_PING from the Keycloak realm dump

### DIFF
--- a/generic/kubernetes/migration/README.md
+++ b/generic/kubernetes/migration/README.md
@@ -477,3 +477,29 @@ aws route53 change-resource-record-sets \
         "ResourceRecords":[{"Value":"keycloak-service.camunda.svc.cluster.local"}]
     }}]}'
 ```
+
+## Troubleshooting
+
+### Migrated Keycloak crashes on startup (`constraint_jgroups_ping`)
+
+If the migrated Keycloak enters `CrashLoopBackOff` with a startup error such as:
+
+```text
+ERROR: Failed to start server in (production) mode
+JDBC exception executing SQL [INSERT INTO JGROUPS_PING values (?, ?, ?, ?, ?)]
+duplicate key value violates unique constraint "constraint_jgroups_ping"
+  Detail: Key (address)=(uuid://...0002) already exists.
+```
+
+the realm dump carried over rows from `JGROUPS_PING`, Keycloak's transient JDBC_PING
+cluster-discovery table. Those rows hold the source cluster's node addresses and
+collide with the target's own startup membership insert.
+
+The migration scripts handle this automatically: `backup_pg` excludes the
+`JGROUPS_PING` table **data** (keeping its schema) from the Keycloak realm dump, so
+the target starts clean and re-registers its own membership. This applies to both
+`KEYCLOAK_TARGET_MODE=operator` and `KEYCLOAK_TARGET_MODE=external`.
+
+If you hit this on a custom or older pipeline, exclude the table data from the dump
+(`pg_dump --exclude-table-data=jgroups_ping …`) or `TRUNCATE jgroups_ping` in the
+target database before starting Keycloak.

--- a/generic/kubernetes/migration/jobs/pg-backup.job.yml
+++ b/generic/kubernetes/migration/jobs/pg-backup.job.yml
@@ -2,6 +2,8 @@
 # PostgreSQL Backup Job (generic, parameterized by COMPONENT)
 # Required env vars: COMPONENT, JOB_NAME, PG_HOST, PG_PORT, PG_DATABASE,
 #   PG_USERNAME, PG_SECRET_NAME, PG_SECRET_KEY, PG_IMAGE, BACKUP_PVC, NAMESPACE, TIMESTAMP
+# Optional: PG_DUMP_EXTRA_ARGS — extra pg_dump flags (e.g. --exclude-table-data
+#   to drop transient tables that must not cross clusters; see lib.sh backup_pg).
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -65,7 +67,7 @@ spec:
                         echo ""
 
                         pg_dump -h "${PG_HOST}" -p "${PG_PORT}" -U "$PGUSER" \
-                          -d "${PG_DATABASE}" -F custom \
+                          -d "${PG_DATABASE}" -F custom ${PG_DUMP_EXTRA_ARGS} \
                           -f /backup/${COMPONENT}/${COMPONENT}-db-${TIMESTAMP}.dump
 
                         echo "Backup complete:"

--- a/generic/kubernetes/migration/lib.sh
+++ b/generic/kubernetes/migration/lib.sh
@@ -1741,8 +1741,19 @@ backup_pg() {
     ensure_backup_pvc
     # shellcheck disable=SC2153
     export JOB_NAME="${COMPONENT}-pg-backup-${TIMESTAMP}"
+
+    # Keycloak's JGROUPS_PING is a transient JDBC_PING cluster-discovery table:
+    # its rows hold the SOURCE cluster's node addresses. Restoring them into a
+    # fresh Keycloak makes the target crash on startup with a duplicate-key on
+    # constraint_jgroups_ping. Exclude the DATA (keep the schema) so the target
+    # starts clean and re-registers its own membership.
+    export PG_DUMP_EXTRA_ARGS=""
+    if [[ "${COMPONENT}" == "keycloak" ]]; then
+        PG_DUMP_EXTRA_ARGS="--exclude-table-data=jgroups_ping"
+    fi
+
     # shellcheck disable=SC2016
-    local pg_varlist='${JOB_NAME} ${NAMESPACE} ${COMPONENT} ${PG_IMAGE} ${PG_HOST} ${PG_PORT} ${PG_DATABASE} ${PG_USERNAME} ${PG_SECRET_NAME} ${PG_SECRET_KEY} ${BACKUP_PVC} ${TIMESTAMP}'
+    local pg_varlist='${JOB_NAME} ${NAMESPACE} ${COMPONENT} ${PG_IMAGE} ${PG_HOST} ${PG_PORT} ${PG_DATABASE} ${PG_USERNAME} ${PG_SECRET_NAME} ${PG_SECRET_KEY} ${BACKUP_PVC} ${TIMESTAMP} ${PG_DUMP_EXTRA_ARGS}'
     run_job "${JOBS_DIR}/pg-backup.job.yml" "${JOB_NAME}" 1800 "$pg_varlist"
 }
 

--- a/generic/kubernetes/migration/lib.sh
+++ b/generic/kubernetes/migration/lib.sh
@@ -1746,10 +1746,17 @@ backup_pg() {
     # its rows hold the SOURCE cluster's node addresses. Restoring them into a
     # fresh Keycloak makes the target crash on startup with a duplicate-key on
     # constraint_jgroups_ping. Exclude the DATA (keep the schema) so the target
-    # starts clean and re-registers its own membership.
+    # starts clean and re-registers its own membership. This applies to both
+    # Keycloak target modes (operator and external) — each restores the realm
+    # dump into a fresh Keycloak.
+    #
+    # PostgreSQL folds unquoted identifiers to lowercase, so the table is
+    # normally "jgroups_ping"; the uppercase spelling is passed too in case a
+    # build created it quoted. An exclude-table-data pattern that matches
+    # nothing is a harmless no-op (never an error, regardless of --strict-names).
     export PG_DUMP_EXTRA_ARGS=""
     if [[ "${COMPONENT}" == "keycloak" ]]; then
-        PG_DUMP_EXTRA_ARGS="--exclude-table-data=jgroups_ping"
+        PG_DUMP_EXTRA_ARGS="--exclude-table-data=jgroups_ping --exclude-table-data=JGROUPS_PING"
     fi
 
     # shellcheck disable=SC2016


### PR DESCRIPTION
## Problem

The Bitnami→external Keycloak realm migration (`generic/kubernetes/migration`) does a full `pg_dump`/`pg_restore` of the Keycloak database, which **includes `JGROUPS_PING`** — Keycloak's JDBC_PING *cluster-discovery* table. Its rows hold the **source** cluster's node addresses. Restored into a fresh target Keycloak, they collide with the target's startup membership insert:

```
ERROR: Failed to start server in (production) mode
JDBC exception executing SQL [INSERT INTO JGROUPS_PING values (?, ?, ?, ?, ?)]
duplicate key value violates unique constraint "constraint_jgroups_ping"
  Detail: Key (address)=(uuid://...0002) already exists.
```

→ the migrated Keycloak `CrashLoopBackOff`s and never serves the restored realm.

## Fix

`backup_pg()` now passes `--exclude-table-data=jgroups_ping` for the **keycloak** component (via a new optional `PG_DUMP_EXTRA_ARGS` that the backup job appends to `pg_dump`). The table **schema** is preserved (restored empty); only the transient cluster-membership rows are dropped, so the target re-registers its own membership on boot. Identity/WebModeler dumps are unaffected — the variable is empty for them.

Restore already does `DROP SCHEMA public CASCADE` + `pg_restore --clean` under `FORCE_RESTORE=true`, so the target gets the dump's empty `jgroups_ping` and starts clean.

## How it was found

Discovered while validating the camunda-platform-helm **post-infra migration hook** (camunda/camunda-platform-helm#6343) on a real **8.9→8.10 modular-upgrade** on GKE. Every data-plane step succeeded — external-target detection, Bitnami Keycloak PG backup, ES warm reindex (9 indices), Phase 3 cutover, **realm restore confirmed** (`camunda-platform` + `master` realms present in the companion Keycloak DB). The carried-over `JGROUPS_PING` row was the **sole** blocker.

## Validation

`bash -n` clean; `envsubst` smoke test confirms the keycloak `pg_dump` gets the flag and other components stay unaffected. Re-running the full GKE 8.9→8.10 migration against this branch to confirm the migrated Keycloak now starts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)