### PR TITLE
fix(ci): install gh at start of helm deprecation check with caching (backport #2713)

### DIFF
--- a/.github/actions/internal-helm-deprecation-check/action.yml
+++ b/.github/actions/internal-helm-deprecation-check/action.yml
@@ -113,6 +113,95 @@ inputs:
 runs:
     using: composite
     steps:
+        - name: 🛠️ Resolve GitHub CLI setup for the scheduled Slack alert
+          id: gh-cli
+          # The report-failure-on-slack step (run on scheduled findings) shells
+          # out to `gh` (silence check + failure-log-analyzer trigger). `gh` is
+          # preinstalled on GitHub-hosted runners but absent from the self-hosted
+          # runners used by the deployment test jobs, where it failed with exit
+          # code 127. Resolve up front whether we must provide our own `gh` and
+          # where it should live, so the binary can be cached across runs.
+          if: |
+              env.IS_SCHEDULE == 'true'
+              && inputs.vault-addr != ''
+              && inputs.vault-role-id != ''
+              && inputs.vault-secret-id != ''
+          shell: bash
+          env:
+              # renovate: datasource=github-tags depName=cli/cli
+              GH_CLI_VERSION: v2.95.0
+          run: |
+              set -euo pipefail
+
+              if command -v gh >/dev/null 2>&1; then
+                  echo "GitHub CLI already available: $(gh --version | head -n1)"
+                  echo "need-install=false" >> "${GITHUB_OUTPUT}"
+                  exit 0
+              fi
+
+              case "$(uname -m)" in
+                  x86_64) GH_ARCH="amd64" ;;
+                  aarch64 | arm64) GH_ARCH="arm64" ;;
+                  *) echo "::error::Unsupported architecture for GitHub CLI install: $(uname -m)"; exit 1 ;;
+              esac
+
+              VERSION="${GH_CLI_VERSION#v}"
+              # Stable, runner-persistent location (RUNNER_TEMP changes per job,
+              # which would defeat actions/cache absolute-path restoration).
+              INSTALL_DIR="${HOME}/.cache/gh-cli/${VERSION}-${GH_ARCH}"
+              mkdir -p "${INSTALL_DIR}"
+
+              {
+                  echo "need-install=true"
+                  echo "version=${VERSION}"
+                  echo "arch=${GH_ARCH}"
+                  echo "install-dir=${INSTALL_DIR}"
+                  echo "bin-dir=${INSTALL_DIR}/gh_${VERSION}_linux_${GH_ARCH}/bin"
+                  echo "cache-key=gh-cli-${RUNNER_OS}-${GH_ARCH}-${VERSION}"
+              } >> "${GITHUB_OUTPUT}"
+
+        - name: 💾 Restore cached GitHub CLI
+          id: gh-cli-cache
+          if: steps.gh-cli.outputs.need-install == 'true'
+          uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+          with:
+              path: ${{ steps.gh-cli.outputs.install-dir }}
+              key: ${{ steps.gh-cli.outputs.cache-key }}
+
+        - name: 🛠️ Install GitHub CLI
+          if: steps.gh-cli.outputs.need-install == 'true'
+          shell: bash
+          env:
+              CACHE_HIT: ${{ steps.gh-cli-cache.outputs.cache-hit }}
+              VERSION: ${{ steps.gh-cli.outputs.version }}
+              GH_ARCH: ${{ steps.gh-cli.outputs.arch }}
+              INSTALL_DIR: ${{ steps.gh-cli.outputs.install-dir }}
+              BIN_DIR: ${{ steps.gh-cli.outputs.bin-dir }}
+          run: |
+              set -euo pipefail
+
+              if [[ "${CACHE_HIT}" == "true" && -x "${BIN_DIR}/gh" ]]; then
+                  echo "Using cached GitHub CLI ${VERSION} (${GH_ARCH})"
+              else
+                  TARBALL="gh_${VERSION}_linux_${GH_ARCH}.tar.gz"
+                  BASE_URL="https://github.com/cli/cli/releases/download/v${VERSION}"
+
+                  echo "Downloading GitHub CLI ${VERSION} (${GH_ARCH})..."
+                  TMP_DIR="$(mktemp -d)"
+                  curl -fsSL --retry 5 --retry-delay 10 -o "${TMP_DIR}/${TARBALL}" "${BASE_URL}/${TARBALL}"
+                  curl -fsSL --retry 5 --retry-delay 10 -o "${TMP_DIR}/checksums.txt" "${BASE_URL}/gh_${VERSION}_checksums.txt"
+
+                  # Verify the download against the official checksums before trusting it.
+                  (cd "${TMP_DIR}" && grep " ${TARBALL}$" checksums.txt | sha256sum -c -)
+
+                  tar -xzf "${TMP_DIR}/${TARBALL}" -C "${INSTALL_DIR}"
+                  rm -rf "${TMP_DIR}"
+              fi
+
+              # Expose gh to the rest of the job, incl. the report-failure-on-slack step.
+              echo "${BIN_DIR}" >> "${GITHUB_PATH}"
+              echo "GitHub CLI ready: $("${BIN_DIR}/gh" --version | head -n1)"
+
         - name: 🔍 Check for Helm deprecation warnings
           shell: bash
           env:


### PR DESCRIPTION
# Description

Manual backport of #2713 to `stable/8.9`.

## Problem

On scheduled runs the `🔍 Check for Helm deprecation warnings` step fails with
`gh: command not found` (exit 127). `internal-helm-deprecation-check` invokes
the shared `report-failure-on-slack` action, which shells out to `gh` (silence
check + failure-log-analyzer trigger). `gh` is preinstalled on GitHub-hosted
runners but **not** on the self-hosted runners used by the deployment test jobs.

Original failing run (`stable/8.9`):
https://github.com/camunda/camunda-deployment-references/actions/runs/27724411899/job/82091191926

## Fix

Provide a pinned, checksum-verified GitHub CLI at the **start** of the action,
cached via `actions/cache` (keyed on OS/arch/version) and skipped entirely when
`gh` is already on `PATH`. The version is Renovate-managed (`cli/cli`).

## Notes

- Only `stable/8.9` is affected among the stable branches: `internal-helm-deprecation-check`
  does not exist on `stable/8.7` / `stable/8.8`, and there `report-failure-on-slack`
  is only called from `report-failure` jobs that run on `ubuntu-latest` (gh preinstalled),
  so the bug cannot occur there.

relates to #2713
