### PR TITLE
feat(ci): tag ingress-nginx NLB with map-migrated for AWS MAP (backport stable/8.7)

### DIFF
--- a/.github/actions/aws-kubernetes-ingress-setup/action.yml
+++ b/.github/actions/aws-kubernetes-ingress-setup/action.yml
@@ -110,6 +110,16 @@ runs:
               echo "Installing ingress-nginx..."
               ./aws/kubernetes/${{ inputs.ref-arch }}/procedure/install-ingress-nginx.sh
 
+              # Tag the ingress-nginx load balancer for the AWS MAP program.
+              # The NLB is provisioned by the in-tree AWS cloud provider from the Service
+              # object, so it does not inherit the Terraform provider default_tags that
+              # carry the map-migrated tag. The tag is applied here, in CI only, so the
+              # reference procedures (which are rendered in the docs) stay free of
+              # Camunda's MAP id; the cloud provider then propagates it onto the NLB.
+              echo "Tagging ingress-nginx-controller load balancer with map-migrated for AWS MAP ..."
+              kubectl annotate service ingress-nginx-controller --namespace ingress-nginx --overwrite \
+                  'service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags=map-migrated=migARUADZHVWZ'
+
               # Install external-dns
               echo "Installing external-dns..."
               export EXTERNAL_DNS_OWNER_ID="external-dns-${{ inputs.cluster-name }}-${{ inputs.scenario-short-name }}"

--- a/aws/kubernetes/eks-single-region/procedure/install-ingress-nginx.sh
+++ b/aws/kubernetes/eks-single-region/procedure/install-ingress-nginx.sh
@@ -7,6 +7,5 @@ helm upgrade --install \
   --set 'controller.service.annotations.service\.beta\.kubernetes\.io\/aws-load-balancer-backend-protocol=tcp' \
   --set 'controller.service.annotations.service\.beta\.kubernetes\.io\/aws-load-balancer-cross-zone-load-balancing-enabled=true' \
   --set 'controller.service.annotations.service\.beta\.kubernetes\.io\/aws-load-balancer-type=nlb' \
-  --set 'controller.service.annotations.service\.beta\.kubernetes\.io\/aws-load-balancer-additional-resource-tags=map-migrated\=migARUADZHVWZ' \
   --namespace ingress-nginx \
   --create-namespace

--- a/aws/kubernetes/eks-single-region/procedure/install-ingress-nginx.sh
+++ b/aws/kubernetes/eks-single-region/procedure/install-ingress-nginx.sh
@@ -7,5 +7,6 @@ helm upgrade --install \
   --set 'controller.service.annotations.service\.beta\.kubernetes\.io\/aws-load-balancer-backend-protocol=tcp' \
   --set 'controller.service.annotations.service\.beta\.kubernetes\.io\/aws-load-balancer-cross-zone-load-balancing-enabled=true' \
   --set 'controller.service.annotations.service\.beta\.kubernetes\.io\/aws-load-balancer-type=nlb' \
+  --set 'controller.service.annotations.service\.beta\.kubernetes\.io\/aws-load-balancer-additional-resource-tags=map-migrated\=migARUADZHVWZ' \
   --namespace ingress-nginx \
   --create-namespace


### PR DESCRIPTION
Backport of #2707 to `stable/8.7`.

On `stable/8.7` the EKS single-region architecture uses **ingress-nginx** (Contour was introduced later) and there is no `eks-dual-region`, so only the ingress controller NLB needs tagging.

Tags it with `map-migrated=migARUADZHVWZ` **in CI only** — the `aws-kubernetes-ingress-setup` action annotates the `ingress-nginx-controller` Service (`ingress-nginx` namespace) after install, and the in-tree AWS cloud provider propagates the tag onto the NLB. The doc-rendered `install-ingress-nginx.sh` stays free of Camunda's MAP id.

relates to camunda/team-infrastructure-experience#1151
