### PR TITLE
fix(ci): retry cluster-login kubectl get nodes in operator-based test (backport 8.9)

### DIFF
--- a/.github/workflows/generic_kubernetes_operator_based_test.yml
+++ b/.github/workflows/generic_kubernetes_operator_based_test.yml
@@ -405,7 +405,7 @@ jobs:
                   encryption_key: ${{ steps.secrets.outputs.CI_ENCRYPTION_KEY }}
 
             - name: 🔐 Login into the cluster
-              timeout-minutes: 2
+              timeout-minutes: 5
               run: |
                   set -euo pipefail
 
@@ -413,7 +413,23 @@ jobs:
                   mv "${{ runner.temp }}/kubeconfig" "$HOME/.kube/config"
 
                   kubectl config current-context
-                  kubectl get nodes
+
+                  # The first call to the cluster API can hit a transient runner->EKS
+                  # network blip ("dial tcp ...: i/o timeout"). Retry a few times with a
+                  # bounded per-attempt request timeout so one dropped connection doesn't
+                  # fail the whole job.
+                  for attempt in $(seq 1 3); do
+                      if kubectl get nodes --request-timeout=30s; then
+                          break
+                      fi
+                      if [[ "$attempt" -lt 3 ]]; then
+                          echo "kubectl get nodes failed (attempt ${attempt}/3); retrying in 15s..."
+                          sleep 15
+                      else
+                          echo "kubectl get nodes failed after 3 attempts"
+                          exit 1
+                      fi
+                  done
 
             - name: 📁 Get a copy of the reference architecture
               timeout-minutes: 10


### PR DESCRIPTION
Backport of #2668.

The operator-based integration test intermittently fails at **🔐 Login into the cluster** when the first `kubectl` call hits a transient runner→EKS network blip (`dial tcp ...: i/o timeout`) and hangs until the 2-minute step timeout. Retry `kubectl get nodes` up to 3× with a bounded `--request-timeout=30s` and a 15s backoff, and raise `timeout-minutes` 2→5. Failure behaviour preserved (exits non-zero after 3 attempts). Clean cherry-pick of `main`.
