### PR TITLE
feat: wait-for-keycloak.sh — fix domain OIDC startup crash-loop (backport stable/8.8)

### DIFF
--- a/.github/workflows/generic_kubernetes_operator_based_test.yml
+++ b/.github/workflows/generic_kubernetes_operator_based_test.yml
@@ -772,7 +772,7 @@ jobs:
                   attempt=0
                   while [ "$(date +%s)" -lt "$DEADLINE" ]; do
                       attempt=$((attempt + 1))
-                      CODE=$(curl -ksS -o /dev/null -w '%{http_code}' --max-time 5 "$KC_URL" 2>/dev/null || true)
+                      CODE=$(curl -ks -o /dev/null -w '%{http_code}' --max-time 5 "$KC_URL" || true)
                       CODE=${CODE:-000}
                       if [[ "$CODE" == "200" ]]; then
                           echo "✅ Keycloak reachable (HTTP $CODE) after ${attempt} attempt(s)"

--- a/.github/workflows/generic_kubernetes_operator_based_test.yml
+++ b/.github/workflows/generic_kubernetes_operator_based_test.yml
@@ -747,49 +747,21 @@ jobs:
                   # Use the install-chart.sh script
                   ../single-region/procedure/install-chart.sh
 
-            # In domain + OIDC mode the Camunda app pods (Zeebe, Connectors, …)
-            # fetch the OIDC discovery document from the public Keycloak issuer
-            # (https://${CAMUNDA_DOMAIN}/auth/realms/camunda-platform) at startup.
-            # That issuer only becomes reachable once (a) the Camunda Identity pod
-            # has provisioned the `camunda-platform` realm and (b) the public route
-            # converges (external-dns record + cert + ingress/route). Until then the
-            # app pods crash-loop, and Kubernetes exponential backoff can delay the
-            # next restart up to ~5 min, so the deployment may never become healthy
-            # within the `Wait for the deployment` timeout. Wait for the realm
-            # discovery document to answer 200, then bounce the crash-looping app
-            # pods so they restart immediately instead of after the next backoff.
+            # In domain + OIDC mode the Camunda app pods fetch the OIDC discovery
+            # document from the public Keycloak issuer at startup, which only
+            # converges minutes after install (realm provisioning + DNS + cert +
+            # ingress). wait-for-keycloak.sh blocks until it answers, then restarts
+            # the crash-looping workloads. The same script is shipped to customers
+            # and reused by the kind flow. KEYCLOAK_WAIT_INSECURE is set because CI
+            # serves the issuer with a Vault wildcard cert from an internal CA the
+            # runner does not trust; the app pods validate it via an injected CA.
             - name: ⏳ Wait for Keycloak realm/issuer reachable
               if: matrix.declination.name == 'domain'
               timeout-minutes: 12
-              run: |
-                  set -uo pipefail
-                  KC_URL="https://${CAMUNDA_DOMAIN}/auth/realms/camunda-platform/.well-known/openid-configuration"
-                  echo "Waiting for Keycloak OIDC discovery: $KC_URL"
-                  # Wall-clock deadline so the loop always finishes (and emits the
-                  # warning below) before the 12-minute step timeout, regardless of
-                  # how long each curl takes.
-                  DEADLINE=$(( $(date +%s) + 600 )) # 10 minutes
-                  attempt=0
-                  while [ "$(date +%s)" -lt "$DEADLINE" ]; do
-                      attempt=$((attempt + 1))
-                      CODE=$(curl -ks -o /dev/null -w '%{http_code}' --max-time 5 "$KC_URL" || true)
-                      CODE=${CODE:-000}
-                      if [[ "$CODE" == "200" ]]; then
-                          echo "✅ Keycloak reachable (HTTP $CODE) after ${attempt} attempt(s)"
-                          # Bounce the crash-looping app pods so they restart now
-                          # instead of waiting out the exponential backoff window.
-                          kubectl -n "$CAMUNDA_NAMESPACE" rollout restart statefulset/camunda-zeebe || true
-                          # Connectors may be disabled in some scenarios; only restart it
-                          # when present, and keep its errors visible (no blanket stderr mute).
-                          if kubectl -n "$CAMUNDA_NAMESPACE" get deployment/camunda-connectors >/dev/null 2>&1; then
-                              kubectl -n "$CAMUNDA_NAMESPACE" rollout restart deployment/camunda-connectors || true
-                          fi
-                          exit 0
-                      fi
-                      echo "[attempt ${attempt}] not ready yet (HTTP $CODE), sleeping 5s…"
-                      sleep 5
-                  done
-                  echo "::warning::Keycloak external URL did not respond 200 within 10 min; continuing anyway."
+              working-directory: ./generic/kubernetes/operator-based/
+              env:
+                  KEYCLOAK_WAIT_INSECURE: 'true'
+              run: ../single-region/procedure/wait-for-keycloak.sh
 
             - name: 👀⏳ Wait for the deployment to be healthy
               timeout-minutes: 10

--- a/.github/workflows/generic_kubernetes_operator_based_test.yml
+++ b/.github/workflows/generic_kubernetes_operator_based_test.yml
@@ -751,11 +751,12 @@ jobs:
             # document from the public Keycloak issuer at startup, which only
             # converges minutes after install (realm provisioning + DNS + cert +
             # ingress). wait-for-keycloak.sh waits (bounded, fail-open) for it to
-            # answer, then restarts the crash-looping workloads; on timeout it warns
-            # and continues. The same script is shipped to customers
-            # and reused by the kind flow. KEYCLOAK_WAIT_INSECURE is enabled only
-            # when the Vault wildcard cert is in use (internal CA the runner does not
-            # trust); with Let's Encrypt certs the issuer poll keeps TLS verification.
+            # answer; the workloads are bounced by the steps below, after the CoreDNS
+            # refresh (hence KEYCLOAK_WAIT_SKIP_RESTART). The same script is shipped
+            # to customers and reused by the kind flow. KEYCLOAK_WAIT_INSECURE is
+            # enabled only when the Vault wildcard cert is in use (internal CA the
+            # runner does not trust); with Let's Encrypt certs the poll keeps TLS
+            # verification.
             - name: ⏳ Wait for Keycloak realm/issuer reachable
               if: matrix.declination.name == 'domain'
               timeout-minutes: 12

--- a/.github/workflows/generic_kubernetes_operator_based_test.yml
+++ b/.github/workflows/generic_kubernetes_operator_based_test.yml
@@ -765,22 +765,27 @@ jobs:
                   set -uo pipefail
                   KC_URL="https://${CAMUNDA_DOMAIN}/auth/realms/camunda-platform/.well-known/openid-configuration"
                   echo "Waiting for Keycloak OIDC discovery: $KC_URL"
-                  ATTEMPTS=120 # 120 * 5s = 10 minutes
-                  for i in $(seq 1 "$ATTEMPTS"); do
+                  # Wall-clock deadline so the loop always finishes (and emits the
+                  # warning below) before the 12-minute step timeout, regardless of
+                  # how long each curl takes.
+                  DEADLINE=$(( $(date +%s) + 600 )) # 10 minutes
+                  attempt=0
+                  while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+                      attempt=$((attempt + 1))
                       CODE=$(curl -ksS -o /dev/null -w '%{http_code}' --max-time 5 "$KC_URL" || echo "000")
                       if [[ "$CODE" == "200" ]]; then
-                          echo "✅ Keycloak reachable (HTTP $CODE) after $i attempt(s)"
-                          # Bounce crash-looping app pods so they restart now
-                          # instead of waiting on exponential backoff.
-                          kubectl -n "$CAMUNDA_NAMESPACE" rollout restart \
-                              statefulset/camunda-zeebe \
-                              deployment/camunda-connectors 2>/dev/null || true
+                          echo "✅ Keycloak reachable (HTTP $CODE) after ${attempt} attempt(s)"
+                          # Bounce the crash-looping app pods so they restart now
+                          # instead of waiting out the exponential backoff window.
+                          kubectl -n "$CAMUNDA_NAMESPACE" rollout restart statefulset/camunda-zeebe || true
+                          # connectors may be disabled in some scenarios; tolerate its absence.
+                          kubectl -n "$CAMUNDA_NAMESPACE" rollout restart deployment/camunda-connectors 2>/dev/null || true
                           exit 0
                       fi
-                      echo "[$i/$ATTEMPTS] not ready yet (HTTP $CODE), sleeping 5s…"
+                      echo "[attempt ${attempt}] not ready yet (HTTP $CODE), sleeping 5s…"
                       sleep 5
                   done
-                  echo "::warning::Keycloak external URL did not respond 200 within ${ATTEMPTS}*5s; continuing anyway."
+                  echo "::warning::Keycloak external URL did not respond 200 within 10 min; continuing anyway."
 
             - name: 👀⏳ Wait for the deployment to be healthy
               timeout-minutes: 10

--- a/.github/workflows/generic_kubernetes_operator_based_test.yml
+++ b/.github/workflows/generic_kubernetes_operator_based_test.yml
@@ -753,15 +753,15 @@ jobs:
             # ingress). wait-for-keycloak.sh waits (bounded, fail-open) for it to
             # answer, then restarts the crash-looping workloads; on timeout it warns
             # and continues. The same script is shipped to customers
-            # and reused by the kind flow. KEYCLOAK_WAIT_INSECURE is set because CI
-            # serves the issuer with a Vault wildcard cert from an internal CA the
-            # runner does not trust; the app pods validate it via an injected CA.
+            # and reused by the kind flow. KEYCLOAK_WAIT_INSECURE is enabled only
+            # when the Vault wildcard cert is in use (internal CA the runner does not
+            # trust); with Let's Encrypt certs the issuer poll keeps TLS verification.
             - name: ⏳ Wait for Keycloak realm/issuer reachable
               if: matrix.declination.name == 'domain'
               timeout-minutes: 12
               working-directory: ./generic/kubernetes/operator-based/
               env:
-                  KEYCLOAK_WAIT_INSECURE: 'true'
+                  KEYCLOAK_WAIT_INSECURE: ${{ steps.cert-config.outputs.use-wildcard-cert == 'true' && 'true' || '' }}
               run: ../single-region/procedure/wait-for-keycloak.sh
 
             - name: 👀⏳ Wait for the deployment to be healthy

--- a/.github/workflows/generic_kubernetes_operator_based_test.yml
+++ b/.github/workflows/generic_kubernetes_operator_based_test.yml
@@ -750,8 +750,9 @@ jobs:
             # In domain + OIDC mode the Camunda app pods fetch the OIDC discovery
             # document from the public Keycloak issuer at startup, which only
             # converges minutes after install (realm provisioning + DNS + cert +
-            # ingress). wait-for-keycloak.sh blocks until it answers, then restarts
-            # the crash-looping workloads. The same script is shipped to customers
+            # ingress). wait-for-keycloak.sh waits (bounded, fail-open) for it to
+            # answer, then restarts the crash-looping workloads; on timeout it warns
+            # and continues. The same script is shipped to customers
             # and reused by the kind flow. KEYCLOAK_WAIT_INSECURE is set because CI
             # serves the issuer with a Vault wildcard cert from an internal CA the
             # runner does not trust; the app pods validate it via an injected CA.

--- a/.github/workflows/generic_kubernetes_operator_based_test.yml
+++ b/.github/workflows/generic_kubernetes_operator_based_test.yml
@@ -762,7 +762,31 @@ jobs:
               working-directory: ./generic/kubernetes/operator-based/
               env:
                   KEYCLOAK_WAIT_INSECURE: ${{ steps.cert-config.outputs.use-wildcard-cert == 'true' && 'true' || '' }}
+                  # Wait only: CoreDNS must be refreshed before the workloads are
+                  # bounced (next two steps), so the script does not restart here.
+                  KEYCLOAK_WAIT_SKIP_RESTART: 'true'
               run: ../single-region/procedure/wait-for-keycloak.sh
+
+            # The app pods resolve the public issuer in-cluster; CoreDNS can hold a
+            # stale/negative record for the domain until external-dns publishes it
+            # (the eager OIDC discovery in newer charts then hard-fails on startup).
+            # Refresh CoreDNS now — before the health wait — then bounce the
+            # workloads so they start with working DNS. Domain declination only.
+            - name: 🔄 Restart CoreDNS (refresh public-domain resolution)
+              if: matrix.declination.name == 'domain'
+              uses: ./.github/actions/kubernetes-restart-coredns
+              timeout-minutes: 10
+              with:
+                  cluster-type: ${{ matrix.distro.type == 'openshift' && 'openshift' || 'kubernetes' }}
+
+            - name: 🔁 Restart Camunda workloads after DNS refresh
+              if: matrix.declination.name == 'domain'
+              run: |
+                  set -uo pipefail
+                  kubectl --namespace "$CAMUNDA_NAMESPACE" rollout restart statefulset/camunda-zeebe
+                  if kubectl --namespace "$CAMUNDA_NAMESPACE" get deployment/camunda-connectors >/dev/null 2>&1; then
+                      kubectl --namespace "$CAMUNDA_NAMESPACE" rollout restart deployment/camunda-connectors
+                  fi
 
             - name: 👀⏳ Wait for the deployment to be healthy
               timeout-minutes: 10
@@ -775,13 +799,6 @@ jobs:
 
                   cd tests && ./check-deployment-ready.sh && cd ..
                   echo "Camunda deployment verified successfully."
-
-            - name: 🔄 Restart CoreDNS
-              if: matrix.declination.name == 'domain' && env.CLEANUP_CLUSTERS == 'false'
-              uses: ./.github/actions/kubernetes-restart-coredns
-              timeout-minutes: 10
-              with:
-                  cluster-type: ${{ matrix.distro.type == 'openshift' && 'openshift' || 'kubernetes' }}
 
             - name: Set current Camunda version
               id: camunda-version

--- a/.github/workflows/generic_kubernetes_operator_based_test.yml
+++ b/.github/workflows/generic_kubernetes_operator_based_test.yml
@@ -747,6 +747,41 @@ jobs:
                   # Use the install-chart.sh script
                   ../single-region/procedure/install-chart.sh
 
+            # In domain + OIDC mode the Camunda app pods (Zeebe, Connectors, …)
+            # fetch the OIDC discovery document from the public Keycloak issuer
+            # (https://${CAMUNDA_DOMAIN}/auth/realms/camunda-platform) at startup.
+            # That issuer only becomes reachable once (a) the Camunda Identity pod
+            # has provisioned the `camunda-platform` realm and (b) the public route
+            # converges (external-dns record + cert + ingress/route). Until then the
+            # app pods crash-loop, and Kubernetes exponential backoff can delay the
+            # next restart up to ~5 min, so the deployment may never become healthy
+            # within the `Wait for the deployment` timeout. Wait for the realm
+            # discovery document to answer 200, then bounce the crash-looping app
+            # pods so they restart immediately instead of after the next backoff.
+            - name: ⏳ Wait for Keycloak realm/issuer reachable
+              if: matrix.declination.name == 'domain'
+              timeout-minutes: 12
+              run: |
+                  set -uo pipefail
+                  KC_URL="https://${CAMUNDA_DOMAIN}/auth/realms/camunda-platform/.well-known/openid-configuration"
+                  echo "Waiting for Keycloak OIDC discovery: $KC_URL"
+                  ATTEMPTS=120 # 120 * 5s = 10 minutes
+                  for i in $(seq 1 "$ATTEMPTS"); do
+                      CODE=$(curl -ksS -o /dev/null -w '%{http_code}' --max-time 5 "$KC_URL" || echo "000")
+                      if [[ "$CODE" == "200" ]]; then
+                          echo "✅ Keycloak reachable (HTTP $CODE) after $i attempt(s)"
+                          # Bounce crash-looping app pods so they restart now
+                          # instead of waiting on exponential backoff.
+                          kubectl -n "$CAMUNDA_NAMESPACE" rollout restart \
+                              statefulset/camunda-zeebe \
+                              deployment/camunda-connectors 2>/dev/null || true
+                          exit 0
+                      fi
+                      echo "[$i/$ATTEMPTS] not ready yet (HTTP $CODE), sleeping 5s…"
+                      sleep 5
+                  done
+                  echo "::warning::Keycloak external URL did not respond 200 within ${ATTEMPTS}*5s; continuing anyway."
+
             - name: 👀⏳ Wait for the deployment to be healthy
               timeout-minutes: 10
               working-directory: ./generic/kubernetes/operator-based/

--- a/.github/workflows/generic_kubernetes_operator_based_test.yml
+++ b/.github/workflows/generic_kubernetes_operator_based_test.yml
@@ -772,14 +772,18 @@ jobs:
                   attempt=0
                   while [ "$(date +%s)" -lt "$DEADLINE" ]; do
                       attempt=$((attempt + 1))
-                      CODE=$(curl -ksS -o /dev/null -w '%{http_code}' --max-time 5 "$KC_URL" || echo "000")
+                      CODE=$(curl -ksS -o /dev/null -w '%{http_code}' --max-time 5 "$KC_URL" 2>/dev/null || true)
+                      CODE=${CODE:-000}
                       if [[ "$CODE" == "200" ]]; then
                           echo "✅ Keycloak reachable (HTTP $CODE) after ${attempt} attempt(s)"
                           # Bounce the crash-looping app pods so they restart now
                           # instead of waiting out the exponential backoff window.
                           kubectl -n "$CAMUNDA_NAMESPACE" rollout restart statefulset/camunda-zeebe || true
-                          # connectors may be disabled in some scenarios; tolerate its absence.
-                          kubectl -n "$CAMUNDA_NAMESPACE" rollout restart deployment/camunda-connectors 2>/dev/null || true
+                          # Connectors may be disabled in some scenarios; only restart it
+                          # when present, and keep its errors visible (no blanket stderr mute).
+                          if kubectl -n "$CAMUNDA_NAMESPACE" get deployment/camunda-connectors >/dev/null 2>&1; then
+                              kubectl -n "$CAMUNDA_NAMESPACE" rollout restart deployment/camunda-connectors || true
+                          fi
                           exit 0
                       fi
                       echo "[attempt ${attempt}] not ready yet (HTTP $CODE), sleeping 5s…"

--- a/generic/kubernetes/single-region/procedure/wait-for-keycloak.sh
+++ b/generic/kubernetes/single-region/procedure/wait-for-keycloak.sh
@@ -33,7 +33,7 @@ issuer="${CAMUNDA_OIDC_ISSUER_URL:-https://${domain}/auth/realms/camunda-platfor
 discovery="${issuer%/}/.well-known/openid-configuration"
 timeout_seconds="${KEYCLOAK_WAIT_TIMEOUT_SECONDS:-600}"
 
-curl_opts=(--silent --show-error --output /dev/null --max-time 5)
+curl_opts=(--silent --output /dev/null --max-time 5)
 if [ "${KEYCLOAK_WAIT_INSECURE:-false}" = "true" ]; then
     curl_opts+=(--insecure)
 fi
@@ -46,6 +46,15 @@ warn() {
         echo "WARNING: $1"
     fi
 }
+
+# Fall back to the default if the timeout is not a positive integer, so a bad
+# value cannot break the arithmetic below or silently skip the wait.
+case "$timeout_seconds" in
+    '' | *[!0-9]*)
+        warn "KEYCLOAK_WAIT_TIMEOUT_SECONDS='${timeout_seconds}' is not a positive integer; using 600."
+        timeout_seconds=600
+        ;;
+esac
 
 # Fail open immediately if a required tool is missing, instead of spinning until
 # the deadline.
@@ -67,10 +76,15 @@ while [ "$(date +%s)" -lt "$deadline" ]; do
         echo "Keycloak issuer is reachable (HTTP ${code}) after ${attempt} attempt(s)."
         echo "Restarting Camunda workloads to clear any first-start crash-loop backoff..."
         kubectl --namespace "$namespace" rollout restart "statefulset/${release}-zeebe" || true
-        # Connectors may be disabled in some scenarios; only restart it when present,
-        # and keep its errors visible (do not blanket-silence stderr).
-        if kubectl --namespace "$namespace" get "deployment/${release}-connectors" >/dev/null 2>&1; then
-            kubectl --namespace "$namespace" rollout restart "deployment/${release}-connectors" || true
+        # Connectors may be disabled in some scenarios; tolerate that specific case
+        # (NotFound) but surface any other error instead of silently swallowing it.
+        if connectors_out=$(kubectl --namespace "$namespace" rollout restart "deployment/${release}-connectors" 2>&1); then
+            printf '%s\n' "$connectors_out"
+        else
+            case "$connectors_out" in
+                *NotFound*) echo "Connectors deployment not present; skipping its restart." ;;
+                *) printf '%s\n' "$connectors_out" >&2 ;;
+            esac
         fi
         exit 0
     fi

--- a/generic/kubernetes/single-region/procedure/wait-for-keycloak.sh
+++ b/generic/kubernetes/single-region/procedure/wait-for-keycloak.sh
@@ -10,8 +10,8 @@
 # the `camunda-platform` realm and (b) the public route converges (DNS + TLS
 # certificate + ingress). Until then the pods crash-loop, and Kubernetes backoff can
 # delay the next restart by several minutes, so a first deployment can look broken
-# for a while. This script blocks until the discovery endpoint returns HTTP 200,
-# then rolls the app workloads so they restart cleanly.
+# for a while. This script waits (up to a timeout) for the discovery endpoint to
+# return HTTP 200, then rolls the app workloads so they restart cleanly.
 #
 # It is safe to run right after the Helm install, and it FAILS OPEN: if the issuer
 # never answers within the timeout it warns and exits 0, so it never blocks a deploy.
@@ -33,7 +33,7 @@ issuer="${CAMUNDA_OIDC_ISSUER_URL:-https://${domain}/auth/realms/camunda-platfor
 discovery="${issuer%/}/.well-known/openid-configuration"
 timeout_seconds="${KEYCLOAK_WAIT_TIMEOUT_SECONDS:-600}"
 
-curl_opts=(--silent --output /dev/null --max-time 5)
+curl_opts=(--silent --show-error --output /dev/null --max-time 5)
 if [ "${KEYCLOAK_WAIT_INSECURE:-false}" = "true" ]; then
     curl_opts+=(--insecure)
 fi
@@ -46,6 +46,15 @@ warn() {
         echo "WARNING: $1"
     fi
 }
+
+# Fail open immediately if a required tool is missing, instead of spinning until
+# the deadline.
+for required in curl kubectl; do
+    if ! command -v "$required" >/dev/null 2>&1; then
+        warn "'$required' is not available; skipping the Keycloak readiness wait."
+        exit 0
+    fi
+done
 
 echo "Waiting for the Keycloak OIDC discovery document (up to ${timeout_seconds}s): ${discovery}"
 deadline=$(($(date +%s) + timeout_seconds))

--- a/generic/kubernetes/single-region/procedure/wait-for-keycloak.sh
+++ b/generic/kubernetes/single-region/procedure/wait-for-keycloak.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+# Wait until the Camunda OIDC issuer (Keycloak realm) is reachable, then restart
+# the application workloads so they recover immediately instead of waiting out
+# Kubernetes CrashLoopBackOff.
+#
+# Why this exists: in domain + OIDC mode the Camunda app pods (Zeebe/orchestration
+# and Connectors) fetch the OIDC discovery document from the public Keycloak issuer
+# at startup. That URL only answers once (a) the Identity component has provisioned
+# the `camunda-platform` realm and (b) the public route converges (DNS + TLS
+# certificate + ingress). Until then the pods crash-loop, and Kubernetes backoff can
+# delay the next restart by several minutes, so a first deployment can look broken
+# for a while. This script blocks until the discovery endpoint returns HTTP 200,
+# then rolls the app workloads so they restart cleanly.
+#
+# It is safe to run right after the Helm install, and it FAILS OPEN: if the issuer
+# never answers within the timeout it warns and exits 0, so it never blocks a deploy.
+#
+# Configuration (all optional, sensible defaults):
+#   CAMUNDA_NAMESPACE              namespace Camunda is installed in (default: camunda)
+#   CAMUNDA_RELEASE_NAME          Helm release name (default: camunda)
+#   CAMUNDA_DOMAIN                public host serving Keycloak (default: camunda.example.com)
+#   CAMUNDA_OIDC_ISSUER_URL       full issuer base URL; overrides the one built from CAMUNDA_DOMAIN
+#   KEYCLOAK_WAIT_TIMEOUT_SECONDS total wall-clock budget in seconds (default: 600)
+#   KEYCLOAK_WAIT_INSECURE        'true' to skip TLS verification (e.g. an untrusted internal CA)
+
+set -uo pipefail
+
+namespace="${CAMUNDA_NAMESPACE:-camunda}"
+release="${CAMUNDA_RELEASE_NAME:-camunda}"
+domain="${CAMUNDA_DOMAIN:-camunda.example.com}"
+issuer="${CAMUNDA_OIDC_ISSUER_URL:-https://${domain}/auth/realms/camunda-platform}"
+discovery="${issuer%/}/.well-known/openid-configuration"
+timeout_seconds="${KEYCLOAK_WAIT_TIMEOUT_SECONDS:-600}"
+
+curl_opts=(--silent --output /dev/null --max-time 5)
+if [ "${KEYCLOAK_WAIT_INSECURE:-false}" = "true" ]; then
+    curl_opts+=(--insecure)
+fi
+
+warn() {
+    # Surface as a GitHub Actions annotation in CI, plain text otherwise.
+    if [ -n "${GITHUB_ACTIONS:-}" ]; then
+        echo "::warning::$1"
+    else
+        echo "WARNING: $1"
+    fi
+}
+
+echo "Waiting for the Keycloak OIDC discovery document (up to ${timeout_seconds}s): ${discovery}"
+deadline=$(($(date +%s) + timeout_seconds))
+attempt=0
+while [ "$(date +%s)" -lt "$deadline" ]; do
+    attempt=$((attempt + 1))
+    code=$(curl "${curl_opts[@]}" -w '%{http_code}' "$discovery" || true)
+    code="${code:-000}"
+    if [ "$code" = "200" ]; then
+        echo "Keycloak issuer is reachable (HTTP ${code}) after ${attempt} attempt(s)."
+        echo "Restarting Camunda workloads to clear any first-start crash-loop backoff..."
+        kubectl --namespace "$namespace" rollout restart "statefulset/${release}-zeebe" || true
+        # Connectors may be disabled in some scenarios; only restart it when present,
+        # and keep its errors visible (do not blanket-silence stderr).
+        if kubectl --namespace "$namespace" get "deployment/${release}-connectors" >/dev/null 2>&1; then
+            kubectl --namespace "$namespace" rollout restart "deployment/${release}-connectors" || true
+        fi
+        exit 0
+    fi
+    echo "[attempt ${attempt}] not ready yet (HTTP ${code}); retrying in 5s..."
+    sleep 5
+done
+
+warn "Keycloak issuer ${discovery} did not return 200 within ${timeout_seconds}s; continuing anyway."
+exit 0

--- a/generic/kubernetes/single-region/procedure/wait-for-keycloak.sh
+++ b/generic/kubernetes/single-region/procedure/wait-for-keycloak.sh
@@ -49,12 +49,10 @@ warn() {
 
 # Fall back to the default if the timeout is not a positive integer, so a bad
 # value cannot break the arithmetic below or silently skip the wait.
-case "$timeout_seconds" in
-    '' | *[!0-9]*)
-        warn "KEYCLOAK_WAIT_TIMEOUT_SECONDS='${timeout_seconds}' is not a positive integer; using 600."
-        timeout_seconds=600
-        ;;
-esac
+if ! [ "${timeout_seconds}" -ge 1 ] 2>/dev/null; then
+    warn "KEYCLOAK_WAIT_TIMEOUT_SECONDS='${timeout_seconds}' is not a positive integer; using 600."
+    timeout_seconds=600
+fi
 
 # Fail open immediately if a required tool is missing, instead of spinning until
 # the deadline.

--- a/generic/kubernetes/single-region/procedure/wait-for-keycloak.sh
+++ b/generic/kubernetes/single-region/procedure/wait-for-keycloak.sh
@@ -40,7 +40,7 @@ fi
 
 warn() {
     # Surface as a GitHub Actions annotation in CI, plain text otherwise.
-    if [ -n "${GITHUB_ACTIONS:-}" ]; then
+    if [ "${GITHUB_ACTIONS:-}" = "true" ]; then
         echo "::warning::$1"
     else
         echo "WARNING: $1"

--- a/generic/kubernetes/single-region/procedure/wait-for-keycloak.sh
+++ b/generic/kubernetes/single-region/procedure/wait-for-keycloak.sh
@@ -52,14 +52,18 @@ warn() {
     fi
 }
 
-# Fall back to the default if the timeout is not a positive integer, so a bad
-# value cannot break the arithmetic below or silently skip the wait.
-if ! [ "${timeout_seconds}" -ge 1 ] 2>/dev/null; then
-    warn "KEYCLOAK_WAIT_TIMEOUT_SECONDS='${timeout_seconds}' is not a positive integer; using 600."
+# Require a plain positive integer; fall back otherwise. The digits-only check
+# rejects signs/letters before the 10# normalization (which also stops a leading
+# zero from being read as octal in the arithmetic below).
+raw_timeout="$timeout_seconds"
+case "$timeout_seconds" in
+    '' | *[!0-9]*) timeout_seconds=0 ;;
+esac
+timeout_seconds=$((10#$timeout_seconds))
+if [ "$timeout_seconds" -lt 1 ]; then
+    warn "KEYCLOAK_WAIT_TIMEOUT_SECONDS='${raw_timeout}' is not a positive integer; using 600."
     timeout_seconds=600
 fi
-# Normalize so a leading zero is not later misread as octal in $(( ... )).
-timeout_seconds=$((10#$timeout_seconds))
 
 # Fail open immediately if a required tool is missing, instead of spinning until
 # the deadline.

--- a/generic/kubernetes/single-region/procedure/wait-for-keycloak.sh
+++ b/generic/kubernetes/single-region/procedure/wait-for-keycloak.sh
@@ -41,9 +41,14 @@ fi
 warn() {
     # Surface as a GitHub Actions annotation in CI, plain text otherwise.
     if [ "${GITHUB_ACTIONS:-}" = "true" ]; then
-        echo "::warning::$1"
+        # Escape the characters GitHub Actions interprets in annotation messages
+        # (% first, then CR/LF), so an arbitrary value cannot corrupt the log.
+        local msg="${1//%/%25}"
+        msg="${msg//$'\r'/%0D}"
+        msg="${msg//$'\n'/%0A}"
+        printf '::warning::%s\n' "$msg"
     else
-        echo "WARNING: $1"
+        printf 'WARNING: %s\n' "$1"
     fi
 }
 
@@ -53,6 +58,8 @@ if ! [ "${timeout_seconds}" -ge 1 ] 2>/dev/null; then
     warn "KEYCLOAK_WAIT_TIMEOUT_SECONDS='${timeout_seconds}' is not a positive integer; using 600."
     timeout_seconds=600
 fi
+# Normalize so a leading zero is not later misread as octal in $(( ... )).
+timeout_seconds=$((10#$timeout_seconds))
 
 # Fail open immediately if a required tool is missing, instead of spinning until
 # the deadline.

--- a/generic/kubernetes/single-region/procedure/wait-for-keycloak.sh
+++ b/generic/kubernetes/single-region/procedure/wait-for-keycloak.sh
@@ -39,17 +39,8 @@ if [ "${KEYCLOAK_WAIT_INSECURE:-false}" = "true" ]; then
 fi
 
 warn() {
-    # Surface as a GitHub Actions annotation in CI, plain text otherwise.
-    if [ "${GITHUB_ACTIONS:-}" = "true" ]; then
-        # Escape the characters GitHub Actions interprets in annotation messages
-        # (% first, then CR/LF), so an arbitrary value cannot corrupt the log.
-        local msg="${1//%/%25}"
-        msg="${msg//$'\r'/%0D}"
-        msg="${msg//$'\n'/%0A}"
-        printf '::warning::%s\n' "$msg"
-    else
-        printf 'WARNING: %s\n' "$1"
-    fi
+    # Non-fatal warning; this script is fail-open and never aborts a deploy.
+    printf 'WARNING: %s\n' "$1"
 }
 
 # Require a plain positive integer; fall back otherwise. The digits-only check

--- a/generic/kubernetes/single-region/procedure/wait-for-keycloak.sh
+++ b/generic/kubernetes/single-region/procedure/wait-for-keycloak.sh
@@ -23,6 +23,7 @@
 #   CAMUNDA_OIDC_ISSUER_URL       full issuer base URL; overrides the one built from CAMUNDA_DOMAIN
 #   KEYCLOAK_WAIT_TIMEOUT_SECONDS total wall-clock budget in seconds (default: 600)
 #   KEYCLOAK_WAIT_INSECURE        'true' to skip TLS verification (e.g. an untrusted internal CA)
+#   KEYCLOAK_WAIT_SKIP_RESTART    'true' to only wait for the issuer and not restart the workloads
 
 set -uo pipefail
 
@@ -74,6 +75,10 @@ while [ "$(date +%s)" -lt "$deadline" ]; do
     code="${code:-000}"
     if [ "$code" = "200" ]; then
         echo "Keycloak issuer is reachable (HTTP ${code}) after ${attempt} attempt(s)."
+        if [ "${KEYCLOAK_WAIT_SKIP_RESTART:-false}" = "true" ]; then
+            echo "KEYCLOAK_WAIT_SKIP_RESTART=true; leaving the workload restart to the caller."
+            exit 0
+        fi
         echo "Restarting Camunda workloads to clear any first-start crash-loop backoff..."
         kubectl --namespace "$namespace" rollout restart "statefulset/${release}-zeebe" || true
         # Connectors may be disabled in some scenarios; tolerate that specific case

--- a/local/kubernetes/kind-single-region/README.md
+++ b/local/kubernetes/kind-single-region/README.md
@@ -16,7 +16,7 @@ make no-domain.init    # Full setup
 make no-domain.clean   # Full cleanup
 ```
 
-> **Domain mode & Keycloak:** in TLS/domain mode the Camunda pods authenticate against the public Keycloak issuer (`https://camunda.example.com/auth/...`), which only becomes reachable a few minutes after install while DNS, the TLS certificate and the `camunda-platform` realm converge. `domain.init` runs `wait-for-keycloak.sh` automatically to block until the issuer answers and then restart the app pods, so a transient `CrashLoopBackOff` on first start clears on its own.
+> **Domain mode & Keycloak:** in TLS/domain mode the Camunda pods authenticate against the public Keycloak issuer (`https://camunda.example.com/auth/...`), which only becomes reachable a few minutes after install while DNS, the TLS certificate and the `camunda-platform` realm converge. `domain.init` runs `wait-for-keycloak.sh` automatically: it waits (up to a timeout) for the issuer, then restarts the app pods so a transient first-start `CrashLoopBackOff` clears quickly. If the issuer is slower than the timeout the script warns and continues, and the pods recover on their own once it converges.
 
 ## Further Instructions
 

--- a/local/kubernetes/kind-single-region/README.md
+++ b/local/kubernetes/kind-single-region/README.md
@@ -16,6 +16,8 @@ make no-domain.init    # Full setup
 make no-domain.clean   # Full cleanup
 ```
 
+> **Domain mode & Keycloak:** in TLS/domain mode the Camunda pods authenticate against the public Keycloak issuer (`https://camunda.example.com/auth/...`), which only becomes reachable a few minutes after install while DNS, the TLS certificate and the `camunda-platform` realm converge. `domain.init` runs `wait-for-keycloak.sh` automatically to block until the issuer answers and then restart the app pods, so a transient `CrashLoopBackOff` on first start clears on its own.
+
 ## Further Instructions
 
 For detailed setup instructions and additional options, see:

--- a/local/kubernetes/kind-single-region/procedure/camunda-deploy-domain.sh
+++ b/local/kubernetes/kind-single-region/procedure/camunda-deploy-domain.sh
@@ -20,14 +20,13 @@ helm upgrade --install "camunda" camunda-platform \
 # pods so they recover from the first-start crash-loop instead of waiting out the
 # backoff. On timeout it warns and continues. Reuses the shared readiness script
 # (also shipped to customers and used by CI). Under CI the host may not trust the
-# mkcert CA (mkcert -install is best-effort), so skip TLS verification there only;
-# local runs keep it enabled.
-insecure_flag=""
+# mkcert CA (mkcert -install is best-effort), so default to skipping TLS
+# verification there; a caller can override via KEYCLOAK_WAIT_INSECURE, and local
+# runs stay secure by default.
 if [ "${GITHUB_ACTIONS:-}" = "true" ]; then
-    insecure_flag="true"
+    export KEYCLOAK_WAIT_INSECURE="${KEYCLOAK_WAIT_INSECURE:-true}"
 fi
-KEYCLOAK_WAIT_INSECURE="$insecure_flag" \
-    ../../../generic/kubernetes/single-region/procedure/wait-for-keycloak.sh
+../../../generic/kubernetes/single-region/procedure/wait-for-keycloak.sh
 
 echo ""
 echo "Camunda Platform deployed"

--- a/local/kubernetes/kind-single-region/procedure/camunda-deploy-domain.sh
+++ b/local/kubernetes/kind-single-region/procedure/camunda-deploy-domain.sh
@@ -16,6 +16,11 @@ helm upgrade --install "camunda" camunda-platform \
     --values helm-values/values-domain.yml \
     --values helm-values/values-mkcert.yml
 
+# Wait for the public Keycloak issuer to converge, then restart the app pods so
+# they recover from the first-start crash-loop instead of waiting out the backoff.
+# Reuses the shared readiness script (also shipped to customers and used by CI).
+../../../generic/kubernetes/single-region/procedure/wait-for-keycloak.sh
+
 echo ""
 echo "Camunda Platform deployed"
 echo "Monitor: kubectl get pods -n camunda -w"

--- a/local/kubernetes/kind-single-region/procedure/camunda-deploy-domain.sh
+++ b/local/kubernetes/kind-single-region/procedure/camunda-deploy-domain.sh
@@ -19,8 +19,11 @@ helm upgrade --install "camunda" camunda-platform \
 # Wait (bounded, fail-open) for the public Keycloak issuer, then restart the app
 # pods so they recover from the first-start crash-loop instead of waiting out the
 # backoff. On timeout it warns and continues. Reuses the shared readiness script
-# (also shipped to customers and used by CI).
-../../../generic/kubernetes/single-region/procedure/wait-for-keycloak.sh
+# (also shipped to customers and used by CI). Under CI the host may not trust the
+# mkcert CA (mkcert -install is best-effort), so skip TLS verification there only;
+# local runs keep it enabled.
+KEYCLOAK_WAIT_INSECURE="${GITHUB_ACTIONS:+true}" \
+    ../../../generic/kubernetes/single-region/procedure/wait-for-keycloak.sh
 
 echo ""
 echo "Camunda Platform deployed"

--- a/local/kubernetes/kind-single-region/procedure/camunda-deploy-domain.sh
+++ b/local/kubernetes/kind-single-region/procedure/camunda-deploy-domain.sh
@@ -16,9 +16,10 @@ helm upgrade --install "camunda" camunda-platform \
     --values helm-values/values-domain.yml \
     --values helm-values/values-mkcert.yml
 
-# Wait for the public Keycloak issuer to converge, then restart the app pods so
-# they recover from the first-start crash-loop instead of waiting out the backoff.
-# Reuses the shared readiness script (also shipped to customers and used by CI).
+# Wait (bounded, fail-open) for the public Keycloak issuer, then restart the app
+# pods so they recover from the first-start crash-loop instead of waiting out the
+# backoff. On timeout it warns and continues. Reuses the shared readiness script
+# (also shipped to customers and used by CI).
 ../../../generic/kubernetes/single-region/procedure/wait-for-keycloak.sh
 
 echo ""

--- a/local/kubernetes/kind-single-region/procedure/camunda-deploy-domain.sh
+++ b/local/kubernetes/kind-single-region/procedure/camunda-deploy-domain.sh
@@ -22,7 +22,11 @@ helm upgrade --install "camunda" camunda-platform \
 # (also shipped to customers and used by CI). Under CI the host may not trust the
 # mkcert CA (mkcert -install is best-effort), so skip TLS verification there only;
 # local runs keep it enabled.
-KEYCLOAK_WAIT_INSECURE="${GITHUB_ACTIONS:+true}" \
+insecure_flag=""
+if [ "${GITHUB_ACTIONS:-}" = "true" ]; then
+    insecure_flag="true"
+fi
+KEYCLOAK_WAIT_INSECURE="$insecure_flag" \
     ../../../generic/kubernetes/single-region/procedure/wait-for-keycloak.sh
 
 echo ""


### PR DESCRIPTION
Backport of #2718 to `stable/8.8`.

Adds the shared `generic/kubernetes/single-region/procedure/wait-for-keycloak.sh` and wires it into the operator-based CI workflow (domain declination) and the kind domain deploy (`camunda-deploy-domain.sh`, auto-covering `make domain.init` + kind CI), with a kind README note. The script polls the public Keycloak OIDC discovery document until 200, then restarts the crash-looping app workloads. Fail-open, secure by default (`KEYCLOAK_WAIT_INSECURE` opt-in for CI's internal-CA cert), and shipped to customers via get-your-copy.

relates to camunda/team-infrastructure-experience#1151
