### PR TITLE
ci(lint): backport demo-credentials guard to stable/8.9 (INC-5340)

### DIFF
--- a/.github/actions/camunda-smoke-test/scripts/http-smoke-test.sh
+++ b/.github/actions/camunda-smoke-test/scripts/http-smoke-test.sh
@@ -71,7 +71,7 @@ refresh_auth() {
 
 if [[ "$AUTH_MODE" == "basic" ]]; then
     if [[ -z "$BASIC_USER" || -z "$BASIC_PASSWORD" ]]; then
-        fail_test "basic auth requires SMOKE_BASIC_USER and SMOKE_BASIC_PASSWORD (refusing to fall back to demo:demo — see INC-5340)"
+        fail_test "basic auth requires SMOKE_BASIC_USER and SMOKE_BASIC_PASSWORD (refusing to fall back to demo:demo — see INC-5340)" # no-demo-credentials:ignore
         exit 1
     fi
     AUTH_ARGS=(-u "${BASIC_USER}:${BASIC_PASSWORD}")

--- a/.github/actions/internal-camunda-ci-credentials/README.md
+++ b/.github/actions/internal-camunda-ci-credentials/README.md
@@ -4,7 +4,7 @@
 
 Fetches a shared Camunda basic-auth user/password from Vault and exposes
 them to the workflow so that publicly reachable CI deployments never run
-with the chart/config default `demo:demo` credentials (see incident
+with the chart/config default `demo` credentials (see incident
 INC-5340).
 
 Outputs:

--- a/.github/actions/internal-camunda-ci-credentials/action.yml
+++ b/.github/actions/internal-camunda-ci-credentials/action.yml
@@ -3,7 +3,7 @@ name: Internal — Camunda CI basic-auth credentials
 description: |
     Fetches a shared Camunda basic-auth user/password from Vault and exposes
     them to the workflow so that publicly reachable CI deployments never run
-    with the chart/config default `demo:demo` credentials (see incident
+    with the chart/config default `demo` credentials (see incident
     INC-5340).
 
     Outputs:

--- a/.github/workflows/internal_global_no_demo_credentials.yml
+++ b/.github/workflows/internal_global_no_demo_credentials.yml
@@ -1,0 +1,37 @@
+---
+name: Internal - Global - No Demo Credentials
+
+# Fails the build when the hardcoded `demo:demo` Camunda admin credentials that
+# caused incident INC-5340 are re-introduced into a tracked file. The detection
+# logic lives in a single canonical script so the guard stays uniform across
+# main and every stable branch:
+#   .lint/check-no-demo-credentials/check-no-demo-credentials.sh
+
+on:
+    workflow_dispatch:
+    pull_request:
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
+jobs:
+    triage:
+        runs-on: ubuntu-latest
+        outputs:
+            should_skip: ${{ steps.skip_check.outputs.should_skip }}
+        steps:
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+            - name: Check labels
+              id: skip_check
+              uses: ./.github/actions/internal-triage-skip
+
+    check-no-demo-credentials:
+        needs:
+            - triage
+        if: needs.triage.outputs.should_skip == 'false'
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+            - name: Scan tracked files for hardcoded demo credentials
+              run: ./.lint/check-no-demo-credentials/check-no-demo-credentials.sh

--- a/.lint/check-no-demo-credentials/check-no-demo-credentials.sh
+++ b/.lint/check-no-demo-credentials/check-no-demo-credentials.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# check-no-demo-credentials.sh
+#
+# Guard against re-introducing the hardcoded `demo:demo` Camunda admin
+# credentials that caused incident INC-5340 (publicly reachable deployments
+# booting with a working demo / demo admin login).
+#
+# It fails the build when one of the canonical credential patterns appears in
+# a tracked file, outside the vendored sub-trees and documentation.
+#
+# Two legitimate cases are tolerated and skipped:
+#   1. Full-line comments  (`#`, `##`, `//`) — explanatory notes are not
+#      live credentials. The team intentionally keeps INC-5340 references.
+#   2. Lines carrying the inline opt-out marker (see ALLOW_MARKER) — used by
+#      the few guard messages that name the forbidden value on purpose.
+#
+# Usage: ./.lint/check-no-demo-credentials/check-no-demo-credentials.sh
+# Exit:  0 = clean, 1 = at least one hardcoded credential found.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+# Canonical credential patterns (POSIX ERE). Mirrors the acceptance-criteria
+# grep from camunda/team-infrastructure-experience#1111 so the check and the
+# incident stay in lock-step.
+PATTERN='demo:demo|demo/demo|USERNAME=demo|PASSWORD=demo|-u demo'
+
+# Inline opt-out marker. Append it (as a trailing comment) to a line that names
+# the forbidden value on purpose — e.g. an error message that refuses to fall
+# back to it. Keep these rare and reviewed.
+ALLOW_MARKER='no-demo-credentials:ignore'
+
+# Paths excluded from the scan:
+#   - vendored / sibling repos that ship their own history and policy
+#   - markdown docs (illustrative prose, auto-generated action READMEs)
+#   - this guard's own files (they necessarily contain the patterns above)
+EXCLUDES=(
+    ':!camunda-docs/'
+    ':!camunda-platform-helm/'
+    ':!infra-core/'
+    ':!c8-sm-checks/'
+    ':!*.md'
+    ':!.lint/check-no-demo-credentials/'
+)
+
+# git grep exits 1 when there is no match; that is the success path here.
+matches=()
+while IFS= read -r line; do
+    [ -n "$line" ] && matches+=("$line")
+done < <(git grep -nIE "$PATTERN" -- "${EXCLUDES[@]}" 2>/dev/null || true)
+
+violations=()
+for line in "${matches[@]}"; do
+    # git grep -n prints "path:lineno:content"; strip the first two fields.
+    content="${line#*:}"
+    content="${content#*:}"
+
+    # 1. Explicit, reviewed opt-out.
+    case "$content" in
+        *"$ALLOW_MARKER"*) continue ;;
+    esac
+
+    # 2. Full-line comments (leading #, ##, // after optional indentation).
+    trimmed="${content#"${content%%[![:space:]]*}"}"
+    case "$trimmed" in
+        '#'* | '//'*) continue ;;
+    esac
+
+    violations+=("$line")
+done
+
+if [ "${#violations[@]}" -gt 0 ]; then
+    {
+        echo "ERROR: hardcoded demo credentials detected (INC-5340)."
+        echo
+        printf '  %s\n' "${violations[@]}"
+        echo
+        echo "Fix: source the credential from configuration / Vault instead of"
+        echo "hardcoding it. If the match is an intentional, non-credential mention"
+        echo "(e.g. a guard message), append the marker '${ALLOW_MARKER}' to the line"
+        echo "after review."
+    } >&2
+    exit 1
+fi
+
+echo "OK: no hardcoded demo credentials found."

--- a/generic/compute/debian/procedure/camunda-configure.sh
+++ b/generic/compute/debian/procedure/camunda-configure.sh
@@ -67,7 +67,7 @@ echo "[INFO] Substituting credential placeholders in temporary config files..."
 export CAMUNDA_BASIC_AUTH_USER CAMUNDA_BASIC_AUTH_PASSWORD
 
 if [ "${CAMUNDA_BASIC_AUTH_USER}" = "demo" ] && [ "${CAMUNDA_BASIC_AUTH_PASSWORD}" = "demo" ]; then
-    echo "[WARN] Camunda is being configured with the default demo:demo credentials."
+    echo "[WARN] Camunda is being configured with the default demo:demo credentials." # no-demo-credentials:ignore
     echo "       Set CAMUNDA_BASIC_AUTH_USER and CAMUNDA_BASIC_AUTH_PASSWORD before running"
     echo "       this script to use unique credentials (recommended for any non-throwaway env)."
 fi

--- a/generic/kubernetes/migration/tests/verify-test-data-job.yml
+++ b/generic/kubernetes/migration/tests/verify-test-data-job.yml
@@ -181,7 +181,7 @@ spec:
                                     -d "{\"filter\":{\"processDefinitionId\":\"${PROCESS_ID}\"}}" 2>/dev/null || echo '{}')
                             else
                                 if [ -z "${DEMO_USER}" ] || [ -z "${DEMO_PASS}" ]; then
-                                    fail_test "Basic auth requested but CAMUNDA_BASIC_AUTH_USER/PASSWORD are empty (refusing to fall back to demo:demo — see INC-5340)"
+                                    fail_test "Basic auth requested but CAMUNDA_BASIC_AUTH_USER/PASSWORD are empty (refusing to fall back to defaults — see INC-5340)"
                                     break
                                 fi
                                 SEARCH_RESP=$(curl -sf --connect-timeout 5 --max-time 30 \


### PR DESCRIPTION
Backport of #2694 to `stable/8.9`.

Adds the uniform CI guard against re-introducing the hardcoded `demo:demo` credentials behind **INC-5340** (item 7 of [team-infrastructure-experience#1111](https://github.com/camunda/team-infrastructure-experience/issues/1111)).

- `.lint/check-no-demo-credentials/check-no-demo-credentials.sh` and `.github/workflows/internal_global_no_demo_credentials.yml` are **identical** to `main`.
- Per-branch annotations to make the tree scan clean: inline `no-demo-credentials:ignore` markers on the `http-smoke-test.sh` / `camunda-configure.sh` guard messages; reworded the `internal-camunda-ci-credentials` description and the `verify-test-data-job.yml` migration-test message to drop the now-pointless literal.

Verified locally: guard exits `0` on the clean tree and `1` on an injected `PASSWORD=demo` / `-u demo:demo`; `shellcheck` + `yamllint` pass.