### PR TITLE
chore(ci): drop stale bundled-Bitnami references in CI action docs/comments

### DIFF
--- a/.github/actions/camunda-smoke-test/README.md
+++ b/.github/actions/camunda-smoke-test/README.md
@@ -19,7 +19,7 @@ For non-Kubernetes (ECS Fargate, EC2):
 | `auth-mode` | <p>Authentication mode: oidc, basic, or none.</p> | `false` | `oidc` |
 | `namespace` | <p>Kubernetes namespace where Camunda is deployed. Used for kubectl port-forward and secret extraction.</p> | `false` | `camunda` |
 | `release-name` | <p>Helm release name for Camunda. Derives service names (e.g., <release>-zeebe-gateway).</p> | `false` | `camunda` |
-| `keycloak-url` | <p>In-cluster Keycloak base URL for OIDC auth. Operator: <code>http://keycloak-service:18080/auth</code> Bitnami: <code>http://&lt;release&gt;-keycloak:80/auth</code></p> | `false` | `""` |
+| `keycloak-url` | <p>In-cluster Keycloak base URL for OIDC auth (operator: <code>http://keycloak-service:18080/auth</code>).</p> | `false` | `""` |
 | `oidc-client-id` | <p>OIDC client ID for M2M authentication. If empty, auto-extracted from <release-name>-credentials secret (client ID defaults to 'orchestration').</p> | `false` | `""` |
 | `oidc-client-secret` | <p>OIDC client secret for M2M authentication. If empty, auto-extracted from <release-name>-credentials secret (key: identity-orchestration-client-token).</p> | `false` | `""` |
 | `oidc-token-url` | <p>OIDC token endpoint URL (e.g., https://<keycloak>/realms/camunda-platform/protocol/openid-connect/token). Required for non-Kubernetes deployments (ECS / EC2) when auth-mode=oidc. In Kubernetes mode this input is ignored — the URL is derived from the auto-port-forwarded Keycloak.</p> | `false` | `""` |
@@ -73,7 +73,7 @@ This action is a `composite` action.
     # Default: camunda
 
     keycloak-url:
-    # In-cluster Keycloak base URL for OIDC auth. Operator: `http://keycloak-service:18080/auth` Bitnami: `http://<release>-keycloak:80/auth`
+    # In-cluster Keycloak base URL for OIDC auth (operator: `http://keycloak-service:18080/auth`).
     #
     # Required: false
     # Default: ""

--- a/.github/actions/camunda-smoke-test/action.yml
+++ b/.github/actions/camunda-smoke-test/action.yml
@@ -41,9 +41,8 @@ inputs:
         default: camunda
     keycloak-url:
         description: >
-            In-cluster Keycloak base URL for OIDC auth.
-            Operator: `http://keycloak-service:18080/auth`
-            Bitnami: `http://<release>-keycloak:80/auth`
+            In-cluster Keycloak base URL for OIDC auth
+            (operator: `http://keycloak-service:18080/auth`).
         required: false
         default: ''
     # ── OIDC auth inputs ────────────────────────────────────────
@@ -234,8 +233,8 @@ runs:
               KC_HOST_PORT=$(echo "$KC_URL" \
                   | sed 's|^http[s]*://||' | sed 's|/.*||')
               KC_HOST=$(echo "$KC_HOST_PORT" | cut -d: -f1)
-              # Default remote port to 80 (operator/bitnami in-cluster keycloak
-              # services typically expose http on 80 or 18080). When the URL
+              # Default remote port to 80 (in-cluster keycloak services
+              # typically expose http on 80 or 18080). When the URL
               # contains an explicit :port (e.g. keycloak-service:18080), keep it.
               if [[ "$KC_HOST_PORT" == *:* ]]; then
                   KC_REMOTE_PORT=$(echo "$KC_HOST_PORT" | cut -d: -f2)

--- a/.github/actions/internal-integration-tests/action.yml
+++ b/.github/actions/internal-integration-tests/action.yml
@@ -265,8 +265,8 @@ runs:
                       echo "pf_es_pid=${PF_ES_PID}" >> "$GITHUB_OUTPUT"
                       # ECK enables xpack.security by default; expose the
                       # generated 'elastic' user password so preflight probes
-                      # can authenticate. Bitnami chart leaves ES open, so the
-                      # secret simply won't exist there.
+                      # can authenticate. If the secret is absent (ES deployed
+                      # without ECK security), fall back to unauthenticated.
                       ES_USER=""
                       ES_PASS=""
                       if kubectl get secret elasticsearch-es-elastic-user -n "$NS" >/dev/null 2>&1; then

--- a/.github/actions/kubernetes-wildcard-certificate/README.md
+++ b/.github/actions/kubernetes-wildcard-certificate/README.md
@@ -10,7 +10,7 @@ Setup wildcard TLS certificate from Vault for Kubernetes clusters
 | --- | --- | --- | --- |
 | `tld` | <p>Top-level domain for the wildcard certificate</p> | `false` | `camunda.ie` |
 | `namespace` | <p>Kubernetes namespace where the TLS secret will be created</p> | `false` | `camunda` |
-| `secret-name` | <p>Name(s) of the TLS secret(s) to create from the same wildcard certificate. Accepts a single name or a newline-separated list to provision multiple identical TLS secrets (e.g. one for the Camunda ingress and one consumed by the Bitnami Keycloak sub-chart) without burning Let's Encrypt quota.</p> | `false` | `camunda-tls` |
+| `secret-name` | <p>Name(s) of the TLS secret(s) to create from the same wildcard certificate. Accepts a single name or a newline-separated list to provision multiple identical TLS secrets (e.g. one for the Camunda ingress and one for a separate component) without burning Let's Encrypt quota.</p> | `false` | `camunda-tls` |
 | `vault-addr` | <p>Vault server address</p> | `true` | `""` |
 | `vault-role-id` | <p>Vault AppRole role ID</p> | `true` | `""` |
 | `vault-secret-id` | <p>Vault AppRole secret ID</p> | `true` | `""` |
@@ -40,8 +40,8 @@ This action is a `composite` action.
     secret-name:
     # Name(s) of the TLS secret(s) to create from the same wildcard certificate.
     # Accepts a single name or a newline-separated list to provision multiple
-    # identical TLS secrets (e.g. one for the Camunda ingress and one consumed
-    # by the Bitnami Keycloak sub-chart) without burning Let's Encrypt quota.
+    # identical TLS secrets (e.g. one for the Camunda ingress and one for a
+    # separate component) without burning Let's Encrypt quota.
     #
     # Required: false
     # Default: camunda-tls

--- a/.github/actions/kubernetes-wildcard-certificate/action.yml
+++ b/.github/actions/kubernetes-wildcard-certificate/action.yml
@@ -15,8 +15,8 @@ inputs:
         description: |
             Name(s) of the TLS secret(s) to create from the same wildcard certificate.
             Accepts a single name or a newline-separated list to provision multiple
-            identical TLS secrets (e.g. one for the Camunda ingress and one consumed
-            by the Bitnami Keycloak sub-chart) without burning Let's Encrypt quota.
+            identical TLS secrets (e.g. one for the Camunda ingress and one for a
+            separate component) without burning Let's Encrypt quota.
         required: false
         default: camunda-tls
     vault-addr:


### PR DESCRIPTION
## Motivation

Follow-up cleanup spun off from #2651's review. Camunda 8.10 (chart 15.x) is fully **operator-based**: the bundled Bitnami subcharts (Keycloak, PostgreSQL, Elasticsearch) were removed, and **no `bitnami/*` image is pulled** anywhere in the reference architectures.

> Verified: `git grep -E "bitnami/[a-z]|docker.io/bitnami"` returns nothing. Keycloak is `camunda/keycloak:quay-optimized-*` (Keycloak operator), PostgreSQL is CloudNativePG, Elasticsearch is ECK. The registry pull secrets (`index-docker-io`, `registry-camunda-cloud`) exist only for **Docker Hub rate limits** and the **Camunda Harbor mirror** (`registry.yml`: "Auth to avoid Docker download rate limit"; `registry-harbor.yml`: "Docker Hub is too slow on Azure") — not Bitnami.

Several CI action descriptions/comments still referenced the old bundled Bitnami Keycloak/Elasticsearch, which is now stale and misleading.

## What this PR does

Pure documentation/comment cleanup in CI actions — **no functional change**:

| File | Change |
|---|---|
| `camunda-smoke-test/action.yml` | `keycloak-url` description: drop the `Bitnami: http://<release>-keycloak:80/auth` example; port-default comment: drop `operator/bitnami` wording |
| `internal-integration-tests/action.yml` | ES preflight comment: keep the still-valid "secret may be absent" rationale, drop the Bitnami framing |
| `kubernetes-wildcard-certificate/action.yml` | `secret-name` description: generalise the multi-secret example (was "consumed by the Bitnami Keycloak sub-chart") |

The two affected action READMEs were regenerated (`action-docs`); the diff is exactly the reworded text, no formatting drift.

## Deliberately kept (not vestigial)

- `azure_kubernetes_aks_single_region_tests.yml` comment explaining that **chart 15 removed the bundled subcharts** (accurate history; justifies the empty `values.yml` base).
- The same workflow's registry **pull-secret** creation + its doc link: the secret is still required for image pulls (rate-limit / mirror), independent of Bitnami.
- `generic/kubernetes/migration/**`: legitimately references Bitnami — it is the migration-from-Bitnami tooling.

## Out of scope

- `CAMUNDA_MAJOR_VERSION` / `CAMUNDA_MINOR_VERSION` unused vars in `internal-camunda-chart-tests/action.yml` (pre-existing dead code from #1226, not Bitnami) — left for a separate cleanup to avoid overlap with #2651.

## Validation

- `yamllint`, `check-yaml`, YAML formatting: pass.
- Action READMEs regenerated and diff-verified (only the reworded text changed).
