### PR TITLE
[READY] ci(openshift-dual-region): capture Submariner gateway diagnostics on failure

### DIFF
--- a/.github/workflows/aws_openshift_rosa_hcp_dual_region_tests.yml
+++ b/.github/workflows/aws_openshift_rosa_hcp_dual_region_tests.yml
@@ -482,7 +482,7 @@ jobs:
 
             - name: 🔬🚨 Debug Submariner connectivity
               if: failure()
-              run: ./generic/openshift/dual-region/procedure/submariner/diagnose-submariner.sh
+              run: bash ./generic/openshift/dual-region/procedure/submariner/diagnose-submariner.sh || true
 
             - name: 🏗️ Retrieve exported Environment values from outputs
               uses: ./.github/actions/internal-generic-decrypt-import

--- a/.github/workflows/aws_openshift_rosa_hcp_dual_region_tests.yml
+++ b/.github/workflows/aws_openshift_rosa_hcp_dual_region_tests.yml
@@ -482,7 +482,8 @@ jobs:
 
             - name: 🔬🚨 Debug Submariner connectivity
               if: failure()
-              run: bash ./generic/openshift/dual-region/procedure/submariner/diagnose-submariner.sh || true
+              timeout-minutes: 5
+              run: bash ./generic/openshift/dual-region/procedure/submariner/diagnose-submariner.sh
 
             - name: 🏗️ Retrieve exported Environment values from outputs
               uses: ./.github/actions/internal-generic-decrypt-import

--- a/.github/workflows/aws_openshift_rosa_hcp_dual_region_tests.yml
+++ b/.github/workflows/aws_openshift_rosa_hcp_dual_region_tests.yml
@@ -480,6 +480,10 @@ jobs:
                   echo "Verifying subctl..."
                   ./verify-subctl.sh
 
+            - name: 🔬🚨 Debug Submariner connectivity
+              if: failure()
+              run: ./generic/openshift/dual-region/procedure/submariner/diagnose-submariner.sh
+
             - name: 🏗️ Retrieve exported Environment values from outputs
               uses: ./.github/actions/internal-generic-decrypt-import
               with:

--- a/generic/openshift/dual-region/procedure/submariner/diagnose-submariner.sh
+++ b/generic/openshift/dual-region/procedure/submariner/diagnose-submariner.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 # Best-effort diagnostics for the dual-region Submariner cross-cluster connection.
-# Dumps Submariner's own state (gateway pods, Gateway/Endpoint CRs, subctl diagnose)
-# to help understand why the cross-cluster tunnel did not establish. Never fails.
+# Dumps Submariner's own state (gateway pods, Gateway/Endpoint CRs, connections) to
+# help understand why the cross-cluster tunnel did not establish. Never fails and
+# never mutates the global kube context.
 set +e
 
 # Support both the 0-indexed (CLUSTER_0/CLUSTER_1) and 1-indexed
@@ -9,16 +10,17 @@ set +e
 C0="${CLUSTER_0:-${CLUSTER_1_NAME:-}}"
 C1="${CLUSTER_1:-${CLUSTER_2_NAME:-}}"
 
+have_subctl=false
+command -v subctl >/dev/null 2>&1 && have_subctl=true
+
 for ctx in "$C0" "$C1"; do
   [ -z "$ctx" ] && continue
   echo "===== Submariner diagnostics for context: ${ctx} ====="
-  # subctl context flags vary across releases; select the context via the kubeconfig
-  # and let subctl use the current context (portable across subctl versions).
-  oc config use-context "$ctx" >/dev/null 2>&1
-  echo "--- subctl show all ---"
-  subctl show all 2>&1
-  echo "--- subctl diagnose all ---"
-  subctl diagnose all 2>&1
+  if [ "$have_subctl" = true ]; then
+    echo "--- subctl show all ---"
+    # `--contexts` matches the repo's verify-subctl.sh (the working Submariner check).
+    subctl show all --contexts "$ctx" 2>&1
+  fi
   echo "--- submariner-operator pods ---"
   oc --context "$ctx" -n submariner-operator get pods -o wide 2>&1
   echo "--- submariner-gateway logs (last 200 lines) ---"

--- a/generic/openshift/dual-region/procedure/submariner/diagnose-submariner.sh
+++ b/generic/openshift/dual-region/procedure/submariner/diagnose-submariner.sh
@@ -12,10 +12,13 @@ C1="${CLUSTER_1:-${CLUSTER_2_NAME:-}}"
 for ctx in "$C0" "$C1"; do
   [ -z "$ctx" ] && continue
   echo "===== Submariner diagnostics for context: ${ctx} ====="
+  # subctl context flags vary across releases; select the context via the kubeconfig
+  # and let subctl use the current context (portable across subctl versions).
+  oc config use-context "$ctx" >/dev/null 2>&1
   echo "--- subctl show all ---"
-  subctl show all --contexts "$ctx" 2>&1
+  subctl show all 2>&1
   echo "--- subctl diagnose all ---"
-  subctl diagnose all --context "$ctx" 2>&1
+  subctl diagnose all 2>&1
   echo "--- submariner-operator pods ---"
   oc --context "$ctx" -n submariner-operator get pods -o wide 2>&1
   echo "--- submariner-gateway logs (last 200 lines) ---"

--- a/generic/openshift/dual-region/procedure/submariner/diagnose-submariner.sh
+++ b/generic/openshift/dual-region/procedure/submariner/diagnose-submariner.sh
@@ -33,7 +33,11 @@ done
 
 if [ -n "$C0" ]; then
   echo "===== ManagedClusterAddons (hub) ====="
-  oc --context "$C0" get managedclusteraddon -A -o wide 2>&1
+  oc --context "$C0" get managedclusteraddon -A 2>&1
+  # `-o wide` omits the status conditions; dump YAML so the addon conditions
+  # (which explain *why* an addon is Degraded / not Available) are captured.
+  echo "--- ManagedClusterAddon conditions ---"
+  oc --context "$C0" get managedclusteraddon -A -o yaml 2>&1
 fi
 
 # Best-effort diagnostics: never fail the `if: failure()` debug step that runs this.

--- a/generic/openshift/dual-region/procedure/submariner/diagnose-submariner.sh
+++ b/generic/openshift/dual-region/procedure/submariner/diagnose-submariner.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Best-effort diagnostics for the dual-region Submariner cross-cluster connection.
+# Dumps Submariner's own state (gateway pods, Gateway/Endpoint CRs, subctl diagnose)
+# to help understand why the cross-cluster tunnel did not establish. Never fails.
+set +e
+
+# Support both the 0-indexed (CLUSTER_0/CLUSTER_1) and 1-indexed
+# (CLUSTER_1_NAME/CLUSTER_2_NAME) cluster-context naming conventions.
+C0="${CLUSTER_0:-${CLUSTER_1_NAME:-}}"
+C1="${CLUSTER_1:-${CLUSTER_2_NAME:-}}"
+
+for ctx in "$C0" "$C1"; do
+  [ -z "$ctx" ] && continue
+  echo "===== Submariner diagnostics for context: ${ctx} ====="
+  echo "--- subctl show all ---"
+  subctl show all --contexts "$ctx" 2>&1
+  echo "--- subctl diagnose all ---"
+  subctl diagnose all --context "$ctx" 2>&1
+  echo "--- submariner-operator pods ---"
+  oc --context "$ctx" -n submariner-operator get pods -o wide 2>&1
+  echo "--- submariner-gateway logs (last 200 lines) ---"
+  oc --context "$ctx" -n submariner-operator logs -l app=submariner-gateway --tail=200 --prefix 2>&1
+  echo "--- Gateway / Endpoint CRs ---"
+  oc --context "$ctx" get gateways.submariner.io,endpoints.submariner.io -A -o wide 2>&1
+  echo "--- gateway-labelled nodes ---"
+  oc --context "$ctx" get nodes -l submariner.io/gateway=true -o wide 2>&1
+done
+
+echo "===== ManagedClusterAddons (hub) ====="
+oc --context "$C0" get managedclusteraddon -A -o wide 2>&1

--- a/generic/openshift/dual-region/procedure/submariner/diagnose-submariner.sh
+++ b/generic/openshift/dual-region/procedure/submariner/diagnose-submariner.sh
@@ -26,5 +26,10 @@ for ctx in "$C0" "$C1"; do
   oc --context "$ctx" get nodes -l submariner.io/gateway=true -o wide 2>&1
 done
 
-echo "===== ManagedClusterAddons (hub) ====="
-oc --context "$C0" get managedclusteraddon -A -o wide 2>&1
+if [ -n "$C0" ]; then
+  echo "===== ManagedClusterAddons (hub) ====="
+  oc --context "$C0" get managedclusteraddon -A -o wide 2>&1
+fi
+
+# Best-effort diagnostics: never fail the `if: failure()` debug step that runs this.
+exit 0


### PR DESCRIPTION
## Context
The dual-region OpenShift `Configure Submariner` failures were hard to diagnose because nothing in CI captured Submariner's own state (existing failure-debug only inspects the Camunda namespace + a clusterset DNS/TCP probe).

## Change
Add `diagnose-submariner.sh` (best-effort, portable across the 0-/1-indexed cluster-var conventions) run from an `if: failure()` step. Per cluster context it dumps: `subctl show all`, `submariner-operator` pods + `submariner-gateway` logs, `Gateway`/`Endpoint` CRs, the gateway-labelled node, and the hub `managedclusteraddon` state (including the conditions that explain a Degraded / not-Available addon).

`verify-subctl.sh` already has the bounded-retry fix on this branch.