### PR TITLE
fix(kind): quiet the Keycloak readiness-probe curl (drop -S)

### DIFF
--- a/local/kubernetes/kind-single-region/procedure/operators-deploy.sh
+++ b/local/kubernetes/kind-single-region/procedure/operators-deploy.sh
@@ -118,7 +118,7 @@ if [[ "$CAMUNDA_MODE" == "domain" ]]; then
     echo "Probing: ${probe_url}"
 
     for attempt in $(seq 1 "$max_attempts"); do
-        if curl -fsS -k -o /dev/null \
+        if curl -fs -k -o /dev/null \
             --resolve "${CAMUNDA_DOMAIN}:443:127.0.0.1" \
             --connect-timeout 5 --max-time 10 "$probe_url"; then
             echo "✓ Keycloak OIDC issuer reachable through the ingress"


### PR DESCRIPTION
## Context

Follow-up to **#2651** (merged). During the Copilot review of the **stable/8.9** backport (**#2652**), Copilot flagged that the Keycloak readiness-probe in `operators-deploy.sh` uses `curl -fsS`, where `-S` re-enables curl's error output even under `-s`. So every failed probe attempt prints a `curl: (...)` error to stderr — up to 60× while waiting for Keycloak — even though the loop already logs its own `attempt N/max` progress line.

#2651 was merged before this one-line fix landed, so `main` kept `-fsS`. This PR brings `main` in line with the 8.9 backport and clears the finding on `main`.

## Change

```diff
-        if curl -fsS -k -o /dev/null \
+        if curl -fs -k -o /dev/null \
```

Behaviour is unchanged: `-f` still fails on HTTP/connection errors (the `if`/exit logic is identical); only the now-redundant per-attempt stderr error messages are suppressed.

## Validation

`shellcheck` + pre-commit pass. The deploy path was already validated end-to-end on #2651 (all 4 kind declinations green); this only changes probe stderr verbosity.