### PR TITLE
fix(ci): surface Helm drift as a Slack warning, not a failure alert

### DIFF
--- a/.github/actions/internal-helm-deprecation-check/README.md
+++ b/.github/actions/internal-helm-deprecation-check/README.md
@@ -15,7 +15,8 @@ Findings are reported in an event-aware, non-blocking way:
     workflow/job/release/namespace combination).
   - schedule (real or simulated via a `schedules/*` head_ref): emitted
     as ::warning:: annotations and, when the Slack inputs are wired,
-    posted to Slack via the shared report-failure-on-slack action.
+    posted to Slack via the shared report-warning-on-slack action
+    (an advisory, non-failure notification).
     Simulated schedules are detected from the caller workflow's
     `IS_SCHEDULE` env var (set to `'true'` when
     `contains(github.head_ref, 'schedules/') || github.event_name == 'schedule'`).

--- a/.github/actions/internal-helm-deprecation-check/action.yml
+++ b/.github/actions/internal-helm-deprecation-check/action.yml
@@ -14,7 +14,8 @@ description: |
         workflow/job/release/namespace combination).
       - schedule (real or simulated via a `schedules/*` head_ref): emitted
         as ::warning:: annotations and, when the Slack inputs are wired,
-        posted to Slack via the shared report-failure-on-slack action.
+        posted to Slack via the shared report-warning-on-slack action
+        (an advisory, non-failure notification).
         Simulated schedules are detected from the caller workflow's
         `IS_SCHEDULE` env var (set to `'true'` when
         `contains(github.head_ref, 'schedules/') || github.event_name == 'schedule'`).
@@ -436,7 +437,7 @@ runs:
                   --run-url "${GH_SERVER_URL}/${GH_REPO}/actions/runs/${GH_RUN_ID}" \
                   --findings-file "${FINDINGS_FILE}"
 
-        - name: 🔔 Alert Slack on scheduled-run findings
+        - name: 🔔 Warn on Slack about scheduled-run findings
           if: |
               always()
               && env.IS_SCHEDULE == 'true'
@@ -444,7 +445,12 @@ runs:
               && inputs.vault-addr != ''
               && inputs.vault-role-id != ''
               && inputs.vault-secret-id != ''
-          uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@ce8f360e366f900378c3d1531d1f278f3789f04b # 1.7.0
+          # report-warning-on-slack posts an advisory (non-failure) Slack message, so
+          # non-blocking Helm drift on scheduled stable/* runs no longer looks like a
+          # red "STABLE BRANCH FAILURE" alert pointing at a green run.
+          # Pending release of camunda/infraex-common-config#502; repin to the tagged
+          # SHA once it merges.
+          uses: camunda/infraex-common-config/.github/actions/report-warning-on-slack@3a947cec0e79beb52e1f04b8da0c8ddc5c51fe52 # pending release (PR #502)
           with:
               vault_addr: ${{ inputs.vault-addr }}
               vault_role_id: ${{ inputs.vault-role-id }}
@@ -452,3 +458,6 @@ runs:
               slack_channel_id: ${{ inputs.slack-channel-id != '' && inputs.slack-channel-id || (env.IS_SCHEDULE == 'true' && 'C076N4G1162' || 'C07E4FF6YMB')
                   }}
               slack_mention_people: ${{ inputs.slack-mention-people }}
+              title: Helm configuration drift
+              message: ${{ format('Helm release {0} has non-blocking deprecation / unknown-key findings (ignored by the chart); run did not fail.', inputs.release-name)
+                  }}

--- a/.github/actions/internal-helm-deprecation-check/action.yml
+++ b/.github/actions/internal-helm-deprecation-check/action.yml
@@ -448,9 +448,7 @@ runs:
           # report-warning-on-slack posts an advisory (non-failure) Slack message, so
           # non-blocking Helm drift on scheduled stable/* runs no longer looks like a
           # red "STABLE BRANCH FAILURE" alert pointing at a green run.
-          # Pending release of camunda/infraex-common-config#502; repin to the tagged
-          # SHA once it merges.
-          uses: camunda/infraex-common-config/.github/actions/report-warning-on-slack@293f79e94a2cd39c7b1a8eac77cf5463325d5f70 # camunda/infraex-common-config#502
+          uses: camunda/infraex-common-config/.github/actions/report-warning-on-slack@bde1b69728d323c1c2d02e19153a8e00382eec4a # 1.8.0
           with:
               vault_addr: ${{ inputs.vault-addr }}
               vault_role_id: ${{ inputs.vault-role-id }}

--- a/.github/actions/internal-helm-deprecation-check/action.yml
+++ b/.github/actions/internal-helm-deprecation-check/action.yml
@@ -450,7 +450,7 @@ runs:
           # red "STABLE BRANCH FAILURE" alert pointing at a green run.
           # Pending release of camunda/infraex-common-config#502; repin to the tagged
           # SHA once it merges.
-          uses: camunda/infraex-common-config/.github/actions/report-warning-on-slack@3a947cec0e79beb52e1f04b8da0c8ddc5c51fe52 # pending release (PR #502)
+          uses: camunda/infraex-common-config/.github/actions/report-warning-on-slack@6ab7c306c135aca22a8519a955ef9cba6167f0b0 # camunda/infraex-common-config#502
           with:
               vault_addr: ${{ inputs.vault-addr }}
               vault_role_id: ${{ inputs.vault-role-id }}
@@ -459,5 +459,5 @@ runs:
                   }}
               slack_mention_people: ${{ inputs.slack-mention-people }}
               title: Helm configuration drift
-              message: ${{ format('Helm release {0} has non-blocking deprecation / unknown-key findings (ignored by the chart); run did not fail.', inputs.release-name)
+              message: ${{ format('Helm release {0} reported deprecation / unknown-key findings (advisory, non-blocking); the run did not fail.', inputs.release-name)
                   }}

--- a/.github/actions/internal-helm-deprecation-check/action.yml
+++ b/.github/actions/internal-helm-deprecation-check/action.yml
@@ -455,7 +455,7 @@ runs:
               vault_addr: ${{ inputs.vault-addr }}
               vault_role_id: ${{ inputs.vault-role-id }}
               vault_secret_id: ${{ inputs.vault-secret-id }}
-              slack_channel_id: ${{ inputs.slack-channel-id != '' && inputs.slack-channel-id || (env.IS_SCHEDULE == 'true' && 'C076N4G1162' || 'C07E4FF6YMB')
+              slack_channel_id: ${{ inputs.slack-channel-id != '' && inputs.slack-channel-id || (github.event_name == 'schedule' && 'C076N4G1162' || 'C07E4FF6YMB')
                   }}
               slack_mention_people: ${{ inputs.slack-mention-people }}
               title: Helm configuration drift

--- a/.github/actions/internal-helm-deprecation-check/action.yml
+++ b/.github/actions/internal-helm-deprecation-check/action.yml
@@ -450,7 +450,7 @@ runs:
           # red "STABLE BRANCH FAILURE" alert pointing at a green run.
           # Pending release of camunda/infraex-common-config#502; repin to the tagged
           # SHA once it merges.
-          uses: camunda/infraex-common-config/.github/actions/report-warning-on-slack@6ab7c306c135aca22a8519a955ef9cba6167f0b0 # camunda/infraex-common-config#502
+          uses: camunda/infraex-common-config/.github/actions/report-warning-on-slack@9d612bfe86b6440ddcedb50e665771a6d271a32e # camunda/infraex-common-config#502
           with:
               vault_addr: ${{ inputs.vault-addr }}
               vault_role_id: ${{ inputs.vault-role-id }}
@@ -459,5 +459,5 @@ runs:
                   }}
               slack_mention_people: ${{ inputs.slack-mention-people }}
               title: Helm configuration drift
-              message: ${{ format('Helm release {0} reported deprecation / unknown-key findings (advisory, non-blocking); the run did not fail.', inputs.release-name)
+              message: ${{ format('Helm release {0} reported non-blocking findings (deprecated / removed / unknown keys); the run did not fail.', inputs.release-name)
                   }}

--- a/.github/actions/internal-helm-deprecation-check/action.yml
+++ b/.github/actions/internal-helm-deprecation-check/action.yml
@@ -450,7 +450,7 @@ runs:
           # red "STABLE BRANCH FAILURE" alert pointing at a green run.
           # Pending release of camunda/infraex-common-config#502; repin to the tagged
           # SHA once it merges.
-          uses: camunda/infraex-common-config/.github/actions/report-warning-on-slack@9d612bfe86b6440ddcedb50e665771a6d271a32e # camunda/infraex-common-config#502
+          uses: camunda/infraex-common-config/.github/actions/report-warning-on-slack@293f79e94a2cd39c7b1a8eac77cf5463325d5f70 # camunda/infraex-common-config#502
           with:
               vault_addr: ${{ inputs.vault-addr }}
               vault_role_id: ${{ inputs.vault-role-id }}


### PR DESCRIPTION
## Problem

Scheduled runs on `stable/*` posted red **STABLE BRANCH FAILURE** Slack alerts that linked to **green** runs (e.g. `27724412027` Azure AKS, `27724411920` Generic Operator). Root cause: `internal-helm-deprecation-check` surfaces *non-blocking* Helm findings (deprecation warnings, removed keys, unknown configuration keys) and, on schedules, posted them through `report-failure-on-slack` — which always frames the message as a failure with a `STABLE BRANCH FAILURE` prefix. The run itself never failed.

## Fix

Switch that single advisory step to the new **`report-warning-on-slack`** action (`:warning:` framing, no `failed!` wording, no severity escalation, no failure-log-analyzer trigger), with an explicit warning `title` / `message`. Also route simulated-schedule warnings to the infraex-test channel (real schedules keep going to infraex-alerts). Real CI failures are untouched — they still go through `report-failure-on-slack` in each workflow's `report-failure` job.

Target branch: stable/8.9 (backport of the main PR).

## Cross-repo dependency (resolved)

Depends on **camunda/infraex-common-config#502**, now merged and released as **1.8.0**. The `uses:` line is pinned to the released tag SHA (`bde1b69`) and annotated `# 1.8.0`, matching the other infraex-common-config pins.

## Testing

Skip labels avoided auto-running every path-triggered cloud suite. Per agreed scope, the 2 workflows that produced the false alarm are run before marking ready:
- Tests - Integration - Azure Kubernetes AKS Single Region
- Tests - Integration - Generic Operator based

The Slack-warning step is schedule-gated (`IS_SCHEDULE`), so a normal PR run validates no regression of the deprecation-check path; the warning formatting itself is covered by `report-warning-on-slack` (1.8.0).