### PR TITLE
[READY] fix(openshift-dual-region): retry Submariner verify-subctl until both clusters connect + add gateway diagnostics

### DIFF
--- a/.github/workflows/aws_openshift_rosa_hcp_dual_region_tests.yml
+++ b/.github/workflows/aws_openshift_rosa_hcp_dual_region_tests.yml
@@ -462,7 +462,7 @@ jobs:
 
             - name: 🔬🚨 Debug Submariner connectivity
               if: failure()
-              run: ./generic/openshift/dual-region/procedure/submariner/diagnose-submariner.sh
+              run: bash ./generic/openshift/dual-region/procedure/submariner/diagnose-submariner.sh || true
 
             - name: 🏗️ Retrieve exported Environment values from outputs
               uses: ./.github/actions/internal-generic-decrypt-import

--- a/.github/workflows/aws_openshift_rosa_hcp_dual_region_tests.yml
+++ b/.github/workflows/aws_openshift_rosa_hcp_dual_region_tests.yml
@@ -460,6 +460,10 @@ jobs:
 
                   ./verify-subctl.sh
 
+            - name: 🔬🚨 Debug Submariner connectivity
+              if: failure()
+              run: ./generic/openshift/dual-region/procedure/submariner/diagnose-submariner.sh
+
             - name: 🏗️ Retrieve exported Environment values from outputs
               uses: ./.github/actions/internal-generic-decrypt-import
               with:

--- a/.github/workflows/aws_openshift_rosa_hcp_dual_region_tests.yml
+++ b/.github/workflows/aws_openshift_rosa_hcp_dual_region_tests.yml
@@ -462,7 +462,8 @@ jobs:
 
             - name: 🔬🚨 Debug Submariner connectivity
               if: failure()
-              run: bash ./generic/openshift/dual-region/procedure/submariner/diagnose-submariner.sh || true
+              timeout-minutes: 5
+              run: bash ./generic/openshift/dual-region/procedure/submariner/diagnose-submariner.sh
 
             - name: 🏗️ Retrieve exported Environment values from outputs
               uses: ./.github/actions/internal-generic-decrypt-import

--- a/generic/openshift/dual-region/procedure/submariner/diagnose-submariner.sh
+++ b/generic/openshift/dual-region/procedure/submariner/diagnose-submariner.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 # Best-effort diagnostics for the dual-region Submariner cross-cluster connection.
-# Dumps Submariner's own state (gateway pods, Gateway/Endpoint CRs, subctl diagnose)
-# to help understand why the cross-cluster tunnel did not establish. Never fails.
+# Dumps Submariner's own state (gateway pods, Gateway/Endpoint CRs, connections) to
+# help understand why the cross-cluster tunnel did not establish. Never fails and
+# never mutates the global kube context.
 set +e
 
 # Support both the 0-indexed (CLUSTER_0/CLUSTER_1) and 1-indexed
@@ -9,16 +10,17 @@ set +e
 C0="${CLUSTER_0:-${CLUSTER_1_NAME:-}}"
 C1="${CLUSTER_1:-${CLUSTER_2_NAME:-}}"
 
+have_subctl=false
+command -v subctl >/dev/null 2>&1 && have_subctl=true
+
 for ctx in "$C0" "$C1"; do
   [ -z "$ctx" ] && continue
   echo "===== Submariner diagnostics for context: ${ctx} ====="
-  # subctl context flags vary across releases; select the context via the kubeconfig
-  # and let subctl use the current context (portable across subctl versions).
-  oc config use-context "$ctx" >/dev/null 2>&1
-  echo "--- subctl show all ---"
-  subctl show all 2>&1
-  echo "--- subctl diagnose all ---"
-  subctl diagnose all 2>&1
+  if [ "$have_subctl" = true ]; then
+    echo "--- subctl show all ---"
+    # `--contexts` matches the repo's verify-subctl.sh (the working Submariner check).
+    subctl show all --contexts "$ctx" 2>&1
+  fi
   echo "--- submariner-operator pods ---"
   oc --context "$ctx" -n submariner-operator get pods -o wide 2>&1
   echo "--- submariner-gateway logs (last 200 lines) ---"

--- a/generic/openshift/dual-region/procedure/submariner/diagnose-submariner.sh
+++ b/generic/openshift/dual-region/procedure/submariner/diagnose-submariner.sh
@@ -12,10 +12,13 @@ C1="${CLUSTER_1:-${CLUSTER_2_NAME:-}}"
 for ctx in "$C0" "$C1"; do
   [ -z "$ctx" ] && continue
   echo "===== Submariner diagnostics for context: ${ctx} ====="
+  # subctl context flags vary across releases; select the context via the kubeconfig
+  # and let subctl use the current context (portable across subctl versions).
+  oc config use-context "$ctx" >/dev/null 2>&1
   echo "--- subctl show all ---"
-  subctl show all --contexts "$ctx" 2>&1
+  subctl show all 2>&1
   echo "--- subctl diagnose all ---"
-  subctl diagnose all --context "$ctx" 2>&1
+  subctl diagnose all 2>&1
   echo "--- submariner-operator pods ---"
   oc --context "$ctx" -n submariner-operator get pods -o wide 2>&1
   echo "--- submariner-gateway logs (last 200 lines) ---"

--- a/generic/openshift/dual-region/procedure/submariner/diagnose-submariner.sh
+++ b/generic/openshift/dual-region/procedure/submariner/diagnose-submariner.sh
@@ -33,7 +33,11 @@ done
 
 if [ -n "$C0" ]; then
   echo "===== ManagedClusterAddons (hub) ====="
-  oc --context "$C0" get managedclusteraddon -A -o wide 2>&1
+  oc --context "$C0" get managedclusteraddon -A 2>&1
+  # `-o wide` omits the status conditions; dump YAML so the addon conditions
+  # (which explain *why* an addon is Degraded / not Available) are captured.
+  echo "--- ManagedClusterAddon conditions ---"
+  oc --context "$C0" get managedclusteraddon -A -o yaml 2>&1
 fi
 
 # Best-effort diagnostics: never fail the `if: failure()` debug step that runs this.

--- a/generic/openshift/dual-region/procedure/submariner/diagnose-submariner.sh
+++ b/generic/openshift/dual-region/procedure/submariner/diagnose-submariner.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Best-effort diagnostics for the dual-region Submariner cross-cluster connection.
+# Dumps Submariner's own state (gateway pods, Gateway/Endpoint CRs, subctl diagnose)
+# to help understand why the cross-cluster tunnel did not establish. Never fails.
+set +e
+
+# Support both the 0-indexed (CLUSTER_0/CLUSTER_1) and 1-indexed
+# (CLUSTER_1_NAME/CLUSTER_2_NAME) cluster-context naming conventions.
+C0="${CLUSTER_0:-${CLUSTER_1_NAME:-}}"
+C1="${CLUSTER_1:-${CLUSTER_2_NAME:-}}"
+
+for ctx in "$C0" "$C1"; do
+  [ -z "$ctx" ] && continue
+  echo "===== Submariner diagnostics for context: ${ctx} ====="
+  echo "--- subctl show all ---"
+  subctl show all --contexts "$ctx" 2>&1
+  echo "--- subctl diagnose all ---"
+  subctl diagnose all --context "$ctx" 2>&1
+  echo "--- submariner-operator pods ---"
+  oc --context "$ctx" -n submariner-operator get pods -o wide 2>&1
+  echo "--- submariner-gateway logs (last 200 lines) ---"
+  oc --context "$ctx" -n submariner-operator logs -l app=submariner-gateway --tail=200 --prefix 2>&1
+  echo "--- Gateway / Endpoint CRs ---"
+  oc --context "$ctx" get gateways.submariner.io,endpoints.submariner.io -A -o wide 2>&1
+  echo "--- gateway-labelled nodes ---"
+  oc --context "$ctx" get nodes -l submariner.io/gateway=true -o wide 2>&1
+done
+
+echo "===== ManagedClusterAddons (hub) ====="
+oc --context "$C0" get managedclusteraddon -A -o wide 2>&1

--- a/generic/openshift/dual-region/procedure/submariner/diagnose-submariner.sh
+++ b/generic/openshift/dual-region/procedure/submariner/diagnose-submariner.sh
@@ -26,5 +26,10 @@ for ctx in "$C0" "$C1"; do
   oc --context "$ctx" get nodes -l submariner.io/gateway=true -o wide 2>&1
 done
 
-echo "===== ManagedClusterAddons (hub) ====="
-oc --context "$C0" get managedclusteraddon -A -o wide 2>&1
+if [ -n "$C0" ]; then
+  echo "===== ManagedClusterAddons (hub) ====="
+  oc --context "$C0" get managedclusteraddon -A -o wide 2>&1
+fi
+
+# Best-effort diagnostics: never fail the `if: failure()` debug step that runs this.
+exit 0

--- a/generic/openshift/dual-region/procedure/submariner/verify-subctl.sh
+++ b/generic/openshift/dual-region/procedure/submariner/verify-subctl.sh
@@ -1,29 +1,44 @@
 #!/bin/bash
+set -euo pipefail
 
 CLUSTERS=("$CLUSTER_1_NAME" "$CLUSTER_2_NAME")
 
+# The cross-cluster IPSec tunnel takes a few minutes to establish even after the
+# Submariner addons report Available=True. Poll until both clusters report an
+# established connection, up to a bounded timeout.
+TIMEOUT_SECONDS="${SUBCTL_VERIFY_TIMEOUT_SECONDS:-600}"
+POLL_INTERVAL_SECONDS="${SUBCTL_VERIFY_POLL_INTERVAL_SECONDS:-15}"
+deadline=$((SECONDS + TIMEOUT_SECONDS))
+
 # Check the status of both clusters
 while true; do
-    last_cluster_ok=false
+    all_connected=true
 
     for CLUSTER_NAME in "${CLUSTERS[@]}"; do
-        STATUS=$(subctl show all --contexts "$CLUSTER_NAME")
+        # `subctl show all` exits non-zero while no connection exists yet; tolerate
+        # that here so the retry loop is not aborted by `set -e` on the first poll.
+        STATUS=$(subctl show all --contexts "$CLUSTER_NAME" 2>&1 || true)
         echo "Status of Cluster ($CLUSTER_NAME):"
         echo "$STATUS"
 
         if echo "$STATUS" | grep -q "All connections (1) are established" && \
            echo "$STATUS" | grep -q " connected "; then
             echo "Gateway and Connection for $CLUSTER_NAME are correctly established!"
-            last_cluster_ok=true
         else
             echo "$CLUSTER_NAME is not fully connected, retrying..."
+            all_connected=false
         fi
     done
 
-    if [ "$last_cluster_ok" = true ]; then
+    if [ "$all_connected" = true ]; then
         echo "Both clusters are correctly connected!"
         exit 0
     fi
 
-    sleep 5
+    if [ "$SECONDS" -ge "$deadline" ]; then
+        echo "Submariner connections were not established within ${TIMEOUT_SECONDS}s." >&2
+        exit 1
+    fi
+
+    sleep "$POLL_INTERVAL_SECONDS"
 done


### PR DESCRIPTION
## Problem
Dual-region OpenShift CI repeatedly failed at **Configure Submariner** (`✗ No gateways detected` / `Connectivity test failed`). Root cause: `verify-subctl.sh` did not wait for the cross-cluster IPsec tunnel to establish on **both** clusters — it returned success as soon as the last/either cluster reported connected and otherwise looped unbounded. The tunnel needs ~2-3 min after the Submariner addons report `Available=True`, so it never got the chance to converge.

## Fix
- Backport the main-line `verify-subctl.sh`: tolerate `subctl show all` transient non-zero exit (`2>&1 || true`), require **both** clusters connected, and bound the loop with `SUBCTL_VERIFY_TIMEOUT_SECONDS` (default 600s) with a clear failure.
- Add `diagnose-submariner.sh` + an `if: failure()` step capturing Submariner state (gateway pods/logs, `Gateway`/`Endpoint` CRs, `subctl show all`, `managedclusteraddon` conditions) — which the existing pod debug does not.