### PR TITLE
[READY] fix(ci): label EC2 upgrade-test Camunda version as 8.10.0-SNAPSHOT

### DIFF
--- a/.github/workflows/aws_compute_ec2_single_region_tests.yml
+++ b/.github/workflows/aws_compute_ec2_single_region_tests.yml
@@ -70,7 +70,12 @@ env:
     # TODO: [release-duty] adjust renovate comment to bump the minor version to the new stable release
     # TODO: [release-duty] Adjust the previous version to the previous stable release, 8.9 --> 8.8, for 8.8 would stick to 8.8
     # renovate: datasource=github-releases depName=camunda/camunda versioning=regex:^8\.10(\.(?<patch>\d+))?$
-    TESTS_CAMUNDA_VERSION: 8.10.0
+    # Pre-GA: the all-in-one installer ships 8.10.0-SNAPSHOT, so this must carry the
+    # "-SNAPSHOT" suffix. The upgrade test keys its pre-release gate (and the final
+    # version assertion) off this string; without the suffix the gate stays off and the
+    # 8.9 -> 8.10.0-SNAPSHOT upgrade is rejected (IncompatibleVersionException). Revert to
+    # the GA version at release time (see release-duty TODOs above).
+    TESTS_CAMUNDA_VERSION: 8.10.0-SNAPSHOT
     TESTS_CAMUNDA_PREVIOUS_VERSION: 8.9.0 # Version to be used for upgrade tests, not updated automatically
 
     # renovate: datasource=github-releases depName=camunda/connectors versioning=regex:^8\.10(\.(?<patch>\d+))?$

--- a/.github/workflows/aws_compute_ec2_single_region_tests.yml
+++ b/.github/workflows/aws_compute_ec2_single_region_tests.yml
@@ -75,6 +75,7 @@ env:
     # version assertion) off this string; without the suffix the gate stays off and the
     # 8.9 -> 8.10.0-SNAPSHOT upgrade is rejected (IncompatibleVersionException). Revert to
     # the GA version at release time (see release-duty TODOs above).
+    # TODO: [release-duty] at 8.10 GA, drop the "-SNAPSHOT" suffix here (revert TESTS_CAMUNDA_VERSION to 8.10.0).
     TESTS_CAMUNDA_VERSION: 8.10.0-SNAPSHOT
     TESTS_CAMUNDA_PREVIOUS_VERSION: 8.9.0 # Version to be used for upgrade tests, not updated automatically
 


### PR DESCRIPTION
## Description

`Tests - Integration - AWS Compute EC2 Single Region` (`aws_compute_ec2_single_region_tests.yml`) has been a **standing failure on `main` (8/8 of the last runs)**. The failing test is `TestCamundaUpgrade`.

### Root cause
The all-in-one installer's upgrade target defaults to the pre-release **`8.10.0-SNAPSHOT`** (`generic/compute/debian/procedure/camunda-install.sh`), but the workflow labelled the current version as GA:

```yaml
TESTS_CAMUNDA_VERSION: 8.10.0
```

The upgrade test only disables the Zeebe broker / search-engine **pre-release version gates** when the version string contains `SNAPSHOT`/`alpha` (`aws/compute/ec2-single-region/test/src/default_ec2_test.go:357`):

```go
if strings.Contains(camundaCurrentVersionFull, "SNAPSHOT") || strings.Contains(camundaCurrentVersionFull, "alpha") {
    // writes ZEEBE_BROKER_EXPERIMENTAL_VERSIONCHECKRESTRICTIONENABLED=false
    //        CAMUNDA_DATABASE_SCHEMAMANAGER_VERSIONCHECKRESTRICTIONENABLED=false
}
```

With the GA-looking label the gate stayed **off**, so Camunda refused the `8.9.0 → 8.10.0-SNAPSHOT` upgrade:

```
io.camunda.search.schema.exceptions.IncompatibleVersionException:
Cannot upgrade to or from a pre-release version: UseOfPreReleaseVersion[from=8.9.0, to=8.10.0-SNAPSHOT]
```

### Fix
Label `TESTS_CAMUNDA_VERSION` as `8.10.0-SNAPSHOT`, matching the artifact actually installed (and the already-correct `TESTS_CONNECTORS_VERSION: 8.10.0-SNAPSHOT`). This makes the guard fire → the pre-release gates are disabled → the upgrade succeeds, and it also fixes the downstream exact-match version assertion (`APICheckCorrectCamundaVersion`). The `camundaCurrentVersionFull` value is used only for that guard and assertion — the upgrade target itself comes from the installer's own default — so this is the minimal, intent-matching change.

### Scope
**`main`-only.** Stable branches (`8.9`/`8.8`) upgrade GA→GA and never hit the pre-release gate. Revert to the GA version at 8.10 release time (existing release-duty TODOs).
