### PR TITLE
perf(ec2): cache distro & connectors downloads across nodes (8.8 backport of #2657)

### DIFF
--- a/.github/workflows/aws_compute_ec2_single_region_tests.yml
+++ b/.github/workflows/aws_compute_ec2_single_region_tests.yml
@@ -293,6 +293,11 @@ jobs:
                   CAMUNDA_CONNECTORS_PREVIOUS_VERSION: ${{ env.TESTS_CONNECTORS_PREVIOUS_VERSION }}
                   CAMUNDA_DISTRO_USER: ${{ steps.artifactory-credentials.outputs.ARTIFACTORY_USR }}
                   CAMUNDA_DISTRO_PASSWORD: ${{ steps.artifactory-credentials.outputs.ARTIFACTORY_PSW }}
+                  # Download the distribution + connectors bundle once on the runner and stage them
+                  # on every node, instead of each node (x3) re-downloading from Artifactory on every
+                  # install. The dir persists for the whole job, so re-installs (CloudWatch, upgrade)
+                  # reuse it too. This is the main lever to cut our Artifactory egress.
+                  CAMUNDA_DISTRO_CACHE_DIR: ${{ runner.temp }}/camunda-distro-cache
                   CAMUNDA_BASIC_AUTH_USER: ${{ steps.camunda-credentials.outputs.CAMUNDA_BASIC_AUTH_USER }}
                   CAMUNDA_BASIC_AUTH_PASSWORD: ${{ steps.camunda-credentials.outputs.CAMUNDA_BASIC_AUTH_PASSWORD }}
               run: |

--- a/.github/workflows/aws_compute_ec2_single_region_tests.yml
+++ b/.github/workflows/aws_compute_ec2_single_region_tests.yml
@@ -293,11 +293,15 @@ jobs:
                   CAMUNDA_CONNECTORS_PREVIOUS_VERSION: ${{ env.TESTS_CONNECTORS_PREVIOUS_VERSION }}
                   CAMUNDA_DISTRO_USER: ${{ steps.artifactory-credentials.outputs.ARTIFACTORY_USR }}
                   CAMUNDA_DISTRO_PASSWORD: ${{ steps.artifactory-credentials.outputs.ARTIFACTORY_PSW }}
-                  # Download the distribution + connectors bundle once on the runner and stage them
-                  # on every node, instead of each node (x3) re-downloading from Artifactory on every
-                  # install. The dir persists for the whole job, so re-installs (CloudWatch, upgrade)
-                  # reuse it too. This is the main lever to cut our Artifactory egress.
+                  # Download the distribution + connectors bundle once and stage them on every node,
+                  # instead of each node (x3) re-downloading from Artifactory on every install. The
+                  # cache dir persists for the whole job, so re-installs (CloudWatch, upgrade) reuse
+                  # it too. This is the main lever to cut our Artifactory egress. The caching logic
+                  # lives in a CI-only helper (test/ci-distro-cache.sh) so the customer-facing
+                  # procedure scripts stay free of it; all-in-one-install.sh sources it only when
+                  # CAMUNDA_DISTRO_CACHE_LIB is set.
                   CAMUNDA_DISTRO_CACHE_DIR: ${{ runner.temp }}/camunda-distro-cache
+                  CAMUNDA_DISTRO_CACHE_LIB: ${{ github.workspace }}/aws/compute/ec2-single-region/test/ci-distro-cache.sh
                   CAMUNDA_BASIC_AUTH_USER: ${{ steps.camunda-credentials.outputs.CAMUNDA_BASIC_AUTH_USER }}
                   CAMUNDA_BASIC_AUTH_PASSWORD: ${{ steps.camunda-credentials.outputs.CAMUNDA_BASIC_AUTH_PASSWORD }}
               run: |

--- a/aws/compute/ec2-single-region/procedure/all-in-one-install.sh
+++ b/aws/compute/ec2-single-region/procedure/all-in-one-install.sh
@@ -5,6 +5,15 @@ CURRENT_DIR="$(dirname "$0")"
 
 source "${CURRENT_DIR}/helpers.sh"
 
+# Optional download-cache helpers. By default this is a no-op: every node downloads its own
+# artifacts directly (see camunda-install.sh). Our CI sets CAMUNDA_DISTRO_CACHE_LIB to a small
+# helper that downloads the distribution + connectors once and stages them on each node, so this
+# reference procedure stays free of any CI/caching plumbing.
+if [[ -n "${CAMUNDA_DISTRO_CACHE_LIB:-}" && -f "${CAMUNDA_DISTRO_CACHE_LIB}" ]]; then
+    # shellcheck source=/dev/null
+    source "${CAMUNDA_DISTRO_CACHE_LIB}"
+fi
+
 CLOUDWATCH_ENABLED=${CLOUDWATCH_ENABLED:-false}
 USERNAME=${USERNAME:-"camunda"}
 ADMIN_USERNAME=${ADMIN_USERNAME:-"ubuntu"}
@@ -14,153 +23,6 @@ TERRAFORM_DIR=${TERRAFORM_DIR:-"${CURRENT_DIR}/../terraform/cluster"}
 
 CAMUNDA_DISTRO_USER=${CAMUNDA_DISTRO_USER:-""}
 CAMUNDA_DISTRO_PASSWORD=${CAMUNDA_DISTRO_PASSWORD:-""}
-
-# Optional shared download cache (used in CI). When CAMUNDA_DISTRO_CACHE_DIR is set, this
-# orchestrator downloads the Camunda distribution + connectors bundle ONCE and stages them on
-# every node, instead of each node downloading the same artifacts from Artifactory. This
-# removes the per-node (and, because the cache dir persists for the whole job, the per-reinstall)
-# duplication that dominates our Artifactory egress.
-# Leave it unset for a normal (customer) run: nodes then download individually, exactly as before.
-CAMUNDA_DISTRO_CACHE_DIR=${CAMUNDA_DISTRO_CACHE_DIR:-""}
-# Where staged files land on each node. Must match camunda-install.sh's CAMUNDA_DISTRO_CACHE_DIR.
-REMOTE_DISTRO_CACHE_DIR="/tmp/.camunda-distro-cache"
-DISTRO_CACHE_READY=false
-# Orchestrator-side cached files for the version currently being installed (empty when not
-# cached). Populated by warm_distro_cache, consumed by push_distro_cache_to_node.
-CACHED_TARBALL_PATH=""
-CACHED_JAR_PATH=""
-
-# Resolve the effective default of a 'VAR=${VAR:-"x"}' (or plain 'VAR=x') assignment in a script.
-script_default() {
-    local var="$1" file="$2" line
-    line=$(grep -E "^${var}=" "${file}" | head -1 || true)
-    line=${line#*=}
-    if [[ "${line}" =~ :-\"?([^\"\}]*)\"?\} ]]; then
-        printf '%s' "${BASH_REMATCH[1]}"
-    else
-        line=${line%\"}
-        line=${line#\"}
-        printf '%s' "${line}"
-    fi
-}
-
-# Download the Camunda distribution and connectors bundle once on this orchestrator host so
-# every node can reuse them. Files are keyed by version, so the upgrade test (previous -> current
-# within the same job) never reuses the wrong artifact. Best-effort: on any failure the cache is
-# left empty and nodes fall back to downloading individually.
-# NOTE: keep the artifact URLs/resolution in sync with
-#       generic/compute/debian/procedure/camunda-install.sh
-warm_distro_cache() {
-    DISTRO_CACHE_READY=false
-    CACHED_TARBALL_PATH=""
-    CACHED_JAR_PATH=""
-
-    # Parse the very same script piped to each node below ("ssh ... < camunda-install.sh") so the
-    # cached artifacts always match what the nodes install -- including the in-place edits the
-    # upgrade test makes to this file. (env vars do NOT cross the SSH boundary; the node uses these
-    # defaults too.)
-    local install_script="${CURRENT_DIR}/camunda-install.sh"
-    local camunda_version connectors_version
-    camunda_version=$(script_default "CAMUNDA_VERSION" "${install_script}")
-    connectors_version=$(script_default "CAMUNDA_CONNECTORS_VERSION" "${install_script}")
-
-    if [[ -z "${camunda_version}" || -z "${connectors_version}" ]]; then
-        echo "[WARN] Could not parse Camunda/Connectors versions from ${install_script}; skipping download cache."
-        return 0
-    fi
-
-    local netrc_opt="" netrc_file=""
-    if [[ -n "${CAMUNDA_DISTRO_USER}" && -n "${CAMUNDA_DISTRO_PASSWORD}" ]]; then
-        netrc_file=$(mktemp)
-        chmod 600 "${netrc_file}"
-        printf 'machine artifacts.camunda.com login %s password %s\n' "${CAMUNDA_DISTRO_USER}" "${CAMUNDA_DISTRO_PASSWORD}" > "${netrc_file}"
-        netrc_opt="--netrc-file ${netrc_file}"
-    fi
-
-    mkdir -p "${CAMUNDA_DISTRO_CACHE_DIR}" || { echo "[WARN] Cannot create ${CAMUNDA_DISTRO_CACHE_DIR}; skipping download cache."; return 0; }
-    local tarball="${CAMUNDA_DISTRO_CACHE_DIR}/camunda-zeebe-${camunda_version}.tar.gz"
-    local jar="${CAMUNDA_DISTRO_CACHE_DIR}/connectors-${connectors_version}.jar"
-
-    # --- Camunda distribution ---
-    if [[ -f "${tarball}" ]]; then
-        echo "[INFO] Reusing cached Camunda distribution at ${tarball}."
-    else
-        local camunda_url=""
-        if [[ "${camunda_version}" =~ SNAPSHOT ]]; then
-            local snap=""
-            # shellcheck disable=SC2086
-            snap=$(curl -sfL ${netrc_opt} "https://artifacts.camunda.com/artifactory/zeebe/io/camunda/camunda-zeebe/${camunda_version}/maven-metadata.xml" | grep -A 1 "<extension>tar.gz</extension>" | grep "<value>" | sed -e 's/<[^>]*>//g' -e 's/^[ \t]*//' || true)
-            camunda_url="https://artifacts.camunda.com/artifactory/zeebe/io/camunda/camunda-zeebe/${camunda_version}/camunda-zeebe-${snap}.tar.gz"
-        else
-            camunda_url="https://artifacts.camunda.com/artifactory/zeebe/io/camunda/camunda-zeebe/${camunda_version}/camunda-zeebe-${camunda_version}.tar.gz"
-        fi
-        echo "[INFO] Caching Camunda distribution ${camunda_version} once for all nodes..."
-        # shellcheck disable=SC2086
-        if ! curl -fL ${netrc_opt} "${camunda_url}" -o "${tarball}"; then
-            echo "[WARN] Failed to cache Camunda distribution; nodes will download it individually."
-            rm -f "${tarball}"
-        fi
-    fi
-    [[ -f "${tarball}" ]] && CACHED_TARBALL_PATH="${tarball}"
-
-    # --- Connectors bundle ---
-    if [[ -f "${jar}" ]]; then
-        echo "[INFO] Reusing cached connectors bundle at ${jar}."
-    else
-        local jar_url=""
-        if [[ "${connectors_version}" =~ SNAPSHOT ]]; then
-            local snap=""
-            # shellcheck disable=SC2086
-            snap=$(curl -sfL ${netrc_opt} "https://artifacts.camunda.com/artifactory/connectors-snapshots/io/camunda/connector/connector-runtime-bundle/${connectors_version}/maven-metadata.xml" | grep -A 1 "<extension>pom</extension>" | grep "<value>" | sed -e 's/<[^>]*>//g' -e 's/^[ \t]*//' || true)
-            jar_url="https://artifacts.camunda.com/artifactory/connectors-snapshots/io/camunda/connector/connector-runtime-bundle/${connectors_version}/connector-runtime-bundle-${snap}-with-dependencies.jar"
-        else
-            jar_url="https://artifacts.camunda.com/artifactory/connectors/io/camunda/connector/connector-runtime-bundle/${connectors_version}/connector-runtime-bundle-${connectors_version}-with-dependencies.jar"
-        fi
-        echo "[INFO] Caching connectors bundle ${connectors_version} once for all nodes..."
-        # shellcheck disable=SC2086
-        if ! curl -fL ${netrc_opt} "${jar_url}" -o "${jar}"; then
-            echo "[WARN] Failed to cache connectors bundle; nodes will download it individually."
-            rm -f "${jar}"
-        fi
-    fi
-    [[ -f "${jar}" ]] && CACHED_JAR_PATH="${jar}"
-
-    [[ -n "${netrc_file}" ]] && rm -f "${netrc_file}"
-
-    if [[ -n "${CACHED_TARBALL_PATH}" || -n "${CACHED_JAR_PATH}" ]]; then
-        DISTRO_CACHE_READY=true
-    fi
-}
-
-# Stage whichever cached artifacts exist onto the current node (${ip}), under the fixed path the
-# install script looks at. Best-effort: a failure just means that node downloads it itself.
-push_distro_cache_to_node() {
-    remote_cmd "mkdir -p ${REMOTE_DISTRO_CACHE_DIR}" || { echo "[WARN] Could not prepare cache dir on ${ip}; it will download individually."; return 0; }
-
-    if [[ -n "${CACHED_TARBALL_PATH}" && -f "${CACHED_TARBALL_PATH}" ]]; then
-        if sftp -J "${ADMIN_USERNAME}@${BASTION_IP}" "${ADMIN_USERNAME}@${ip}" >/dev/null 2>&1 <<EOF
-put "${CACHED_TARBALL_PATH}" "${REMOTE_DISTRO_CACHE_DIR}/camunda.tar.gz"
-bye
-EOF
-        then
-            remote_cmd "chmod 644 ${REMOTE_DISTRO_CACHE_DIR}/camunda.tar.gz" || true
-        else
-            echo "[WARN] Failed to stage cached distribution on ${ip}; it will download individually."
-        fi
-    fi
-
-    if [[ -n "${CACHED_JAR_PATH}" && -f "${CACHED_JAR_PATH}" ]]; then
-        if sftp -J "${ADMIN_USERNAME}@${BASTION_IP}" "${ADMIN_USERNAME}@${ip}" >/dev/null 2>&1 <<EOF
-put "${CACHED_JAR_PATH}" "${REMOTE_DISTRO_CACHE_DIR}/connectors.jar"
-bye
-EOF
-        then
-            remote_cmd "chmod 644 ${REMOTE_DISTRO_CACHE_DIR}/connectors.jar" || true
-        else
-            echo "[WARN] Failed to stage cached connectors bundle on ${ip}; it will download individually."
-        fi
-    fi
-}
 
 check_tool_installed "ssh"
 check_tool_installed "openssl"
@@ -215,10 +77,9 @@ done
 ips_list=${ips_list%,}
 total_ip_count=${#IPS[@]}
 
-# When a shared cache dir is configured (CI), download the distribution + connectors bundle once
-# here so the per-node loop below copies them instead of each node hitting Artifactory.
-if [[ -n "${CAMUNDA_DISTRO_CACHE_DIR}" ]]; then
-    echo "[INFO] Distribution download cache enabled (CAMUNDA_DISTRO_CACHE_DIR=${CAMUNDA_DISTRO_CACHE_DIR})."
+# Optionally pre-download the artifacts once for all nodes (no-op unless the cache helper above is
+# loaded, i.e. in CI).
+if declare -F warm_distro_cache >/dev/null; then
     warm_distro_cache
 fi
 
@@ -238,14 +99,10 @@ for index in "${!IPS[@]}"; do
             'cat > /tmp/.camunda-distro-credentials && chmod 600 /tmp/.camunda-distro-credentials'
     fi
 
-    # Stage the pre-downloaded artifacts on the node. Always start from a clean node cache so a
-    # previous install round (e.g. the upgrade test's other version) is never reused. No-op when
-    # the cache is disabled.
-    if [[ -n "${CAMUNDA_DISTRO_CACHE_DIR}" ]]; then
-        remote_cmd "rm -rf ${REMOTE_DISTRO_CACHE_DIR}" || true
-        if [[ "${DISTRO_CACHE_READY}" == "true" ]]; then
-            push_distro_cache_to_node
-        fi
+    # Optionally stage the pre-downloaded artifacts on this node (no-op unless the cache helper is
+    # loaded). The install script then copies them instead of downloading.
+    if declare -F push_distro_cache_to_node >/dev/null; then
+        push_distro_cache_to_node "${ip}"
     fi
 
     ssh -J "${ADMIN_USERNAME}@${BASTION_IP}" "${ADMIN_USERNAME}@${ip}" < "${CURRENT_DIR}/camunda-install.sh"

--- a/aws/compute/ec2-single-region/procedure/all-in-one-install.sh
+++ b/aws/compute/ec2-single-region/procedure/all-in-one-install.sh
@@ -105,7 +105,15 @@ for index in "${!IPS[@]}"; do
         push_distro_cache_to_node "${ip}"
     fi
 
-    ssh -J "${ADMIN_USERNAME}@${BASTION_IP}" "${ADMIN_USERNAME}@${ip}" < "${CURRENT_DIR}/camunda-install.sh"
+    # Pipe the install script to the node. When the optional cache helper is loaded it prepends an
+    # opt-in export so the node consults the staged artifacts; otherwise only the script is sent and
+    # the node downloads from Artifactory as usual.
+    {
+        if declare -F distro_install_prelude >/dev/null; then
+            distro_install_prelude
+        fi
+        cat "${CURRENT_DIR}/camunda-install.sh"
+    } | ssh -J "${ADMIN_USERNAME}@${BASTION_IP}" "${ADMIN_USERNAME}@${ip}"
 
     echo "[INFO] Attempting to connect to ${ip} to configure the Camunda 8 environment."
 

--- a/aws/compute/ec2-single-region/procedure/all-in-one-install.sh
+++ b/aws/compute/ec2-single-region/procedure/all-in-one-install.sh
@@ -15,6 +15,153 @@ TERRAFORM_DIR=${TERRAFORM_DIR:-"${CURRENT_DIR}/../terraform/cluster"}
 CAMUNDA_DISTRO_USER=${CAMUNDA_DISTRO_USER:-""}
 CAMUNDA_DISTRO_PASSWORD=${CAMUNDA_DISTRO_PASSWORD:-""}
 
+# Optional shared download cache (used in CI). When CAMUNDA_DISTRO_CACHE_DIR is set, this
+# orchestrator downloads the Camunda distribution + connectors bundle ONCE and stages them on
+# every node, instead of each node downloading the same artifacts from Artifactory. This
+# removes the per-node (and, because the cache dir persists for the whole job, the per-reinstall)
+# duplication that dominates our Artifactory egress.
+# Leave it unset for a normal (customer) run: nodes then download individually, exactly as before.
+CAMUNDA_DISTRO_CACHE_DIR=${CAMUNDA_DISTRO_CACHE_DIR:-""}
+# Where staged files land on each node. Must match camunda-install.sh's CAMUNDA_DISTRO_CACHE_DIR.
+REMOTE_DISTRO_CACHE_DIR="/tmp/.camunda-distro-cache"
+DISTRO_CACHE_READY=false
+# Orchestrator-side cached files for the version currently being installed (empty when not
+# cached). Populated by warm_distro_cache, consumed by push_distro_cache_to_node.
+CACHED_TARBALL_PATH=""
+CACHED_JAR_PATH=""
+
+# Resolve the effective default of a 'VAR=${VAR:-"x"}' (or plain 'VAR=x') assignment in a script.
+script_default() {
+    local var="$1" file="$2" line
+    line=$(grep -E "^${var}=" "${file}" | head -1 || true)
+    line=${line#*=}
+    if [[ "${line}" =~ :-\"?([^\"\}]*)\"?\} ]]; then
+        printf '%s' "${BASH_REMATCH[1]}"
+    else
+        line=${line%\"}
+        line=${line#\"}
+        printf '%s' "${line}"
+    fi
+}
+
+# Download the Camunda distribution and connectors bundle once on this orchestrator host so
+# every node can reuse them. Files are keyed by version, so the upgrade test (previous -> current
+# within the same job) never reuses the wrong artifact. Best-effort: on any failure the cache is
+# left empty and nodes fall back to downloading individually.
+# NOTE: keep the artifact URLs/resolution in sync with
+#       generic/compute/debian/procedure/camunda-install.sh
+warm_distro_cache() {
+    DISTRO_CACHE_READY=false
+    CACHED_TARBALL_PATH=""
+    CACHED_JAR_PATH=""
+
+    # Parse the very same script piped to each node below ("ssh ... < camunda-install.sh") so the
+    # cached artifacts always match what the nodes install -- including the in-place edits the
+    # upgrade test makes to this file. (env vars do NOT cross the SSH boundary; the node uses these
+    # defaults too.)
+    local install_script="${CURRENT_DIR}/camunda-install.sh"
+    local camunda_version connectors_version
+    camunda_version=$(script_default "CAMUNDA_VERSION" "${install_script}")
+    connectors_version=$(script_default "CAMUNDA_CONNECTORS_VERSION" "${install_script}")
+
+    if [[ -z "${camunda_version}" || -z "${connectors_version}" ]]; then
+        echo "[WARN] Could not parse Camunda/Connectors versions from ${install_script}; skipping download cache."
+        return 0
+    fi
+
+    local netrc_opt="" netrc_file=""
+    if [[ -n "${CAMUNDA_DISTRO_USER}" && -n "${CAMUNDA_DISTRO_PASSWORD}" ]]; then
+        netrc_file=$(mktemp)
+        chmod 600 "${netrc_file}"
+        printf 'machine artifacts.camunda.com login %s password %s\n' "${CAMUNDA_DISTRO_USER}" "${CAMUNDA_DISTRO_PASSWORD}" > "${netrc_file}"
+        netrc_opt="--netrc-file ${netrc_file}"
+    fi
+
+    mkdir -p "${CAMUNDA_DISTRO_CACHE_DIR}" || { echo "[WARN] Cannot create ${CAMUNDA_DISTRO_CACHE_DIR}; skipping download cache."; return 0; }
+    local tarball="${CAMUNDA_DISTRO_CACHE_DIR}/camunda-zeebe-${camunda_version}.tar.gz"
+    local jar="${CAMUNDA_DISTRO_CACHE_DIR}/connectors-${connectors_version}.jar"
+
+    # --- Camunda distribution ---
+    if [[ -f "${tarball}" ]]; then
+        echo "[INFO] Reusing cached Camunda distribution at ${tarball}."
+    else
+        local camunda_url=""
+        if [[ "${camunda_version}" =~ SNAPSHOT ]]; then
+            local snap=""
+            # shellcheck disable=SC2086
+            snap=$(curl -sfL ${netrc_opt} "https://artifacts.camunda.com/artifactory/zeebe/io/camunda/camunda-zeebe/${camunda_version}/maven-metadata.xml" | grep -A 1 "<extension>tar.gz</extension>" | grep "<value>" | sed -e 's/<[^>]*>//g' -e 's/^[ \t]*//' || true)
+            camunda_url="https://artifacts.camunda.com/artifactory/zeebe/io/camunda/camunda-zeebe/${camunda_version}/camunda-zeebe-${snap}.tar.gz"
+        else
+            camunda_url="https://artifacts.camunda.com/artifactory/zeebe/io/camunda/camunda-zeebe/${camunda_version}/camunda-zeebe-${camunda_version}.tar.gz"
+        fi
+        echo "[INFO] Caching Camunda distribution ${camunda_version} once for all nodes..."
+        # shellcheck disable=SC2086
+        if ! curl -fL ${netrc_opt} "${camunda_url}" -o "${tarball}"; then
+            echo "[WARN] Failed to cache Camunda distribution; nodes will download it individually."
+            rm -f "${tarball}"
+        fi
+    fi
+    [[ -f "${tarball}" ]] && CACHED_TARBALL_PATH="${tarball}"
+
+    # --- Connectors bundle ---
+    if [[ -f "${jar}" ]]; then
+        echo "[INFO] Reusing cached connectors bundle at ${jar}."
+    else
+        local jar_url=""
+        if [[ "${connectors_version}" =~ SNAPSHOT ]]; then
+            local snap=""
+            # shellcheck disable=SC2086
+            snap=$(curl -sfL ${netrc_opt} "https://artifacts.camunda.com/artifactory/connectors-snapshots/io/camunda/connector/connector-runtime-bundle/${connectors_version}/maven-metadata.xml" | grep -A 1 "<extension>pom</extension>" | grep "<value>" | sed -e 's/<[^>]*>//g' -e 's/^[ \t]*//' || true)
+            jar_url="https://artifacts.camunda.com/artifactory/connectors-snapshots/io/camunda/connector/connector-runtime-bundle/${connectors_version}/connector-runtime-bundle-${snap}-with-dependencies.jar"
+        else
+            jar_url="https://artifacts.camunda.com/artifactory/connectors/io/camunda/connector/connector-runtime-bundle/${connectors_version}/connector-runtime-bundle-${connectors_version}-with-dependencies.jar"
+        fi
+        echo "[INFO] Caching connectors bundle ${connectors_version} once for all nodes..."
+        # shellcheck disable=SC2086
+        if ! curl -fL ${netrc_opt} "${jar_url}" -o "${jar}"; then
+            echo "[WARN] Failed to cache connectors bundle; nodes will download it individually."
+            rm -f "${jar}"
+        fi
+    fi
+    [[ -f "${jar}" ]] && CACHED_JAR_PATH="${jar}"
+
+    [[ -n "${netrc_file}" ]] && rm -f "${netrc_file}"
+
+    if [[ -n "${CACHED_TARBALL_PATH}" || -n "${CACHED_JAR_PATH}" ]]; then
+        DISTRO_CACHE_READY=true
+    fi
+}
+
+# Stage whichever cached artifacts exist onto the current node (${ip}), under the fixed path the
+# install script looks at. Best-effort: a failure just means that node downloads it itself.
+push_distro_cache_to_node() {
+    remote_cmd "mkdir -p ${REMOTE_DISTRO_CACHE_DIR}" || { echo "[WARN] Could not prepare cache dir on ${ip}; it will download individually."; return 0; }
+
+    if [[ -n "${CACHED_TARBALL_PATH}" && -f "${CACHED_TARBALL_PATH}" ]]; then
+        if sftp -J "${ADMIN_USERNAME}@${BASTION_IP}" "${ADMIN_USERNAME}@${ip}" >/dev/null 2>&1 <<EOF
+put "${CACHED_TARBALL_PATH}" "${REMOTE_DISTRO_CACHE_DIR}/camunda.tar.gz"
+bye
+EOF
+        then
+            remote_cmd "chmod 644 ${REMOTE_DISTRO_CACHE_DIR}/camunda.tar.gz" || true
+        else
+            echo "[WARN] Failed to stage cached distribution on ${ip}; it will download individually."
+        fi
+    fi
+
+    if [[ -n "${CACHED_JAR_PATH}" && -f "${CACHED_JAR_PATH}" ]]; then
+        if sftp -J "${ADMIN_USERNAME}@${BASTION_IP}" "${ADMIN_USERNAME}@${ip}" >/dev/null 2>&1 <<EOF
+put "${CACHED_JAR_PATH}" "${REMOTE_DISTRO_CACHE_DIR}/connectors.jar"
+bye
+EOF
+        then
+            remote_cmd "chmod 644 ${REMOTE_DISTRO_CACHE_DIR}/connectors.jar" || true
+        else
+            echo "[WARN] Failed to stage cached connectors bundle on ${ip}; it will download individually."
+        fi
+    fi
+}
+
 check_tool_installed "ssh"
 check_tool_installed "openssl"
 check_tool_installed "sftp"
@@ -68,6 +215,13 @@ done
 ips_list=${ips_list%,}
 total_ip_count=${#IPS[@]}
 
+# When a shared cache dir is configured (CI), download the distribution + connectors bundle once
+# here so the per-node loop below copies them instead of each node hitting Artifactory.
+if [[ -n "${CAMUNDA_DISTRO_CACHE_DIR}" ]]; then
+    echo "[INFO] Distribution download cache enabled (CAMUNDA_DISTRO_CACHE_DIR=${CAMUNDA_DISTRO_CACHE_DIR})."
+    warm_distro_cache
+fi
+
 # Loop over each IP address
 # We're using source to call up child scripts with the same variable context
 # The idea is to divide the logic into smaller scripts for better readability and maintainability
@@ -82,6 +236,16 @@ for index in "${!IPS[@]}"; do
         printf '%s\n%s\n' "${CAMUNDA_DISTRO_USER}" "${CAMUNDA_DISTRO_PASSWORD}" | \
             ssh -J "${ADMIN_USERNAME}@${BASTION_IP}" "${ADMIN_USERNAME}@${ip}" \
             'cat > /tmp/.camunda-distro-credentials && chmod 600 /tmp/.camunda-distro-credentials'
+    fi
+
+    # Stage the pre-downloaded artifacts on the node. Always start from a clean node cache so a
+    # previous install round (e.g. the upgrade test's other version) is never reused. No-op when
+    # the cache is disabled.
+    if [[ -n "${CAMUNDA_DISTRO_CACHE_DIR}" ]]; then
+        remote_cmd "rm -rf ${REMOTE_DISTRO_CACHE_DIR}" || true
+        if [[ "${DISTRO_CACHE_READY}" == "true" ]]; then
+            push_distro_cache_to_node
+        fi
     fi
 
     ssh -J "${ADMIN_USERNAME}@${BASTION_IP}" "${ADMIN_USERNAME}@${ip}" < "${CURRENT_DIR}/camunda-install.sh"

--- a/aws/compute/ec2-single-region/procedure/all-in-one-install.sh
+++ b/aws/compute/ec2-single-region/procedure/all-in-one-install.sh
@@ -5,10 +5,8 @@ CURRENT_DIR="$(dirname "$0")"
 
 source "${CURRENT_DIR}/helpers.sh"
 
-# Optional download-cache helpers. By default this is a no-op: every node downloads its own
-# artifacts directly (see camunda-install.sh). Our CI sets CAMUNDA_DISTRO_CACHE_LIB to a small
-# helper that downloads the distribution + connectors once and stages them on each node, so this
-# reference procedure stays free of any CI/caching plumbing.
+# Optional hook: if CAMUNDA_DISTRO_CACHE_LIB points to a shell library, source it. Unset by
+# default, so this is a no-op and each node downloads its own artifacts (see camunda-install.sh).
 if [[ -n "${CAMUNDA_DISTRO_CACHE_LIB:-}" && -f "${CAMUNDA_DISTRO_CACHE_LIB}" ]]; then
     # shellcheck source=/dev/null
     source "${CAMUNDA_DISTRO_CACHE_LIB}"

--- a/aws/compute/ec2-single-region/test/ci-distro-cache.sh
+++ b/aws/compute/ec2-single-region/test/ci-distro-cache.sh
@@ -151,7 +151,10 @@ warm_distro_cache() {
 push_distro_cache_to_node() {
     local ip="$1"
 
-    remote_cmd "rm -rf ${REMOTE_DISTRO_CACHE_DIR} && mkdir -p ${REMOTE_DISTRO_CACHE_DIR}" \
+    # Recreate the cache dir with an explicit, non-world-writable mode (don't rely on the remote
+    # umask): 0755 keeps it readable/traversable by the unprivileged camunda user that consumes it
+    # in camunda-install.sh, while preventing other local users from planting artifacts.
+    remote_cmd "rm -rf ${REMOTE_DISTRO_CACHE_DIR} && mkdir -p ${REMOTE_DISTRO_CACHE_DIR} && chmod 755 ${REMOTE_DISTRO_CACHE_DIR}" \
         || { echo "[WARN] Could not prepare cache dir on ${ip}; it will download individually."; return 0; }
 
     if [[ "${DISTRO_CACHE_READY}" != "true" ]]; then
@@ -166,6 +169,9 @@ EOF
         then
             remote_cmd "chmod 644 ${REMOTE_DISTRO_CACHE_DIR}/camunda.tar.gz" || true
         else
+            # Drop any partial upload so camunda-install.sh's existence check can't treat a truncated
+            # file as a valid cache hit; the node then downloads it itself.
+            remote_cmd "rm -f ${REMOTE_DISTRO_CACHE_DIR}/camunda.tar.gz" || true
             echo "[WARN] Failed to stage cached distribution on ${ip}; it will download individually."
         fi
     fi
@@ -178,6 +184,7 @@ EOF
         then
             remote_cmd "chmod 644 ${REMOTE_DISTRO_CACHE_DIR}/connectors.jar" || true
         else
+            remote_cmd "rm -f ${REMOTE_DISTRO_CACHE_DIR}/connectors.jar" || true
             echo "[WARN] Failed to stage cached connectors bundle on ${ip}; it will download individually."
         fi
     fi

--- a/aws/compute/ec2-single-region/test/ci-distro-cache.sh
+++ b/aws/compute/ec2-single-region/test/ci-distro-cache.sh
@@ -1,0 +1,170 @@
+# shellcheck shell=bash
+# CI-only helpers for caching the Camunda distribution + connectors bundle.
+#
+# This file is NOT part of the customer-facing reference procedure. It is sourced by
+# aws/compute/ec2-single-region/procedure/all-in-one-install.sh ONLY when CAMUNDA_DISTRO_CACHE_LIB
+# points at it (our CI sets that env var). It keeps the reference install scripts free of any
+# download-caching plumbing.
+#
+# Why: the EC2 tests install Camunda on every node (x3) and on every install round (initial,
+# CloudWatch, upgrade previous + current). Downloading the distribution tarball and the connectors
+# uber-jar from Artifactory each time dominates the InfraEx Artifactory egress. Here we download
+# each artifact ONCE on the orchestrator and stage it on every node instead.
+#
+# It relies on variables/functions provided by the sourcing script (all-in-one-install.sh):
+#   CURRENT_DIR, BASTION_IP, ADMIN_USERNAME, CAMUNDA_DISTRO_USER, CAMUNDA_DISTRO_PASSWORD, remote_cmd
+# and on CAMUNDA_DISTRO_CACHE_DIR (orchestrator-side cache dir) from the environment.
+# shellcheck disable=SC2154  # BASTION_IP/ADMIN_USERNAME/CAMUNDA_DISTRO_* come from the sourcing script
+
+# Where staged files land on each node. Must match camunda-install.sh's CAMUNDA_DISTRO_CACHE_DIR.
+REMOTE_DISTRO_CACHE_DIR="/tmp/.camunda-distro-cache"
+
+# Orchestrator-side cached files for the version currently being installed (empty when not cached).
+CACHED_TARBALL_PATH=""
+CACHED_JAR_PATH=""
+DISTRO_CACHE_READY=false
+
+# Resolve the effective default of a 'VAR=${VAR:-"x"}' (or plain 'VAR=x') assignment in a script.
+script_default() {
+    local var="$1" file="$2" line
+    line=$(grep -E "^${var}=" "${file}" | head -1 || true)
+    line=${line#*=}
+    if [[ "${line}" =~ :-\"?([^\"\}]*)\"?\} ]]; then
+        printf '%s' "${BASH_REMATCH[1]}"
+    else
+        line=${line%\"}
+        line=${line#\"}
+        printf '%s' "${line}"
+    fi
+}
+
+# Download the Camunda distribution and connectors bundle once into CAMUNDA_DISTRO_CACHE_DIR.
+# Files are keyed by version, so the upgrade test (previous -> current within the same job) never
+# reuses the wrong artifact. Best-effort: on any failure the cache is left empty and nodes fall
+# back to downloading individually.
+# NOTE: keep the artifact URLs/resolution in sync with
+#       generic/compute/debian/procedure/camunda-install.sh
+warm_distro_cache() {
+    DISTRO_CACHE_READY=false
+    CACHED_TARBALL_PATH=""
+    CACHED_JAR_PATH=""
+
+    if [[ -z "${CAMUNDA_DISTRO_CACHE_DIR:-}" ]]; then
+        return 0
+    fi
+    echo "[INFO] Distribution download cache enabled (CAMUNDA_DISTRO_CACHE_DIR=${CAMUNDA_DISTRO_CACHE_DIR})."
+
+    # Parse the very same script piped to each node ("ssh ... < camunda-install.sh") so the cached
+    # artifacts always match what the nodes install -- including the in-place edits the upgrade test
+    # makes to this file. (env vars do NOT cross the SSH boundary; the node uses these defaults too.)
+    local install_script="${CURRENT_DIR}/camunda-install.sh"
+    local camunda_version connectors_version
+    camunda_version=$(script_default "CAMUNDA_VERSION" "${install_script}")
+    connectors_version=$(script_default "CAMUNDA_CONNECTORS_VERSION" "${install_script}")
+
+    if [[ -z "${camunda_version}" || -z "${connectors_version}" ]]; then
+        echo "[WARN] Could not parse Camunda/Connectors versions from ${install_script}; skipping download cache."
+        return 0
+    fi
+
+    local netrc_opt="" netrc_file=""
+    if [[ -n "${CAMUNDA_DISTRO_USER}" && -n "${CAMUNDA_DISTRO_PASSWORD}" ]]; then
+        netrc_file=$(mktemp)
+        chmod 600 "${netrc_file}"
+        printf 'machine artifacts.camunda.com login %s password %s\n' "${CAMUNDA_DISTRO_USER}" "${CAMUNDA_DISTRO_PASSWORD}" > "${netrc_file}"
+        netrc_opt="--netrc-file ${netrc_file}"
+    fi
+
+    mkdir -p "${CAMUNDA_DISTRO_CACHE_DIR}" || { echo "[WARN] Cannot create ${CAMUNDA_DISTRO_CACHE_DIR}; skipping download cache."; return 0; }
+    local tarball="${CAMUNDA_DISTRO_CACHE_DIR}/camunda-zeebe-${camunda_version}.tar.gz"
+    local jar="${CAMUNDA_DISTRO_CACHE_DIR}/connectors-${connectors_version}.jar"
+
+    # --- Camunda distribution ---
+    if [[ -f "${tarball}" ]]; then
+        echo "[INFO] Reusing cached Camunda distribution ${camunda_version} at ${tarball}."
+    else
+        local camunda_url=""
+        if [[ "${camunda_version}" =~ SNAPSHOT ]]; then
+            local snap=""
+            # shellcheck disable=SC2086
+            snap=$(curl -sfL ${netrc_opt} "https://artifacts.camunda.com/artifactory/zeebe/io/camunda/camunda-zeebe/${camunda_version}/maven-metadata.xml" | grep -A 1 "<extension>tar.gz</extension>" | grep "<value>" | sed -e 's/<[^>]*>//g' -e 's/^[ \t]*//' || true)
+            camunda_url="https://artifacts.camunda.com/artifactory/zeebe/io/camunda/camunda-zeebe/${camunda_version}/camunda-zeebe-${snap}.tar.gz"
+        else
+            camunda_url="https://artifacts.camunda.com/artifactory/zeebe/io/camunda/camunda-zeebe/${camunda_version}/camunda-zeebe-${camunda_version}.tar.gz"
+        fi
+        echo "[INFO] Caching Camunda distribution ${camunda_version} once for all nodes..."
+        # shellcheck disable=SC2086
+        if ! curl -fL ${netrc_opt} "${camunda_url}" -o "${tarball}"; then
+            echo "[WARN] Failed to cache Camunda distribution; nodes will download it individually."
+            rm -f "${tarball}"
+        fi
+    fi
+    [[ -f "${tarball}" ]] && CACHED_TARBALL_PATH="${tarball}"
+
+    # --- Connectors bundle ---
+    if [[ -f "${jar}" ]]; then
+        echo "[INFO] Reusing cached connectors bundle ${connectors_version} at ${jar}."
+    else
+        local jar_url=""
+        if [[ "${connectors_version}" =~ SNAPSHOT ]]; then
+            local snap=""
+            # shellcheck disable=SC2086
+            snap=$(curl -sfL ${netrc_opt} "https://artifacts.camunda.com/artifactory/connectors-snapshots/io/camunda/connector/connector-runtime-bundle/${connectors_version}/maven-metadata.xml" | grep -A 1 "<extension>pom</extension>" | grep "<value>" | sed -e 's/<[^>]*>//g' -e 's/^[ \t]*//' || true)
+            jar_url="https://artifacts.camunda.com/artifactory/connectors-snapshots/io/camunda/connector/connector-runtime-bundle/${connectors_version}/connector-runtime-bundle-${snap}-with-dependencies.jar"
+        else
+            jar_url="https://artifacts.camunda.com/artifactory/connectors/io/camunda/connector/connector-runtime-bundle/${connectors_version}/connector-runtime-bundle-${connectors_version}-with-dependencies.jar"
+        fi
+        echo "[INFO] Caching connectors bundle ${connectors_version} once for all nodes..."
+        # shellcheck disable=SC2086
+        if ! curl -fL ${netrc_opt} "${jar_url}" -o "${jar}"; then
+            echo "[WARN] Failed to cache connectors bundle; nodes will download it individually."
+            rm -f "${jar}"
+        fi
+    fi
+    [[ -f "${jar}" ]] && CACHED_JAR_PATH="${jar}"
+
+    [[ -n "${netrc_file}" ]] && rm -f "${netrc_file}"
+
+    if [[ -n "${CACHED_TARBALL_PATH}" || -n "${CACHED_JAR_PATH}" ]]; then
+        DISTRO_CACHE_READY=true
+    fi
+}
+
+# Stage the cached artifacts (for the version currently being installed) onto a node, under the
+# fixed path camunda-install.sh looks at. Always clears the node cache first so a previous install
+# round (e.g. the upgrade test's other version) is never reused. Best-effort.
+# Usage: push_distro_cache_to_node <node-ip>
+push_distro_cache_to_node() {
+    local ip="$1"
+
+    remote_cmd "rm -rf ${REMOTE_DISTRO_CACHE_DIR} && mkdir -p ${REMOTE_DISTRO_CACHE_DIR}" \
+        || { echo "[WARN] Could not prepare cache dir on ${ip}; it will download individually."; return 0; }
+
+    if [[ "${DISTRO_CACHE_READY}" != "true" ]]; then
+        return 0
+    fi
+
+    if [[ -n "${CACHED_TARBALL_PATH}" && -f "${CACHED_TARBALL_PATH}" ]]; then
+        if sftp -J "${ADMIN_USERNAME}@${BASTION_IP}" "${ADMIN_USERNAME}@${ip}" >/dev/null 2>&1 <<EOF
+put "${CACHED_TARBALL_PATH}" "${REMOTE_DISTRO_CACHE_DIR}/camunda.tar.gz"
+bye
+EOF
+        then
+            remote_cmd "chmod 644 ${REMOTE_DISTRO_CACHE_DIR}/camunda.tar.gz" || true
+        else
+            echo "[WARN] Failed to stage cached distribution on ${ip}; it will download individually."
+        fi
+    fi
+
+    if [[ -n "${CACHED_JAR_PATH}" && -f "${CACHED_JAR_PATH}" ]]; then
+        if sftp -J "${ADMIN_USERNAME}@${BASTION_IP}" "${ADMIN_USERNAME}@${ip}" >/dev/null 2>&1 <<EOF
+put "${CACHED_JAR_PATH}" "${REMOTE_DISTRO_CACHE_DIR}/connectors.jar"
+bye
+EOF
+        then
+            remote_cmd "chmod 644 ${REMOTE_DISTRO_CACHE_DIR}/connectors.jar" || true
+        else
+            echo "[WARN] Failed to stage cached connectors bundle on ${ip}; it will download individually."
+        fi
+    fi
+}

--- a/aws/compute/ec2-single-region/test/ci-distro-cache.sh
+++ b/aws/compute/ec2-single-region/test/ci-distro-cache.sh
@@ -67,6 +67,12 @@ warm_distro_cache() {
         return 0
     fi
 
+    mkdir -p "${CAMUNDA_DISTRO_CACHE_DIR}" || { echo "[WARN] Cannot create ${CAMUNDA_DISTRO_CACHE_DIR}; skipping download cache."; return 0; }
+    local tarball="${CAMUNDA_DISTRO_CACHE_DIR}/camunda-zeebe-${camunda_version}.tar.gz"
+    local jar="${CAMUNDA_DISTRO_CACHE_DIR}/connectors-${connectors_version}.jar"
+
+    # Create the netrc only after the cache dir is ready, so we never leave credentials behind on an
+    # early return.
     local netrc_opt="" netrc_file=""
     if [[ -n "${CAMUNDA_DISTRO_USER}" && -n "${CAMUNDA_DISTRO_PASSWORD}" ]]; then
         netrc_file=$(mktemp)
@@ -74,10 +80,6 @@ warm_distro_cache() {
         printf 'machine artifacts.camunda.com login %s password %s\n' "${CAMUNDA_DISTRO_USER}" "${CAMUNDA_DISTRO_PASSWORD}" > "${netrc_file}"
         netrc_opt="--netrc-file ${netrc_file}"
     fi
-
-    mkdir -p "${CAMUNDA_DISTRO_CACHE_DIR}" || { echo "[WARN] Cannot create ${CAMUNDA_DISTRO_CACHE_DIR}; skipping download cache."; return 0; }
-    local tarball="${CAMUNDA_DISTRO_CACHE_DIR}/camunda-zeebe-${camunda_version}.tar.gz"
-    local jar="${CAMUNDA_DISTRO_CACHE_DIR}/connectors-${connectors_version}.jar"
 
     # --- Camunda distribution ---
     if [[ -f "${tarball}" ]]; then
@@ -88,15 +90,21 @@ warm_distro_cache() {
             local snap=""
             # shellcheck disable=SC2086
             snap=$(curl -sfL ${netrc_opt} "https://artifacts.camunda.com/artifactory/zeebe/io/camunda/camunda-zeebe/${camunda_version}/maven-metadata.xml" | grep -A 1 "<extension>tar.gz</extension>" | grep "<value>" | sed -e 's/<[^>]*>//g' -e 's/^[ \t]*//' || true)
-            camunda_url="https://artifacts.camunda.com/artifactory/zeebe/io/camunda/camunda-zeebe/${camunda_version}/camunda-zeebe-${snap}.tar.gz"
+            if [[ -n "${snap}" ]]; then
+                camunda_url="https://artifacts.camunda.com/artifactory/zeebe/io/camunda/camunda-zeebe/${camunda_version}/camunda-zeebe-${snap}.tar.gz"
+            else
+                echo "[WARN] Could not resolve a SNAPSHOT build for Camunda ${camunda_version}; nodes will download it individually."
+            fi
         else
             camunda_url="https://artifacts.camunda.com/artifactory/zeebe/io/camunda/camunda-zeebe/${camunda_version}/camunda-zeebe-${camunda_version}.tar.gz"
         fi
-        echo "[INFO] Caching Camunda distribution ${camunda_version} once for all nodes..."
-        # shellcheck disable=SC2086
-        if ! curl -fL ${netrc_opt} "${camunda_url}" -o "${tarball}"; then
-            echo "[WARN] Failed to cache Camunda distribution; nodes will download it individually."
-            rm -f "${tarball}"
+        if [[ -n "${camunda_url}" ]]; then
+            echo "[INFO] Caching Camunda distribution ${camunda_version} once for all nodes..."
+            # shellcheck disable=SC2086
+            if ! curl -fL ${netrc_opt} "${camunda_url}" -o "${tarball}"; then
+                echo "[WARN] Failed to cache Camunda distribution; nodes will download it individually."
+                rm -f "${tarball}"
+            fi
         fi
     fi
     [[ -f "${tarball}" ]] && CACHED_TARBALL_PATH="${tarball}"
@@ -110,15 +118,21 @@ warm_distro_cache() {
             local snap=""
             # shellcheck disable=SC2086
             snap=$(curl -sfL ${netrc_opt} "https://artifacts.camunda.com/artifactory/connectors-snapshots/io/camunda/connector/connector-runtime-bundle/${connectors_version}/maven-metadata.xml" | grep -A 1 "<extension>pom</extension>" | grep "<value>" | sed -e 's/<[^>]*>//g' -e 's/^[ \t]*//' || true)
-            jar_url="https://artifacts.camunda.com/artifactory/connectors-snapshots/io/camunda/connector/connector-runtime-bundle/${connectors_version}/connector-runtime-bundle-${snap}-with-dependencies.jar"
+            if [[ -n "${snap}" ]]; then
+                jar_url="https://artifacts.camunda.com/artifactory/connectors-snapshots/io/camunda/connector/connector-runtime-bundle/${connectors_version}/connector-runtime-bundle-${snap}-with-dependencies.jar"
+            else
+                echo "[WARN] Could not resolve a SNAPSHOT build for connectors ${connectors_version}; nodes will download it individually."
+            fi
         else
             jar_url="https://artifacts.camunda.com/artifactory/connectors/io/camunda/connector/connector-runtime-bundle/${connectors_version}/connector-runtime-bundle-${connectors_version}-with-dependencies.jar"
         fi
-        echo "[INFO] Caching connectors bundle ${connectors_version} once for all nodes..."
-        # shellcheck disable=SC2086
-        if ! curl -fL ${netrc_opt} "${jar_url}" -o "${jar}"; then
-            echo "[WARN] Failed to cache connectors bundle; nodes will download it individually."
-            rm -f "${jar}"
+        if [[ -n "${jar_url}" ]]; then
+            echo "[INFO] Caching connectors bundle ${connectors_version} once for all nodes..."
+            # shellcheck disable=SC2086
+            if ! curl -fL ${netrc_opt} "${jar_url}" -o "${jar}"; then
+                echo "[WARN] Failed to cache connectors bundle; nodes will download it individually."
+                rm -f "${jar}"
+            fi
         fi
     fi
     [[ -f "${jar}" ]] && CACHED_JAR_PATH="${jar}"
@@ -166,5 +180,15 @@ EOF
         else
             echo "[WARN] Failed to stage cached connectors bundle on ${ip}; it will download individually."
         fi
+    fi
+}
+
+# Emit shell statements to prepend to the install script so the node opts in to the staged cache.
+# Caching is OFF by default in camunda-install.sh, so this is the explicit, trusted opt-in signal
+# (it travels over the authenticated SSH channel, not via a world-writable path). Empty unless the
+# cache is ready, keeping the default (download) path untouched.
+distro_install_prelude() {
+    if [[ "${DISTRO_CACHE_READY}" == "true" ]]; then
+        printf 'export CAMUNDA_DISTRO_CACHE_DIR=%q\n' "${REMOTE_DISTRO_CACHE_DIR}"
     fi
 }

--- a/generic/compute/debian/procedure/camunda-install.sh
+++ b/generic/compute/debian/procedure/camunda-install.sh
@@ -32,14 +32,20 @@ if [[ -f "${CAMUNDA_DISTRO_CRED_FILE}" ]]; then
     rm -f "${CAMUNDA_DISTRO_CRED_FILE}"
 fi
 
-# Optional local artifact cache. When the orchestrator (all-in-one-install.sh) runs the
-# install across several nodes it can download the distribution and connectors bundle ONCE
-# and stage them here, so each node copies the files instead of re-downloading them from
-# Artifactory. For a plain (customer) run this directory does not exist and the curl path
-# below is used unchanged.
-CAMUNDA_DISTRO_CACHE_DIR=${CAMUNDA_DISTRO_CACHE_DIR:-"/tmp/.camunda-distro-cache"}
-CACHED_CAMUNDA_TARBALL="${CAMUNDA_DISTRO_CACHE_DIR}/camunda.tar.gz"
-CACHED_CONNECTORS_JAR="${CAMUNDA_DISTRO_CACHE_DIR}/connectors.jar"
+# Optional local artifact cache (opt-in). When CAMUNDA_DISTRO_CACHE_DIR is set and points to a
+# trusted directory containing the artifacts, this script copies them instead of downloading from
+# Artifactory. This is used by the CI orchestrator (it downloads once and stages the files on each
+# node), and can also be used for air-gapped / pre-downloaded installs.
+# It is OFF by default: a plain run downloads from Artifactory as before. We do NOT default to a
+# world-writable location (e.g. /tmp) so that a normal run never trusts artifacts it didn't fetch.
+# If you enable it, make sure the directory is only writable by a trusted user.
+CAMUNDA_DISTRO_CACHE_DIR=${CAMUNDA_DISTRO_CACHE_DIR:-""}
+CACHED_CAMUNDA_TARBALL=""
+CACHED_CONNECTORS_JAR=""
+if [[ -n "${CAMUNDA_DISTRO_CACHE_DIR}" ]]; then
+    CACHED_CAMUNDA_TARBALL="${CAMUNDA_DISTRO_CACHE_DIR}/camunda.tar.gz"
+    CACHED_CONNECTORS_JAR="${CAMUNDA_DISTRO_CACHE_DIR}/connectors.jar"
+fi
 
 CURL_AUTH_OPTS=()
 CURL_NETRC_FILE=""

--- a/generic/compute/debian/procedure/camunda-install.sh
+++ b/generic/compute/debian/procedure/camunda-install.sh
@@ -34,8 +34,7 @@ fi
 
 # Optional local artifact cache (opt-in). When CAMUNDA_DISTRO_CACHE_DIR is set and points to a
 # trusted directory containing the artifacts, this script copies them instead of downloading from
-# Artifactory. This is used by the CI orchestrator (it downloads once and stages the files on each
-# node), and can also be used for air-gapped / pre-downloaded installs.
+# Artifactory -- useful for air-gapped or pre-downloaded installs.
 # It is OFF by default: a plain run downloads from Artifactory as before. We do NOT default to a
 # world-writable location (e.g. /tmp) so that a normal run never trusts artifacts it didn't fetch.
 # If you enable it, make sure the directory is only writable by a trusted user.

--- a/generic/compute/debian/procedure/camunda-install.sh
+++ b/generic/compute/debian/procedure/camunda-install.sh
@@ -32,6 +32,15 @@ if [[ -f "${CAMUNDA_DISTRO_CRED_FILE}" ]]; then
     rm -f "${CAMUNDA_DISTRO_CRED_FILE}"
 fi
 
+# Optional local artifact cache. When the orchestrator (all-in-one-install.sh) runs the
+# install across several nodes it can download the distribution and connectors bundle ONCE
+# and stage them here, so each node copies the files instead of re-downloading them from
+# Artifactory. For a plain (customer) run this directory does not exist and the curl path
+# below is used unchanged.
+CAMUNDA_DISTRO_CACHE_DIR=${CAMUNDA_DISTRO_CACHE_DIR:-"/tmp/.camunda-distro-cache"}
+CACHED_CAMUNDA_TARBALL="${CAMUNDA_DISTRO_CACHE_DIR}/camunda.tar.gz"
+CACHED_CONNECTORS_JAR="${CAMUNDA_DISTRO_CACHE_DIR}/connectors.jar"
+
 CURL_AUTH_OPTS=()
 CURL_NETRC_FILE=""
 if [[ -n "${CAMUNDA_DISTRO_USER}" && -n "${CAMUNDA_DISTRO_PASSWORD}" ]]; then
@@ -90,7 +99,7 @@ fi
 
 sudo chown -R "${USERNAME}:${USERNAME}" "${MNT_DIR}/"
 
-if [[ "${CAMUNDA_VERSION}" =~ "SNAPSHOT" ]]; then
+if [[ "${CAMUNDA_VERSION}" =~ "SNAPSHOT" && ! -f "${CACHED_CAMUNDA_TARBALL}" ]]; then
     echo "[INFO] Fetching the latest snapshot version of Camunda ${CAMUNDA_VERSION}."
     CAMUNDA_SNAPSHOT_VERSION=$(curl -sfL "${CURL_AUTH_OPTS[@]}" "https://artifacts.camunda.com/artifactory/zeebe/io/camunda/camunda-zeebe/${CAMUNDA_VERSION}/maven-metadata.xml" | grep -A 1 "<extension>tar.gz</extension>" | \
         grep "<value>" | \
@@ -98,7 +107,7 @@ if [[ "${CAMUNDA_VERSION}" =~ "SNAPSHOT" ]]; then
     echo "[INFO] Latest snapshot version is ${CAMUNDA_SNAPSHOT_VERSION}."
 fi
 
-if [[ "${CAMUNDA_CONNECTORS_VERSION}" =~ "SNAPSHOT" ]]; then
+if [[ "${CAMUNDA_CONNECTORS_VERSION}" =~ "SNAPSHOT" && ! -f "${CACHED_CONNECTORS_JAR}" ]]; then
     echo "[INFO] Fetching the latest snapshot version of Camunda Connectors ${CAMUNDA_CONNECTORS_VERSION}."
     CONNECTORS_SNAPSHOT_VERSION=$(curl -sfL "${CURL_AUTH_OPTS[@]}" "https://artifacts.camunda.com/artifactory/connectors-snapshots/io/camunda/connector/connector-runtime-bundle/${CAMUNDA_CONNECTORS_VERSION}/maven-metadata.xml" | grep -A 1 "<extension>pom</extension>" | \
         grep "<value>" | \
@@ -127,7 +136,10 @@ fi
 
 # Install Camunda 8
 
-if [[ "${CAMUNDA_VERSION}" =~ "SNAPSHOT" ]]; then
+if [[ -f "${CACHED_CAMUNDA_TARBALL}" ]]; then
+    echo "[INFO] Using pre-staged Camunda distribution from ${CACHED_CAMUNDA_TARBALL} (download cache)."
+    cp "${CACHED_CAMUNDA_TARBALL}" "${MNT_DIR}/camunda.tar.gz"
+elif [[ "${CAMUNDA_VERSION}" =~ "SNAPSHOT" ]]; then
     # shellcheck disable=SC2086
     curl -fL ${CURL_NETRC_OPT} "https://artifacts.camunda.com/artifactory/zeebe/io/camunda/camunda-zeebe/${CAMUNDA_VERSION}/camunda-zeebe-${CAMUNDA_SNAPSHOT_VERSION}.tar.gz" -o "${MNT_DIR}/camunda.tar.gz"
 else
@@ -145,7 +157,10 @@ mkdir -p "${MNT_DIR}/connectors/"
 
 # --fail-with-body (instead of -f) keeps the response body on HTTP error so the
 # Artifactory error message (e.g. 401/403 JSON) is visible in CI logs.
-if [[ "${CAMUNDA_CONNECTORS_VERSION}" =~ "SNAPSHOT" ]]; then
+if [[ -f "${CACHED_CONNECTORS_JAR}" ]]; then
+    echo "[INFO] Using pre-staged connectors bundle from ${CACHED_CONNECTORS_JAR} (download cache)."
+    cp "${CACHED_CONNECTORS_JAR}" "${MNT_DIR}/connectors/connectors.jar"
+elif [[ "${CAMUNDA_CONNECTORS_VERSION}" =~ "SNAPSHOT" ]]; then
     # shellcheck disable=SC2086
     curl -L --fail-with-body --show-error -w "[INFO] connectors download: HTTP %{http_code} (%{size_download} bytes)\n" ${CURL_NETRC_OPT} "https://artifacts.camunda.com/artifactory/connectors-snapshots/io/camunda/connector/connector-runtime-bundle/${CAMUNDA_CONNECTORS_VERSION}/connector-runtime-bundle-${CONNECTORS_SNAPSHOT_VERSION}-with-dependencies.jar" -o "${MNT_DIR}/connectors/connectors.jar" || { echo "[FAIL] connectors download failed; response body:"; cat "${MNT_DIR}/connectors/connectors.jar" 2>/dev/null | head -c 4096; echo; exit 1; }
 else


### PR DESCRIPTION
Backport of #2657 to `stable/8.8`.

Same change as #2657 (cherry-picked, clean) + the 8.9 backport #2660. On `stable/8.8` the EC2 tests use **GA releases** (`8.8.25` / connectors `8.8.14`, upgrade from `8.8.0`), so `TestCamundaUpgrade` exercises a **GA→GA** upgrade and does not hit the `8.10.0-SNAPSHOT` upstream-upgrade flake seen on `main`/#2657.

- `all-in-one-install.sh` (customer procedure): tiny, no-op-by-default cache hooks.
- `test/ci-distro-cache.sh` (CI-only): download-once + stage-on-nodes helper (version-keyed).
- `camunda-install.sh`: opt-in cache consumption (default off; no implicit `/tmp` trust).
- workflow: sets `CAMUNDA_DISTRO_CACHE_DIR` + `CAMUNDA_DISTRO_CACHE_LIB`.

> [!NOTE]
> Do not merge before #2657. Opened to get the CI signal (expected green, like #2660).
