### PR TITLE
ci(tests): gate c8-sm connectivity check on stable pod readiness (backport #2721)

### DIFF
--- a/.github/actions/internal-camunda-chart-tests/action.yml
+++ b/.github/actions/internal-camunda-chart-tests/action.yml
@@ -645,6 +645,58 @@ runs:
                 -d "$HELM_DEPLOYMENT_NAME" \
                 -c "$REQUIRED_CONTAINERS"
 
+        - name: ⏳ C8-SM-CHECKS - Wait for all pods to be stably Ready
+          if: ${{ inputs.enable-c8sm-connectivity-check == 'true' }}
+          shell: bash
+          env:
+              NAMESPACE: ${{ inputs.test-namespace }}
+          run: |
+              set -euo pipefail
+
+              # The connectivity check below probes every Service from every pod
+              # with a single-shot TCP test. Components such as Connectors can
+              # still be restarting / flapping (slow readiness probe) when it
+              # runs, failing the sweep against a momentarily-unready endpoint.
+              # Require every pod Running and Ready, stable across a few
+              # consecutive polls, before starting the sweep. Completed Job/init
+              # pods (Succeeded/Failed) are ignored, and the wait is bounded so a
+              # genuinely broken pod still surfaces (warning + the sweep's own
+              # failure) instead of hanging here.
+              READY_TIMEOUT_SECONDS="${READY_TIMEOUT_SECONDS:-300}"
+              STABLE_POLLS_REQUIRED="${STABLE_POLLS_REQUIRED:-3}"
+              POLL_INTERVAL_SECONDS="${POLL_INTERVAL_SECONDS:-10}"
+
+              deadline=$(( $(date +%s) + READY_TIMEOUT_SECONDS ))
+              stable=0
+
+              while true; do
+                  not_ready=$(kubectl get pods -n "$NAMESPACE" -o json | jq '
+                    [ .items[]
+                      | select(.status.phase != "Succeeded" and .status.phase != "Failed")
+                      | select( (.status.phase != "Running")
+                                or ( [ .status.containerStatuses[]? | select(.ready == false) ] | length > 0 ) )
+                    ] | length')
+
+                  if [[ "$not_ready" -eq 0 ]]; then
+                      stable=$(( stable + 1 ))
+                      echo "✅ All pods Running and Ready (stable ${stable}/${STABLE_POLLS_REQUIRED})."
+                      if [[ "$stable" -ge "$STABLE_POLLS_REQUIRED" ]]; then
+                          break
+                      fi
+                  else
+                      stable=0
+                      echo "⏳ ${not_ready} pod(s) not yet Running/Ready, waiting..."
+                  fi
+
+                  if [[ "$(date +%s)" -ge "$deadline" ]]; then
+                      echo "::warning::Pods were not stably Ready within ${READY_TIMEOUT_SECONDS}s; running the connectivity check anyway."
+                      kubectl get pods -n "$NAMESPACE" -o wide || true
+                      break
+                  fi
+
+                  sleep "$POLL_INTERVAL_SECONDS"
+              done
+
         - name: 🧪 C8-SM-CHECKS - Run Kubernetes Connectivity Check
           if: ${{ inputs.enable-c8sm-connectivity-check == 'true' }}
           shell: bash

--- a/.github/actions/internal-camunda-chart-tests/action.yml
+++ b/.github/actions/internal-camunda-chart-tests/action.yml
@@ -682,13 +682,13 @@ runs:
 
                   if [[ "$not_ready" -eq 0 ]]; then
                       stable=$(( stable + 1 ))
-                      echo "✅ All pods Running and Ready (stable ${stable}/${STABLE_POLLS_REQUIRED})."
+                      echo "✅ All pods Ready (stable ${stable}/${STABLE_POLLS_REQUIRED})."
                       if [[ "$stable" -ge "$STABLE_POLLS_REQUIRED" ]]; then
                           break
                       fi
                   else
                       stable=0
-                      echo "⏳ ${not_ready} pod(s) not yet Running/Ready, waiting..."
+                      echo "⏳ ${not_ready} pod(s) not yet Ready, waiting..."
                   fi
 
                   if [[ "$(date +%s)" -ge "$deadline" ]]; then

--- a/.github/actions/internal-camunda-chart-tests/action.yml
+++ b/.github/actions/internal-camunda-chart-tests/action.yml
@@ -657,11 +657,14 @@ runs:
               # with a single-shot TCP test. Components such as Connectors can
               # still be restarting / flapping (slow readiness probe) when it
               # runs, failing the sweep against a momentarily-unready endpoint.
-              # Require every pod Running and Ready, stable across a few
-              # consecutive polls, before starting the sweep. Completed Job/init
-              # pods (Succeeded/Failed) are ignored, and the wait is bounded so a
-              # genuinely broken pod still surfaces (warning + the sweep's own
-              # failure) instead of hanging here.
+              # Require every pod's pod-level Ready condition to be True
+              # (this honours readiness gates and matches what Service
+              # endpoints key off — per-container .ready does not), stable
+              # across a few consecutive polls, before starting the sweep.
+              # Completed Job/init pods (Succeeded/Failed) and pods being
+              # deleted (deletionTimestamp) are ignored, and the wait is
+              # bounded so a genuinely broken pod still surfaces (warning +
+              # the sweep's own failure) instead of hanging here.
               READY_TIMEOUT_SECONDS="${READY_TIMEOUT_SECONDS:-300}"
               STABLE_POLLS_REQUIRED="${STABLE_POLLS_REQUIRED:-3}"
               POLL_INTERVAL_SECONDS="${POLL_INTERVAL_SECONDS:-10}"
@@ -673,8 +676,8 @@ runs:
                   not_ready=$(kubectl get pods -n "$NAMESPACE" -o json | jq '
                     [ .items[]
                       | select(.status.phase != "Succeeded" and .status.phase != "Failed")
-                      | select( (.status.phase != "Running")
-                                or ( [ .status.containerStatuses[]? | select(.ready == false) ] | length > 0 ) )
+                      | select(.metadata.deletionTimestamp == null)
+                      | select( ( [ .status.conditions[]? | select(.type == "Ready") | .status ] | first // "False" ) != "True" )
                     ] | length')
 
                   if [[ "$not_ready" -eq 0 ]]; then


### PR DESCRIPTION
Manual backport of **fix #2 only** from #2721 to `stable/8.8`.

Wait for all pods Running+Ready and stable before the c8-sm connectivity sweep, so a flapping Connectors pod (slow readiness probe / early CrashLoopBackOff) doesn't fail the one-shot TCP probes. Completed Job/init pods are ignored; bounded wait (default 300s) only warns on timeout.

The gRPC-dial retry (fix #1 of #2721) is **not** backported here: `generic/kubernetes/single-region/tests/integration/core/grpc_test.go` does not exist on `stable/8.8`.

Validated: shellcheck clean, yamllint/yamlfmt pass, action-docs no-op.

relates to #2721