### PR TITLE
fix(ci): skip identityKeycloak IRSA check when using operator Keycloak

### DIFF
--- a/.github/actions/internal-camunda-chart-tests/action.yml
+++ b/.github/actions/internal-camunda-chart-tests/action.yml
@@ -473,6 +473,7 @@ runs:
           env:
               NAMESPACE: ${{ inputs.test-namespace }}
               ELASTICSEARCH_ENABLED: ${{ inputs.elasticsearch-enabled }}
+              KEYCLOAK_SERVICE_NAME: ${{ inputs.keycloak-service-name }}
           run: |
               set -euo pipefail
 
@@ -499,7 +500,19 @@ runs:
                 OS_COMPONENTS="${OS_COMPONENTS},optimize"
               fi
 
-              PG_COMPONENTS="identityKeycloak,identity"
+              PG_COMPONENTS="identity"
+
+              # The bundled identityKeycloak (Bitnami) subchart only backs Keycloak when no
+              # external/operator Keycloak is configured. With an operator-based Keycloak
+              # (keycloak-service-name set, e.g. "keycloak-service:18080"), identityKeycloak is
+              # disabled and never deployed, so its Helm values are absent and every
+              # identityKeycloak.* IRSA lookup fails (aws-irsa.sh exits 163). Only check it when
+              # the bundled subchart is actually part of the release.
+              if [[ -z "$KEYCLOAK_SERVICE_NAME" ]]; then
+                PG_COMPONENTS="identityKeycloak,${PG_COMPONENTS}"
+              else
+                echo "ℹ️ External/operator Keycloak detected ($KEYCLOAK_SERVICE_NAME); excluding bundled identityKeycloak from IRSA checks"
+              fi
 
               if [[ "${{ inputs.webmodeler-enabled }}" == "true" ]]; then
                 PG_COMPONENTS="${PG_COMPONENTS},webModeler"


### PR DESCRIPTION
## Description

The AWS IRSA check (`internal-camunda-chart-tests` → `c8-sm-checks/checks/kube/aws-irsa.sh`) hardcoded `identityKeycloak` in the PostgreSQL component list:

```bash
PG_COMPONENTS="identityKeycloak,identity"
```

In the `eks-single-region-irsa` scenario, Keycloak is deployed via the **Keycloak Operator** (`keycloak-service:18080`, with its own `pg-keycloak-*` database), so the bundled `identityKeycloak` (Bitnami) subchart is disabled and never deployed. The check then fails every `identityKeycloak.*` lookup and `aws-irsa.sh` exits `163`:

```
[FAIL] identityKeycloak.externalDatabase.host is not defined in your helm values.
[FAIL] The Aurora host is not set. ...
[FAIL] The service account camunda-identityKeycloak does not have a valid eks.amazonaws.com/role-arn annotation.
[FAIL] ./.c8-sm-checks/checks/kube/aws-irsa.sh: At least one of the checks failed (error code: 163).
```

This has been a **standing failure** of the scheduled `Tests - Integration - AWS Kubernetes EKS Single Region (IRSA)` workflow on `main` (failing weekly since the IRSA scenario moved to the Keycloak Operator in #1630). All `[FAIL]` lines are `identityKeycloak`-only; `identity` (PostgreSQL) and `orchestration`/`optimize` (OpenSearch) IRSA checks already pass.

## Change

Only include `identityKeycloak` in the IRSA PostgreSQL component list when **no** external/operator Keycloak is configured. The action already receives `keycloak-service-name` (set to `keycloak-service:18080` only in operator mode, empty otherwise), so it is used as the signal.

- Operator/external Keycloak → `PG_COMPONENTS="identity"` (+`webModeler` if enabled)
- Bundled Keycloak → `PG_COMPONENTS="identityKeycloak,identity"` (**unchanged behaviour**)

No new inputs, no caller changes.

## Backport

- `stable/8.9` — affected (same operator wiring), backport PR to follow.
- `stable/8.8` / `8.7` / `8.6` — **not affected**: 8.8's IRSA scenario uses the bundled Keycloak (so the check is correct there) and 8.7/8.6 don't have this code path.

## Verification

- `bash -n` + `shellcheck` on the embedded logic; runtime check confirms both branches produce the expected component lists.
- `pre-commit` content hooks (yamllint, yamlfmt, check-yaml, …) pass. Docker-based hooks (actionlint/README) unavailable locally — covered by the `lint / pre-commit` CI job.
