### PR TITLE
fix(ci): install gh CLI before Slack alert in helm deprecation check

### DIFF
--- a/.github/actions/internal-helm-deprecation-check/action.yml
+++ b/.github/actions/internal-helm-deprecation-check/action.yml
@@ -436,6 +436,58 @@ runs:
                   --run-url "${GH_SERVER_URL}/${GH_REPO}/actions/runs/${GH_RUN_ID}" \
                   --findings-file "${FINDINGS_FILE}"
 
+        - name: 🛠️ Ensure GitHub CLI is available for the Slack alert
+          # The report-failure-on-slack step below shells out to `gh` (silence
+          # check + failure-log-analyzer trigger). `gh` is preinstalled on
+          # GitHub-hosted runners but NOT on the self-hosted runners used by the
+          # deployment test jobs, so the step failed there with exit code 127.
+          # Install a pinned, checksum-verified `gh` only when the Slack alert
+          # will actually run and `gh` is missing; GitHub-hosted callers keep
+          # using their preinstalled CLI.
+          if: |
+              always()
+              && env.IS_SCHEDULE == 'true'
+              && steps.report-findings.outputs.findings-present == 'true'
+              && inputs.vault-addr != ''
+              && inputs.vault-role-id != ''
+              && inputs.vault-secret-id != ''
+          shell: bash
+          env:
+              # renovate: datasource=github-tags depName=cli/cli
+              GH_CLI_VERSION: v2.95.0
+          run: |
+              set -euo pipefail
+
+              if command -v gh >/dev/null 2>&1; then
+                  echo "GitHub CLI already available: $(gh --version | head -n1)"
+                  exit 0
+              fi
+
+              VERSION="${GH_CLI_VERSION#v}"
+              case "$(uname -m)" in
+                  x86_64) GH_ARCH="amd64" ;;
+                  aarch64 | arm64) GH_ARCH="arm64" ;;
+                  *) echo "::error::Unsupported architecture for GitHub CLI install: $(uname -m)"; exit 1 ;;
+              esac
+
+              TMP_DIR="$(mktemp -d)"
+              TARBALL="gh_${VERSION}_linux_${GH_ARCH}.tar.gz"
+              BASE_URL="https://github.com/cli/cli/releases/download/${GH_CLI_VERSION}"
+
+              echo "GitHub CLI not found; installing ${VERSION} (${GH_ARCH})..."
+              curl -fsSL --retry 5 --retry-delay 10 -o "${TMP_DIR}/${TARBALL}" "${BASE_URL}/${TARBALL}"
+              curl -fsSL --retry 5 --retry-delay 10 -o "${TMP_DIR}/checksums.txt" "${BASE_URL}/gh_${VERSION}_checksums.txt"
+
+              # Verify the download against the official checksums before trusting it.
+              (cd "${TMP_DIR}" && grep " ${TARBALL}$" checksums.txt | sha256sum -c -)
+
+              tar -xzf "${TMP_DIR}/${TARBALL}" -C "${TMP_DIR}"
+              GH_BIN_DIR="${TMP_DIR}/gh_${VERSION}_linux_${GH_ARCH}/bin"
+
+              # Expose gh to the subsequent report-failure-on-slack step.
+              echo "${GH_BIN_DIR}" >> "${GITHUB_PATH}"
+              echo "GitHub CLI installed: $("${GH_BIN_DIR}/gh" --version | head -n1)"
+
         - name: 🔔 Alert Slack on scheduled-run findings
           if: |
               always()

--- a/.github/actions/internal-helm-deprecation-check/action.yml
+++ b/.github/actions/internal-helm-deprecation-check/action.yml
@@ -113,6 +113,95 @@ inputs:
 runs:
     using: composite
     steps:
+        - name: 🛠️ Resolve GitHub CLI setup for the scheduled Slack alert
+          id: gh-cli
+          # The report-failure-on-slack step (run on scheduled findings) shells
+          # out to `gh` (silence check + failure-log-analyzer trigger). `gh` is
+          # preinstalled on GitHub-hosted runners but absent from the self-hosted
+          # runners used by the deployment test jobs, where it failed with exit
+          # code 127. Resolve up front whether we must provide our own `gh` and
+          # where it should live, so the binary can be cached across runs.
+          if: |
+              env.IS_SCHEDULE == 'true'
+              && inputs.vault-addr != ''
+              && inputs.vault-role-id != ''
+              && inputs.vault-secret-id != ''
+          shell: bash
+          env:
+              # renovate: datasource=github-tags depName=cli/cli
+              GH_CLI_VERSION: v2.95.0
+          run: |
+              set -euo pipefail
+
+              if command -v gh >/dev/null 2>&1; then
+                  echo "GitHub CLI already available: $(gh --version | head -n1)"
+                  echo "need-install=false" >> "${GITHUB_OUTPUT}"
+                  exit 0
+              fi
+
+              case "$(uname -m)" in
+                  x86_64) GH_ARCH="amd64" ;;
+                  aarch64 | arm64) GH_ARCH="arm64" ;;
+                  *) echo "::error::Unsupported architecture for GitHub CLI install: $(uname -m)"; exit 1 ;;
+              esac
+
+              VERSION="${GH_CLI_VERSION#v}"
+              # Stable, runner-persistent location (RUNNER_TEMP changes per job,
+              # which would defeat actions/cache absolute-path restoration).
+              INSTALL_DIR="${HOME}/.cache/gh-cli/${VERSION}-${GH_ARCH}"
+              mkdir -p "${INSTALL_DIR}"
+
+              {
+                  echo "need-install=true"
+                  echo "version=${VERSION}"
+                  echo "arch=${GH_ARCH}"
+                  echo "install-dir=${INSTALL_DIR}"
+                  echo "bin-dir=${INSTALL_DIR}/gh_${VERSION}_linux_${GH_ARCH}/bin"
+                  echo "cache-key=gh-cli-${RUNNER_OS}-${GH_ARCH}-${VERSION}"
+              } >> "${GITHUB_OUTPUT}"
+
+        - name: 💾 Restore cached GitHub CLI
+          id: gh-cli-cache
+          if: steps.gh-cli.outputs.need-install == 'true'
+          uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+          with:
+              path: ${{ steps.gh-cli.outputs.install-dir }}
+              key: ${{ steps.gh-cli.outputs.cache-key }}
+
+        - name: 🛠️ Install GitHub CLI
+          if: steps.gh-cli.outputs.need-install == 'true'
+          shell: bash
+          env:
+              CACHE_HIT: ${{ steps.gh-cli-cache.outputs.cache-hit }}
+              VERSION: ${{ steps.gh-cli.outputs.version }}
+              GH_ARCH: ${{ steps.gh-cli.outputs.arch }}
+              INSTALL_DIR: ${{ steps.gh-cli.outputs.install-dir }}
+              BIN_DIR: ${{ steps.gh-cli.outputs.bin-dir }}
+          run: |
+              set -euo pipefail
+
+              if [[ "${CACHE_HIT}" == "true" && -x "${BIN_DIR}/gh" ]]; then
+                  echo "Using cached GitHub CLI ${VERSION} (${GH_ARCH})"
+              else
+                  TARBALL="gh_${VERSION}_linux_${GH_ARCH}.tar.gz"
+                  BASE_URL="https://github.com/cli/cli/releases/download/v${VERSION}"
+
+                  echo "Downloading GitHub CLI ${VERSION} (${GH_ARCH})..."
+                  TMP_DIR="$(mktemp -d)"
+                  curl -fsSL --retry 5 --retry-delay 10 -o "${TMP_DIR}/${TARBALL}" "${BASE_URL}/${TARBALL}"
+                  curl -fsSL --retry 5 --retry-delay 10 -o "${TMP_DIR}/checksums.txt" "${BASE_URL}/gh_${VERSION}_checksums.txt"
+
+                  # Verify the download against the official checksums before trusting it.
+                  (cd "${TMP_DIR}" && grep " ${TARBALL}$" checksums.txt | sha256sum -c -)
+
+                  tar -xzf "${TMP_DIR}/${TARBALL}" -C "${INSTALL_DIR}"
+                  rm -rf "${TMP_DIR}"
+              fi
+
+              # Expose gh to the rest of the job, incl. the report-failure-on-slack step.
+              echo "${BIN_DIR}" >> "${GITHUB_PATH}"
+              echo "GitHub CLI ready: $("${BIN_DIR}/gh" --version | head -n1)"
+
         - name: 🔍 Check for Helm deprecation warnings
           shell: bash
           env:
@@ -435,58 +524,6 @@ runs:
                   --section-key "${INPUT_SECTION_KEY}" \
                   --run-url "${GH_SERVER_URL}/${GH_REPO}/actions/runs/${GH_RUN_ID}" \
                   --findings-file "${FINDINGS_FILE}"
-
-        - name: 🛠️ Ensure GitHub CLI is available for the Slack alert
-          # The report-failure-on-slack step below shells out to `gh` (silence
-          # check + failure-log-analyzer trigger). `gh` is preinstalled on
-          # GitHub-hosted runners but NOT on the self-hosted runners used by the
-          # deployment test jobs, so the step failed there with exit code 127.
-          # Install a pinned, checksum-verified `gh` only when the Slack alert
-          # will actually run and `gh` is missing; GitHub-hosted callers keep
-          # using their preinstalled CLI.
-          if: |
-              always()
-              && env.IS_SCHEDULE == 'true'
-              && steps.report-findings.outputs.findings-present == 'true'
-              && inputs.vault-addr != ''
-              && inputs.vault-role-id != ''
-              && inputs.vault-secret-id != ''
-          shell: bash
-          env:
-              # renovate: datasource=github-tags depName=cli/cli
-              GH_CLI_VERSION: v2.95.0
-          run: |
-              set -euo pipefail
-
-              if command -v gh >/dev/null 2>&1; then
-                  echo "GitHub CLI already available: $(gh --version | head -n1)"
-                  exit 0
-              fi
-
-              VERSION="${GH_CLI_VERSION#v}"
-              case "$(uname -m)" in
-                  x86_64) GH_ARCH="amd64" ;;
-                  aarch64 | arm64) GH_ARCH="arm64" ;;
-                  *) echo "::error::Unsupported architecture for GitHub CLI install: $(uname -m)"; exit 1 ;;
-              esac
-
-              TMP_DIR="$(mktemp -d)"
-              TARBALL="gh_${VERSION}_linux_${GH_ARCH}.tar.gz"
-              BASE_URL="https://github.com/cli/cli/releases/download/${GH_CLI_VERSION}"
-
-              echo "GitHub CLI not found; installing ${VERSION} (${GH_ARCH})..."
-              curl -fsSL --retry 5 --retry-delay 10 -o "${TMP_DIR}/${TARBALL}" "${BASE_URL}/${TARBALL}"
-              curl -fsSL --retry 5 --retry-delay 10 -o "${TMP_DIR}/checksums.txt" "${BASE_URL}/gh_${VERSION}_checksums.txt"
-
-              # Verify the download against the official checksums before trusting it.
-              (cd "${TMP_DIR}" && grep " ${TARBALL}$" checksums.txt | sha256sum -c -)
-
-              tar -xzf "${TMP_DIR}/${TARBALL}" -C "${TMP_DIR}"
-              GH_BIN_DIR="${TMP_DIR}/gh_${VERSION}_linux_${GH_ARCH}/bin"
-
-              # Expose gh to the subsequent report-failure-on-slack step.
-              echo "${GH_BIN_DIR}" >> "${GITHUB_PATH}"
-              echo "GitHub CLI installed: $("${GH_BIN_DIR}/gh" --version | head -n1)"
 
         - name: 🔔 Alert Slack on scheduled-run findings
           if: |


### PR DESCRIPTION
## Problem

On scheduled runs of the Kubernetes integration test workflows, the
`🔍 Check for Helm deprecation warnings` step fails with:

```
gh: command not found
##[error]Process completed with exit code 127.
```

Example failure (Kind single region, `stable/8.9`, `Test Kind - no-domain`):
https://github.com/camunda/camunda-deployment-references/actions/runs/27724411899/job/82091191926

## Root cause

`internal-helm-deprecation-check` invokes the shared
`camunda/infraex-common-config/.github/actions/report-failure-on-slack`
action to post deprecation-drift findings on scheduled runs. That action
shells out to `gh` twice (silence-issue check + failure-log-analyzer
trigger). `gh` is preinstalled on GitHub-hosted runners but **not** on the
self-hosted runners (`aws-core-8-*`) used by the deployment test jobs, so
both `gh` calls exit `127`.

The workflow-level `report-failure` jobs don't hit this because they run on
`ubuntu-latest`; only the in-job deprecation check (running on the
self-hosted deploy runner) is affected.

## Fix

Add a step to `internal-helm-deprecation-check` that installs a pinned,
checksum-verified GitHub CLI immediately before the Slack alert — only when
that alert will actually run (scheduled run + findings present + Vault inputs)
**and** `gh` is missing. GitHub-hosted callers keep using their preinstalled
CLI, and the version is Renovate-managed (`datasource=github-tags depName=cli/cli`).

This action is shared by every single- and multi-region Kubernetes test
workflow (Kind, EKS, AKS, ROSA, generic operator-based), so the fix applies
to all of them.

## Validation

- `yamllint`, `yamlfmt`, `check-yaml`, `end-of-file-fixer`, `trailing-whitespace`: pass
- `shellcheck` on the embedded install script: clean
- `action-docs` output is byte-identical before/after (README needs no update)
- Verified the real download + checksum + `bin/gh` extraction end-to-end against `v2.95.0`

## Backport

Labeled `backport stable/8.9` (the action only exists on `main` and
`stable/8.9`; it is not present on `stable/8.7` / `stable/8.8`).
