### PR TITLE
fix(ci): skip identityKeycloak IRSA check when using operator Keycloak (backport 8.9)

### DIFF
--- a/.github/actions/internal-camunda-chart-tests/action.yml
+++ b/.github/actions/internal-camunda-chart-tests/action.yml
@@ -473,6 +473,7 @@ runs:
           env:
               NAMESPACE: ${{ inputs.test-namespace }}
               ELASTICSEARCH_ENABLED: ${{ inputs.elasticsearch-enabled }}
+              KEYCLOAK_SERVICE_NAME: ${{ inputs.keycloak-service-name }}
           run: |
               set -euo pipefail
 
@@ -499,7 +500,19 @@ runs:
                 OS_COMPONENTS="${OS_COMPONENTS},optimize"
               fi
 
-              PG_COMPONENTS="identityKeycloak,identity"
+              PG_COMPONENTS="identity"
+
+              # The bundled identityKeycloak (Bitnami) subchart only backs Keycloak when no
+              # external/operator Keycloak is configured. With an operator-based Keycloak
+              # (keycloak-service-name set, e.g. "keycloak-service:18080"), identityKeycloak is
+              # disabled and never deployed, so its Helm values are absent and every
+              # identityKeycloak.* IRSA lookup fails (aws-irsa.sh exits 163). Only check it when
+              # the bundled subchart is actually part of the release.
+              if [[ -z "$KEYCLOAK_SERVICE_NAME" ]]; then
+                PG_COMPONENTS="identityKeycloak,${PG_COMPONENTS}"
+              else
+                echo "ℹ️ External/operator Keycloak detected ($KEYCLOAK_SERVICE_NAME); excluding bundled identityKeycloak from IRSA checks"
+              fi
 
               if [[ "${{ inputs.webmodeler-enabled }}" == "true" ]]; then
                 PG_COMPONENTS="${PG_COMPONENTS},webModeler"


### PR DESCRIPTION
## Description

Backport of #2665 to `stable/8.9`.

The AWS IRSA check hardcoded `identityKeycloak` in the PostgreSQL component list. In the `eks-single-region-irsa` scenario Keycloak is deployed via the **Keycloak Operator** (`keycloak-service:18080`, own `pg-keycloak-*` DB), so the bundled `identityKeycloak` (Bitnami) subchart is disabled and never deployed. Every `identityKeycloak.*` lookup then fails and `aws-irsa.sh` exits `163`, making the EKS Single Region (IRSA) integration test fail.

`stable/8.9` carries the same operator wiring as `main` (`keycloak-service:18080` set for the IRSA scenario), so it is affected identically.

## Change

Only include `identityKeycloak` in the IRSA PostgreSQL list when no external/operator Keycloak is configured (`keycloak-service-name` unset). Bundled-Keycloak behaviour is unchanged (`identityKeycloak,identity`). No new inputs, no caller changes. Cherry-pick of `main`, applied cleanly.

## Not backported further

`stable/8.8` is **not affected** — its IRSA scenario uses the bundled Keycloak (no operator), so the check is correct there. `8.7`/`8.6` lack this code path.
