### PR TITLE
ci(migration): reclaim dind image cache and report disk usage in heavy runs

### DIFF
--- a/.github/workflows/_migration_test_run.yml
+++ b/.github/workflows/_migration_test_run.yml
@@ -242,6 +242,19 @@ jobs:
                       rm -f "${archive}"
                   done
 
+                  # The pulled images now live inside each Kind node's own
+                  # containerd store (loaded via `ctr images import` above), so
+                  # the copies still held by the host (dind) Docker daemon are
+                  # redundant for the deployment — Kind never reads from the host
+                  # daemon. On the heavy benchmark these copies are several GB
+                  # that push the runner node toward DiskPressure (which evicts
+                  # pods and breaks the run). Drop them now that side-load is
+                  # done. `kindest/node` backs the running node containers, so
+                  # `docker image prune` keeps it.
+                  echo "Reclaiming host (dind) image cache after side-load..."
+                  docker image prune -af || true
+                  docker system df || true
+
                   echo "Pre-pull complete."
 
             - name: Deploy Camunda with Bitnami sub-charts
@@ -421,6 +434,25 @@ jobs:
 
                   echo "Data propagation complete"
 
+            # Disk consumed by the Kind nodes + images lives in the dind Docker
+            # daemon, so `docker system df` is the metric that tracks node
+            # DiskPressure (`df -h` is best-effort from the runner container).
+            # Logged at the data-generation and cutover boundaries so the heavy
+            # run's disk high-water mark can be measured and the runner volume
+            # sized accordingly.
+            - name: Report disk usage (after data generation)
+              if: always()
+              run: |
+                  set -euo pipefail
+                  {
+                    echo "### Disk usage — after data generation (scenario: ${BENCHMARK_SCENARIO:-light})"
+                    echo '```'
+                    docker system df || true
+                    echo ""
+                    df -h || true
+                    echo '```'
+                  } | tee -a "$GITHUB_STEP_SUMMARY"
+
             # =================================================================
             # STEP 2: Run Migration (4 phases)
             # =================================================================
@@ -527,6 +559,22 @@ jobs:
                   fi
 
                   ./3-cutover.sh --yes
+
+            # Peak disk: source (Bitnami) and target (ECK) Elasticsearch both
+            # hold the full data set at cutover, so this is the high-water mark
+            # used to size the dedicated runner volume.
+            - name: Report disk usage (after cutover)
+              if: always()
+              run: |
+                  set -euo pipefail
+                  {
+                    echo "### Disk usage — after cutover, peak: source + target ES (scenario: ${BENCHMARK_SCENARIO:-light})"
+                    echo '```'
+                    docker system df || true
+                    echo ""
+                    df -h || true
+                    echo '```'
+                  } | tee -a "$GITHUB_STEP_SUMMARY"
 
             - name: 🔍 Check for Helm deprecation warnings (after cutover)
               uses: ./.github/actions/internal-helm-deprecation-check


### PR DESCRIPTION
## Context

The **Tests - Integration - Generic Migration from Bitnami** heavy jobs
(`Kind-Heavy-Domain`, `Kind-Heavy-WarmReindex-Domain`) build a 4-node Kind
cluster, two full Elasticsearch clusters (Bitnami source + ECK target, migrated
via remote `_reindex`) and ~20 GB of benchmark data — all on a single
`aws-core-16-longrunning` runner node disk (~100 GB).

The node reaches **DiskPressure**, the kubelet evicts pods, and that takes down
**co-tenant runner pods of unrelated workflows** (the "runner lost
communication" failures InfraEx reported, e.g. run `27311141304`).

This PR ships the **low-risk, our-side** reductions. The dedicated bigger-disk /
ephemeral-EBS runner remains an InfraEx-side follow-up.

## Changes (`_migration_test_run.yml`)

- **Reclaim the host (dind) image cache after side-load.** Images are pre-pulled
  on the host Docker daemon and then `ctr images import`ed into each Kind node's
  own containerd. Once side-loaded, the host-level copies are redundant (Kind
  never reads from the host daemon) and only consume runner disk — several GB on
  the heavy run. `docker image prune -af` drops them; `kindest/node` stays since
  it backs the running node containers.
- **Instrument disk usage** (`docker system df` + `df -h`) after data generation
  and after cutover (the source + target ES high-water mark), written to the job
  summary. `docker system df` is the metric that tracks the dind daemon usage
  driving node DiskPressure. This lets us measure the real peak and size the
  dedicated runner volume.

## Non-goals / what this does NOT change

- No change to the **test topology** (still 4-node Kind, 2 ES clusters, remote
  `_reindex`).
- No change to the **data volume** or **coverage** (heavy benchmark stays
  ~20 GB — the migration realism is the point of the test).
- Not a full fix on its own: the cutover peak (both ES full at once) is inherent
  to the migration test, so a dedicated/bigger runner disk is still the primary
  remediation (tracked separately with InfraEx).

## Testing

- `actionlint` v1.7.12 → clean.
- `yamllint`, `yamlfmt`, `check-yaml`, `end-of-file-fixer`, `trailing-whitespace`
  → pass.
- The disk-report steps use `if: always()`, so they also capture disk state when
  an upstream step fails (useful for the ongoing DiskPressure investigation).
