### PR TITLE
fix(ci): retry cluster-login kubectl get nodes in operator-based test

### DIFF
--- a/.github/workflows/generic_kubernetes_operator_based_test.yml
+++ b/.github/workflows/generic_kubernetes_operator_based_test.yml
@@ -405,7 +405,7 @@ jobs:
                   encryption_key: ${{ steps.secrets.outputs.CI_ENCRYPTION_KEY }}
 
             - name: 🔐 Login into the cluster
-              timeout-minutes: 2
+              timeout-minutes: 5
               run: |
                   set -euo pipefail
 
@@ -413,7 +413,23 @@ jobs:
                   mv "${{ runner.temp }}/kubeconfig" "$HOME/.kube/config"
 
                   kubectl config current-context
-                  kubectl get nodes
+
+                  # The first call to the cluster API can hit a transient runner->EKS
+                  # network blip ("dial tcp ...: i/o timeout"). Retry a few times with a
+                  # bounded per-attempt request timeout so one dropped connection doesn't
+                  # fail the whole job.
+                  for attempt in $(seq 1 3); do
+                      if kubectl get nodes --request-timeout=30s; then
+                          break
+                      fi
+                      if [[ "$attempt" -lt 3 ]]; then
+                          echo "kubectl get nodes failed (attempt ${attempt}/3); retrying in 15s..."
+                          sleep 15
+                      else
+                          echo "kubectl get nodes failed after 3 attempts"
+                          exit 1
+                      fi
+                  done
 
             - name: 📁 Get a copy of the reference architecture
               timeout-minutes: 10


### PR DESCRIPTION
## Description

The `Tests - Integration - Generic Operator based` workflow intermittently fails at the **🔐 Login into the cluster** step. The root cause is a transient runner→EKS network blip on the first API call:

```
... Get "https://...eks.amazonaws.com/api?timeout=32s": dial tcp 16.61.59.53:443: i/o timeout
##[error]The action '🔐 Login into the cluster' has timed out after 2 minutes.
```

Evidence it's transient (not a cluster/auth problem): in the same run, on the same cluster, a sibling matrix leg ran the identical `kubectl get nodes` and got Ready nodes in ~1.4s. The single un-retried call simply hung until the 2-minute step timeout.

## Change

- Retry `kubectl get nodes` up to **3×** with a bounded **`--request-timeout=30s`** per attempt and a 15s backoff, so one dropped connection no longer fails the whole job.
- Raise `timeout-minutes` `2 → 5` to give the retry loop headroom.
- `kubectl config current-context` is a local op, left as-is. Failure behaviour is preserved (still exits non-zero after 3 failed attempts).

## Backport

Applies to `main`, `stable/8.9`, `stable/8.8` (same step). Not present on 8.7/8.6.
