### PR TITLE
ci(lint): backport demo-credentials guard to stable/8.6 (INC-5340)

### DIFF
--- a/.github/workflows/internal_global_no_demo_credentials.yml
+++ b/.github/workflows/internal_global_no_demo_credentials.yml
@@ -1,0 +1,24 @@
+---
+name: Internal - Global - No Demo Credentials
+
+# Fails the build when the hardcoded `demo:demo` Camunda admin credentials that
+# caused incident INC-5340 are re-introduced into a tracked file. The detection
+# logic lives in a single canonical script so the guard stays uniform across
+# main and every stable branch:
+#   .lint/check-no-demo-credentials/check-no-demo-credentials.sh
+
+on:
+    workflow_dispatch:
+    pull_request:
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
+jobs:
+    check-no-demo-credentials:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+            - name: Scan tracked files for hardcoded demo credentials
+              run: ./.lint/check-no-demo-credentials/check-no-demo-credentials.sh

--- a/.lint/check-no-demo-credentials/check-no-demo-credentials.sh
+++ b/.lint/check-no-demo-credentials/check-no-demo-credentials.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# check-no-demo-credentials.sh
+#
+# Guard against re-introducing the hardcoded `demo:demo` Camunda admin
+# credentials that caused incident INC-5340 (publicly reachable deployments
+# booting with a working demo / demo admin login).
+#
+# It fails the build when one of the canonical credential patterns appears in
+# a tracked file, outside the vendored sub-trees and documentation.
+#
+# Two legitimate cases are tolerated and skipped:
+#   1. Full-line comments  (`#`, `##`, `//`) — explanatory notes are not
+#      live credentials. The team intentionally keeps INC-5340 references.
+#   2. Lines carrying the inline opt-out marker (see ALLOW_MARKER) — used by
+#      the few guard messages that name the forbidden value on purpose.
+#
+# Usage: ./.lint/check-no-demo-credentials/check-no-demo-credentials.sh
+# Exit:  0 = clean, 1 = at least one hardcoded credential found.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+# Canonical credential patterns (POSIX ERE). Mirrors the acceptance-criteria
+# grep from camunda/team-infrastructure-experience#1111 so the check and the
+# incident stay in lock-step.
+PATTERN='demo:demo|demo/demo|USERNAME=demo|PASSWORD=demo|-u demo'
+
+# Inline opt-out marker. Append it (as a trailing comment) to a line that names
+# the forbidden value on purpose — e.g. an error message that refuses to fall
+# back to it. Keep these rare and reviewed.
+ALLOW_MARKER='no-demo-credentials:ignore'
+
+# Paths excluded from the scan:
+#   - vendored / sibling repos that ship their own history and policy
+#   - markdown docs (illustrative prose, auto-generated action READMEs)
+#   - this guard's own files (they necessarily contain the patterns above)
+EXCLUDES=(
+    ':!camunda-docs/'
+    ':!camunda-platform-helm/'
+    ':!infra-core/'
+    ':!c8-sm-checks/'
+    ':!*.md'
+    ':!.lint/check-no-demo-credentials/'
+)
+
+# git grep exits 1 when there is no match; that is the success path here.
+matches=()
+while IFS= read -r line; do
+    [ -n "$line" ] && matches+=("$line")
+done < <(git grep -nIE "$PATTERN" -- "${EXCLUDES[@]}" 2>/dev/null || true)
+
+violations=()
+for line in "${matches[@]}"; do
+    # git grep -n prints "path:lineno:content"; strip the first two fields.
+    content="${line#*:}"
+    content="${content#*:}"
+
+    # 1. Explicit, reviewed opt-out.
+    case "$content" in
+        *"$ALLOW_MARKER"*) continue ;;
+    esac
+
+    # 2. Full-line comments (leading #, ##, // after optional indentation).
+    trimmed="${content#"${content%%[![:space:]]*}"}"
+    case "$trimmed" in
+        '#'* | '//'*) continue ;;
+    esac
+
+    violations+=("$line")
+done
+
+if [ "${#violations[@]}" -gt 0 ]; then
+    {
+        echo "ERROR: hardcoded demo credentials detected (INC-5340)."
+        echo
+        printf '  %s\n' "${violations[@]}"
+        echo
+        echo "Fix: source the credential from configuration / Vault instead of"
+        echo "hardcoding it. If the match is an intentional, non-credential mention"
+        echo "(e.g. a guard message), append the marker '${ALLOW_MARKER}' to the line"
+        echo "after review."
+    } >&2
+    exit 1
+fi
+
+echo "OK: no hardcoded demo credentials found."


### PR DESCRIPTION
Backport of #2694 to `stable/8.6`.

Adds the uniform CI guard against re-introducing the hardcoded `demo:demo` credentials behind **INC-5340** (item 7 of [team-infrastructure-experience#1111](https://github.com/camunda/team-infrastructure-experience/issues/1111)).

- `.lint/check-no-demo-credentials/check-no-demo-credentials.sh` is **identical** to `main`.
- The tree is already clean on this branch — no annotations were required.
- The workflow **omits the `triage`/skip job** used on newer branches, because the `internal-triage-skip` action does not exist on `stable/8.6`; it runs the guard directly on `pull_request` / `workflow_dispatch`, matching this branch's simpler workflow style.

Verified locally: guard exits `0` clean / `1` on injected credentials; `shellcheck` + `yamllint` pass.