### PR TITLE
test(aws): track latest EKS version in EKS upgrade test (8.9)

### DIFF
--- a/aws/modules/.test/src/upgrade_eks_test.go
+++ b/aws/modules/.test/src/upgrade_eks_test.go
@@ -49,7 +49,16 @@ func (suite *UpgradeEKSTestSuite) SetupTest() {
 	suite.tfBinaryName = utils.GetEnv("TESTS_TF_BINARY_NAME", "terraform")
 	suite.sugaredLogger.Infow("Terraform binary for the suite", "binary", suite.tfBinaryName)
 	suite.expectedNodes = 3
-	suite.kubeVersion = "1.29"
+	// The upgrade test creates the cluster one minor version below the latest EKS
+	// release and then upgrades it to that latest version. The latest version is
+	// tracked by Renovate (endoflife-date, in lockstep with the kubernetes_version
+	// module default) so the start version never drifts out of EKS's supported
+	// range and the upgrade always targets a creatable version.
+	// renovate: datasource=endoflife-date depName=amazon-eks versioning=loose
+	latestKubeVersion := "1.35"
+	var errDecVersion error
+	suite.kubeVersion, errDecVersion = utils.DecrementMinorVersionTwoParts(latestKubeVersion)
+	suite.Require().NoErrorf(errDecVersion, "Failed to compute the start Kubernetes version")
 	var errAbsPath error
 	suite.tfStateS3Bucket = utils.GetEnv("TF_STATE_BUCKET", fmt.Sprintf("tests-eks-tf-state-%s", suite.bucketRegion))
 	suite.tfDataDir, errAbsPath = filepath.Abs(fmt.Sprintf("../states/tf-data-%s", suite.clusterName))

--- a/aws/modules/.test/src/upgrade_eks_test.go
+++ b/aws/modules/.test/src/upgrade_eks_test.go
@@ -56,9 +56,9 @@ func (suite *UpgradeEKSTestSuite) SetupTest() {
 	// range and the upgrade always targets a creatable version.
 	// renovate: datasource=endoflife-date depName=amazon-eks versioning=loose
 	latestKubeVersion := "1.35"
-	var errDecVersion error
-	suite.kubeVersion, errDecVersion = utils.DecrementMinorVersionTwoParts(latestKubeVersion)
-	suite.Require().NoErrorf(errDecVersion, "Failed to compute the start Kubernetes version")
+	startVersion, err := utils.DecrementMinorVersionTwoParts(latestKubeVersion)
+	suite.Require().NoErrorf(err, "failed to derive the start Kubernetes version from latest %q", latestKubeVersion)
+	suite.kubeVersion = startVersion
 	var errAbsPath error
 	suite.tfStateS3Bucket = utils.GetEnv("TF_STATE_BUCKET", fmt.Sprintf("tests-eks-tf-state-%s", suite.bucketRegion))
 	suite.tfDataDir, errAbsPath = filepath.Abs(fmt.Sprintf("../states/tf-data-%s", suite.clusterName))

--- a/aws/modules/.test/src/utils/helper.go
+++ b/aws/modules/.test/src/utils/helper.go
@@ -31,3 +31,24 @@ func IncrementMinorVersionTwoParts(version string) (string, error) {
 
 	return newVersion, nil
 }
+
+func DecrementMinorVersionTwoParts(version string) (string, error) {
+	parts := strings.Split(version, ".")
+
+	if len(parts) != 2 {
+		return "", fmt.Errorf("invalid version format, expected 2 parts got %d", len(parts))
+	}
+
+	minor, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return "", err
+	}
+
+	if minor <= 0 {
+		return "", fmt.Errorf("cannot decrement minor version below 0, got %q", version)
+	}
+
+	newVersion := fmt.Sprintf("%s.%d", parts[0], minor-1)
+
+	return newVersion, nil
+}

--- a/aws/modules/.test/src/utils/helper.go
+++ b/aws/modules/.test/src/utils/helper.go
@@ -19,7 +19,7 @@ func IncrementMinorVersionTwoParts(version string) (string, error) {
 	parts := strings.Split(version, ".")
 
 	if len(parts) != 2 {
-		return "", fmt.Errorf("invalid version format, expected 2 parts got %d", len(parts))
+		return "", fmt.Errorf("invalid version format %q, expected 2 parts, got %d", version, len(parts))
 	}
 
 	minor, err := strconv.Atoi(parts[1])
@@ -36,7 +36,7 @@ func DecrementMinorVersionTwoParts(version string) (string, error) {
 	parts := strings.Split(version, ".")
 
 	if len(parts) != 2 {
-		return "", fmt.Errorf("invalid version format, expected 2 parts got %d", len(parts))
+		return "", fmt.Errorf("invalid version format %q, expected 2 parts, got %d", version, len(parts))
 	}
 
 	minor, err := strconv.Atoi(parts[1])
@@ -45,7 +45,7 @@ func DecrementMinorVersionTwoParts(version string) (string, error) {
 	}
 
 	if minor <= 0 {
-		return "", fmt.Errorf("cannot decrement minor version below 0, got %q", version)
+		return "", fmt.Errorf("cannot decrement minor version of %q: resulting minor version would be negative", version)
 	}
 
 	newVersion := fmt.Sprintf("%s.%d", parts[0], minor-1)

--- a/aws/modules/.test/src/utils/helper.go
+++ b/aws/modules/.test/src/utils/helper.go
@@ -24,7 +24,7 @@ func IncrementMinorVersionTwoParts(version string) (string, error) {
 
 	minor, err := strconv.Atoi(parts[1])
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("invalid minor version in %q: %w", version, err)
 	}
 
 	newVersion := fmt.Sprintf("%s.%d", parts[0], minor+1)
@@ -41,7 +41,7 @@ func DecrementMinorVersionTwoParts(version string) (string, error) {
 
 	minor, err := strconv.Atoi(parts[1])
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("invalid minor version in %q: %w", version, err)
 	}
 
 	if minor <= 0 {

--- a/aws/modules/.test/src/utils/helper_test.go
+++ b/aws/modules/.test/src/utils/helper_test.go
@@ -1,0 +1,89 @@
+package utils
+
+import "testing"
+
+func TestIncrementMinorVersionTwoParts(t *testing.T) {
+	tests := []struct {
+		name      string
+		version   string
+		expected  string
+		expectErr bool
+	}{
+		{name: "standard minor bump", version: "1.34", expected: "1.35"},
+		{name: "minor rolls over tens", version: "1.29", expected: "1.30"},
+		{name: "zero minor", version: "2.0", expected: "2.1"},
+		{name: "too many parts", version: "1.34.0", expectErr: true},
+		{name: "too few parts", version: "134", expectErr: true},
+		{name: "non numeric minor", version: "1.x", expectErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := IncrementMinorVersionTwoParts(tt.version)
+			if tt.expectErr {
+				if err == nil {
+					t.Fatalf("expected an error for version %q, got none", tt.version)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error for version %q: %v", tt.version, err)
+			}
+			if got != tt.expected {
+				t.Fatalf("IncrementMinorVersionTwoParts(%q) = %q, want %q", tt.version, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestDecrementMinorVersionTwoParts(t *testing.T) {
+	tests := []struct {
+		name      string
+		version   string
+		expected  string
+		expectErr bool
+	}{
+		{name: "standard minor drop", version: "1.35", expected: "1.34"},
+		{name: "minor rolls under tens", version: "1.30", expected: "1.29"},
+		{name: "cannot go below zero", version: "1.0", expectErr: true},
+		{name: "too many parts", version: "1.34.0", expectErr: true},
+		{name: "too few parts", version: "134", expectErr: true},
+		{name: "non numeric minor", version: "1.x", expectErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := DecrementMinorVersionTwoParts(tt.version)
+			if tt.expectErr {
+				if err == nil {
+					t.Fatalf("expected an error for version %q, got none", tt.version)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error for version %q: %v", tt.version, err)
+			}
+			if got != tt.expected {
+				t.Fatalf("DecrementMinorVersionTwoParts(%q) = %q, want %q", tt.version, got, tt.expected)
+			}
+		})
+	}
+}
+
+// TestIncrementDecrementRoundTrip ensures the two helpers are inverses for the
+// version range the upgrade test relies on (start = latest - 1, target = start + 1).
+func TestIncrementDecrementRoundTrip(t *testing.T) {
+	for _, latest := range []string{"1.30", "1.34", "1.35", "1.40"} {
+		start, err := DecrementMinorVersionTwoParts(latest)
+		if err != nil {
+			t.Fatalf("DecrementMinorVersionTwoParts(%q) unexpected error: %v", latest, err)
+		}
+		target, err := IncrementMinorVersionTwoParts(start)
+		if err != nil {
+			t.Fatalf("IncrementMinorVersionTwoParts(%q) unexpected error: %v", start, err)
+		}
+		if target != latest {
+			t.Fatalf("round trip mismatch: latest=%q start=%q target=%q", latest, start, target)
+		}
+	}
+}


### PR DESCRIPTION
Backport of #2682 to `stable/8.9`.

## Problem

`TestUpgradeEKSTestSuite` created the EKS cluster with a hardcoded Kubernetes version `1.29` and upgraded it by one minor. AWS EKS dropped `1.29`, so `CreateCluster` fails with `unsupported Kubernetes version 1.29`. The line had no Renovate annotation, so it silently rotted out of EKS's supported range.

## Fix

- Add `DecrementMinorVersionTwoParts` helper (+ unit tests).
- Track the latest EKS version via the `endoflife-date` / `amazon-eks` datasource (in lockstep with this branch's `kubernetes_version` module default, currently `1.35`) and derive the start version as `latest - 1`.
- The upgrade therefore creates `1.34` and upgrades to `1.35`, always targeting a creatable version, kept current by Renovate.

## Testing

- `go test ./utils/`, `go vet`, `gofmt`, `pre-commit` ✅
- Same change validated green on the integration test in #2682.
- The integration suite is skipped here for now via the `skip_aws_modules_eks_rds_os_tests` label.