### PR TITLE
Revert "feat(openshift): add RDBMS secondary storage variant for ROSA HCP (#2345)" [ready]

### DIFF
--- a/.github/actions/kubernetes-cnpg-cluster/README.md
+++ b/.github/actions/kubernetes-cnpg-cluster/README.md
@@ -12,7 +12,7 @@ Uses scripts and manifests from generic/kubernetes/operator-based/postgresql/.
 | name | description | required | default |
 | --- | --- | --- | --- |
 | `namespace` | <p>Kubernetes namespace for the PostgreSQL cluster</p> | `false` | `camunda` |
-| `cluster-name` | <p>Name of the CNPG cluster to deploy (must match a cluster in postgresql-clusters.yml or postgresql-orchestration-cluster.yml for pg-camunda). Examples: pg-keycloak, pg-identity, pg-webmodeler, pg-camunda</p> | `true` | `""` |
+| `cluster-name` | <p>Name of the CNPG cluster to deploy (must match a cluster in postgresql-clusters.yml). Examples: pg-keycloak, pg-identity, pg-webmodeler</p> | `true` | `""` |
 
 
 ## Outputs
@@ -40,9 +40,8 @@ This action is a `composite` action.
     # Default: camunda
 
     cluster-name:
-    # Name of the CNPG cluster to deploy (must match a cluster in postgresql-clusters.yml
-    # or postgresql-orchestration-cluster.yml for pg-camunda).
-    # Examples: pg-keycloak, pg-identity, pg-webmodeler, pg-camunda
+    # Name of the CNPG cluster to deploy (must match a cluster in postgresql-clusters.yml).
+    # Examples: pg-keycloak, pg-identity, pg-webmodeler
     #
     # Required: true
     # Default: ""

--- a/.github/actions/kubernetes-cnpg-cluster/action.yml
+++ b/.github/actions/kubernetes-cnpg-cluster/action.yml
@@ -12,9 +12,8 @@ inputs:
         default: camunda
     cluster-name:
         description: |
-            Name of the CNPG cluster to deploy (must match a cluster in postgresql-clusters.yml
-            or postgresql-orchestration-cluster.yml for pg-camunda).
-            Examples: pg-keycloak, pg-identity, pg-webmodeler, pg-camunda
+            Name of the CNPG cluster to deploy (must match a cluster in postgresql-clusters.yml).
+            Examples: pg-keycloak, pg-identity, pg-webmodeler
         required: true
 
 outputs:

--- a/.github/workflows-config/aws-openshift-rosa-hcp-single-region/test_matrix.yml
+++ b/.github/workflows-config/aws-openshift-rosa-hcp-single-region/test_matrix.yml
@@ -33,14 +33,6 @@ matrix:
 
     declination:
         - name: no-domain
-          declination_mode: no-domain
-          secondary_storage: elasticsearch
-          desc: Setup chart in production-like setup without Ingress and TLS.
-        - name: domain
-          declination_mode: domain
-          secondary_storage: elasticsearch
           desc: Setup chart in production-like setup with Ingress and TLS.
-        - name: no-domain-rdbms
-          declination_mode: no-domain
-          secondary_storage: rdbms
-          desc: Setup chart without domain, RDBMS secondary storage (no Elasticsearch, no Optimize).
+        - name: domain
+          desc: Setup chart in production-like setup without Ingress and TLS.

--- a/.github/workflows/aws_openshift_rosa_hcp_single_region_tests.yml
+++ b/.github/workflows/aws_openshift_rosa_hcp_single_region_tests.yml
@@ -300,18 +300,14 @@ jobs:
             - access-info
         strategy:
             fail-fast: false
-            # Declinations of a scenario share a single cluster and must run sequentially.
-            # The concurrency group below can only keep one job pending, so it cannot
-            # queue three or more declinations (the extra one is cancelled). max-parallel: 1
-            # serializes the matrix instead, which scales to any number of declinations
-            # without cancellations while keeping the same one-deployment-at-a-time cluster load.
-            max-parallel: 1
             matrix:
                 distro: ${{ fromJson(needs.clusters-info.outputs.platform-matrix).distro }}
                 scenario: ${{ fromJson(needs.clusters-info.outputs.platform-matrix).scenario }}
                 declination: ${{ fromJson(needs.clusters-info.outputs.platform-matrix).declination }}
         concurrency:
-            # Per-scenario cross-run deduplication; in-run ordering is handled by max-parallel above.
+            # instead of running sequentially in a matrix, we use concurrency to run the different scenarios
+            # in parallel but the declinations sequentially
+            # max-parallel would limit us to run 1 matrix job but this way we can run 2 jobs in parallel.
             group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.distro.name }}-${{ matrix.scenario.name }}
             cancel-in-progress: false
         env:
@@ -447,10 +443,8 @@ jobs:
                   cp -f generic/openshift/single-region/helm-values/base.yml ./values.yml
 
                   echo "Applying declination: ${{ matrix.declination.name }}"
-                  echo "  mode: ${{ matrix.declination.declination_mode }}"
-                  echo "  secondary_storage: ${{ matrix.declination.secondary_storage }}"
 
-                  if [[ ${{ matrix.declination.declination_mode }} == "domain" ]]; then
+                  if [[ ${{ matrix.declination.name }} == "domain" ]]; then
 
                     source ./generic/openshift/single-region/procedure/setup-application-domain.sh
                     echo "CAMUNDA_DOMAIN=$CAMUNDA_DOMAIN" | tee -a "$GITHUB_ENV"
@@ -476,7 +470,7 @@ jobs:
                         yq ". *+ load(\"generic/openshift/single-region/helm-values/$file\")" values.yml > values-result.yml
                         cat values-result.yml && mv values-result.yml values.yml
                     done
-                  elif [[ ${{ matrix.declination.declination_mode }} == "no-domain" ]]; then
+                  elif [[ ${{ matrix.declination.name }} == "no-domain" ]]; then
                       # explicitely set no domain
                       echo "CAMUNDA_DOMAIN=" | tee -a "$GITHUB_ENV"
                       echo "CAMUNDA_GRPC_DOMAIN=" | tee -a "$GITHUB_ENV"
@@ -484,7 +478,7 @@ jobs:
                       yq ". *+ load(\"generic/openshift/single-region/helm-values/no-domain.yml\")" values.yml > values-result.yml
                       cat values-result.yml && mv values-result.yml values.yml
                   else
-                    echo "Error: matrix.declination.declination_mode must be set to 'domain' or 'no-domain'" >&2
+                    echo "Error: matrix.declaration must be set to 'domain' or 'no-domain'" >&2
                     exit 1
                   fi
 
@@ -492,19 +486,11 @@ jobs:
                   yq '. *+ load("generic/openshift/single-region/helm-values/scc.yml")' values.yml > values-result.yml
                   cat values-result.yml && mv values-result.yml values.yml
 
-                  # Merge ECK Elasticsearch operator overlay (only for Elasticsearch scenarios)
-                  if [[ "${{ matrix.declination.secondary_storage }}" != "rdbms" ]]; then
-                    echo "Merging ECK Elasticsearch config"
-                    OPERATOR_ES_PATH="generic/kubernetes/operator-based/elasticsearch"
-                    yq ". *+ load(\"${OPERATOR_ES_PATH}/camunda-elastic-values.yml\")" values.yml > values-merged.yml
-                    cat values-merged.yml && mv values-merged.yml values.yml
-                  else
-                    echo "Skipping ECK Elasticsearch config (RDBMS mode)"
-                    echo "Merging RDBMS secondary storage config"
-                    OPERATOR_PG_PATH="generic/kubernetes/operator-based/postgresql"
-                    yq ". *+ load(\"${OPERATOR_PG_PATH}/camunda-rdbms-values.yml\")" values.yml > values-merged.yml
-                    cat values-merged.yml && mv values-merged.yml values.yml
-                  fi
+                  # Merge ECK Elasticsearch operator overlay
+                  echo "Merging ECK Elasticsearch config"
+                  OPERATOR_ES_PATH="generic/kubernetes/operator-based/elasticsearch"
+                  yq ". *+ load(\"${OPERATOR_ES_PATH}/camunda-elastic-values.yml\")" values.yml > values-merged.yml
+                  cat values-merged.yml && mv values-merged.yml values.yml
 
                   # Merge auth provider specific overlays (keycloak-operator or OIDC)
                   # These overlays contain the auth-specific configuration
@@ -514,12 +500,12 @@ jobs:
                   if [[ "$AUTH_PROVIDER" == "oidc" ]]; then
                     echo "Applying OIDC auth overlays"
                     yq ". *+ load(\"${HELM_VALUES_PATH}/values-oidc.yml\")" values.yml > values-merged.yml
-                    yq ". *+ load(\"${HELM_VALUES_PATH}/values-oidc-${{ matrix.declination.declination_mode }}.yml\")" values-merged.yml > values-merged2.yml
+                    yq ". *+ load(\"${HELM_VALUES_PATH}/values-oidc-${{ matrix.declination.name }}.yml\")" values-merged.yml > values-merged2.yml
                     cat values-merged2.yml && mv values-merged2.yml values.yml && rm values-merged.yml
                   elif [[ "$AUTH_PROVIDER" == "keycloak-operator" ]]; then
                     echo "Merging operator-based Keycloak config for Keycloak Operator"
                     OPERATOR_KEYCLOAK_PATH="generic/kubernetes/operator-based/keycloak"
-                    yq ". *+ load(\"${OPERATOR_KEYCLOAK_PATH}/camunda-keycloak-${{ matrix.declination.declination_mode }}-values.yml\")" values.yml > values-merged.yml
+                    yq ". *+ load(\"${OPERATOR_KEYCLOAK_PATH}/camunda-keycloak-${{ matrix.declination.name }}-values.yml\")" values.yml > values-merged.yml
                     cat values-merged.yml && mv values-merged.yml values.yml
 
                     # Merge identity secrets configuration for keycloak-operator auth
@@ -554,37 +540,15 @@ jobs:
                       yq ". *+ load(\"generic/kubernetes/single-region/tests/helm-values/$file\")" values.yml > values-result.yml
                       cat values-result.yml && mv values-result.yml values.yml
                     done
-
-                    # Remove optimize-api permissions when Optimize is disabled (e.g. RDBMS variant)
-                    if [[ "${{ matrix.declination.secondary_storage }}" == "rdbms" ]]; then
-                      yq 'del(.identity.clients[].permissions[] | select(.resourceServerId == "optimize-api"))' values.yml > values-result.yml
-                      cat values-result.yml && mv values-result.yml values.yml
-                    fi
                   fi
 
                   ./generic/openshift/single-region/procedure/assemble-envsubst-values.sh
 
             - name: Deploy Elasticsearch via ECK Operator
-              if: ${{ matrix.declination.secondary_storage != 'rdbms' }}
               timeout-minutes: 10
               uses: ./.github/actions/kubernetes-eck-operator
               with:
                   namespace: ${{ env.CAMUNDA_NAMESPACE }}
-
-            - name: 🐘 Deploy CNPG cluster pg-identity
-              timeout-minutes: 10
-              uses: ./.github/actions/kubernetes-cnpg-cluster
-              with:
-                  namespace: ${{ env.CAMUNDA_NAMESPACE }}
-                  cluster-name: pg-identity
-
-            - name: 🐘 Deploy CNPG cluster pg-camunda (RDBMS secondary storage)
-              if: ${{ matrix.declination.secondary_storage == 'rdbms' }}
-              timeout-minutes: 10
-              uses: ./.github/actions/kubernetes-cnpg-cluster
-              with:
-                  namespace: ${{ env.CAMUNDA_NAMESPACE }}
-                  cluster-name: pg-camunda
 
             - name: 🐘 Deploy Keycloak via Operator (keycloak-operator mode)
               if: ${{ matrix.scenario.auth_provider == 'keycloak-operator' }}
@@ -592,8 +556,15 @@ jobs:
               uses: ./.github/actions/kubernetes-keycloak-operator
               with:
                   namespace: ${{ env.CAMUNDA_NAMESPACE }}
-                  keycloak-mode: ${{ matrix.declination.declination_mode == 'domain' && 'domain-openshift' || 'no-domain' }}
+                  keycloak-mode: ${{ matrix.declination.name == 'domain' && 'domain-openshift' || 'no-domain' }}
                   domain-name: ${{ env.CAMUNDA_DOMAIN }}
+
+            - name: 🐘 Deploy CNPG cluster pg-identity
+              timeout-minutes: 10
+              uses: ./.github/actions/kubernetes-cnpg-cluster
+              with:
+                  namespace: ${{ env.CAMUNDA_NAMESPACE }}
+                  cluster-name: pg-identity
 
             - name: 🐘 Deploy CNPG cluster pg-webmodeler
               if: env.WEBMODELER_ENABLED == 'true'
@@ -665,7 +636,7 @@ jobs:
                   ./generic/kubernetes/single-region/procedure/check-deployment-ready.sh
 
             - name: 🔄 Restart CoreDNS
-              if: matrix.declination.declination_mode == 'domain' && env.CLEANUP_CLUSTERS == 'false'
+              if: matrix.declination.name == 'domain' && env.CLEANUP_CLUSTERS == 'false'
               uses: ./.github/actions/kubernetes-restart-coredns
               timeout-minutes: 10
               with:
@@ -716,9 +687,8 @@ jobs:
                   # In domain mode the Connectors app is exposed under /connectors
                   # by the chart's `connectors.contextPath`, so the actuator probes
                   # need the same prefix when reached through the local port-forward.
-                  connectors-context-path: ${{ matrix.declination.declination_mode == 'domain' && '/connectors' || '' }}
+                  connectors-context-path: ${{ matrix.declination.name == 'domain' && '/connectors' || '' }}
                   elasticsearch-enabled: 'false'
-                  optimize-enabled: ${{ matrix.declination.secondary_storage != 'rdbms' && 'true' || 'false' }}
                   webmodeler-enabled: ${{ env.WEBMODELER_ENABLED }}
                   console-enabled: ${{ env.CONSOLE_ENABLED }}
 
@@ -732,15 +702,13 @@ jobs:
                   camunda-domain-grpc: ${{ env.CAMUNDA_GRPC_DOMAIN }}
                   webmodeler-enabled: ${{ env.WEBMODELER_ENABLED }}
                   console-enabled: ${{ env.CONSOLE_ENABLED }}
-                  optimize-enabled: ${{ matrix.declination.secondary_storage != 'rdbms' && 'true' || 'false' }}
-                  elasticsearch-enabled: ${{ matrix.declination.secondary_storage != 'rdbms' && 'true' || 'false' }}
                   test-namespace: ${{ env.CAMUNDA_NAMESPACE }}
                   test-cluster-type: ${{ env.TEST_CLUSTER_TYPE }}
                   test-release-name: ${{ env.CAMUNDA_RELEASE_NAME }}
                   test-client-id: ${{ steps.secrets.outputs.CI_CAMUNDA_USER_TEST_CLIENT_ID }}
                   test-client-secret: ${{ steps.secrets.outputs.CI_CAMUNDA_USER_TEST_CLIENT_SECRET }}
                   keycloak-service-name: ${{ matrix.scenario.auth_provider == 'keycloak-operator' && 'keycloak-service:18080' || '' }}
-                  elasticsearch-service-name: ${{ matrix.declination.secondary_storage != 'rdbms' && 'elasticsearch-es-http:9200' || '' }}
+                  elasticsearch-service-name: elasticsearch-es-http:9200
                   skip-c8sm-connectivity-ingress-class-check: 'true' # OpenShift uses different ingress class names
 
             - name: 🔬🚨 Get failed Pods info
@@ -749,13 +717,6 @@ jobs:
               with:
                   namespace: ${{ env.CAMUNDA_NAMESPACE }}
                   artifact-suffix: ${{ matrix.distro.name }}-${{ matrix.scenario.name }}-${{ matrix.declination.name }}
-
-            - name: 🧹 Cleanup CNPG cluster pg-camunda
-              if: always() && env.CLEANUP_CLUSTERS == 'true' && matrix.declination.secondary_storage == 'rdbms'
-              uses: ./.github/actions/kubernetes-cnpg-cluster-cleanup
-              with:
-                  namespace: ${{ env.CAMUNDA_NAMESPACE }}
-                  cluster-name: pg-camunda
 
             - name: 🧹 Cleanup CNPG cluster pg-identity
               if: always() && env.CLEANUP_CLUSTERS == 'true'
@@ -772,7 +733,7 @@ jobs:
                   cluster-name: pg-webmodeler
 
             - name: 🧹 Cleanup ECK Elasticsearch deployment
-              if: always() && env.CLEANUP_CLUSTERS == 'true' && matrix.declination.secondary_storage != 'rdbms'
+              if: always() && env.CLEANUP_CLUSTERS == 'true'
               uses: ./.github/actions/kubernetes-eck-operator-cleanup
               with:
                   namespace: ${{ env.CAMUNDA_NAMESPACE }}
@@ -791,7 +752,7 @@ jobs:
                   skip-operator-uninstall: 'false'
 
             - name: 🧹 Uninstall ECK Operator
-              if: always() && env.CLEANUP_CLUSTERS == 'true' && matrix.declination.secondary_storage != 'rdbms'
+              if: always() && env.CLEANUP_CLUSTERS == 'true'
               uses: ./.github/actions/kubernetes-eck-operator-cleanup
               with:
                   namespace: ${{ env.CAMUNDA_NAMESPACE }}

--- a/generic/kubernetes/dual-region/tests/helm-values/registry.yml
+++ b/generic/kubernetes/dual-region/tests/helm-values/registry.yml
@@ -4,7 +4,17 @@
 
 # Auth to avoid Docker download rate limit.
 # https://docs.docker.com/docker-hub/download-rate-limit/
+identityKeycloak:
+    image:
+        pullSecrets:
+            - name: index-docker-io
+
 global:
     image:
         pullSecrets:
+            - name: index-docker-io
+
+elasticsearch:
+    global:
+        imagePullSecrets:
             - name: index-docker-io

--- a/generic/kubernetes/migration/tests/bitnami-values-domain.yml
+++ b/generic/kubernetes/migration/tests/bitnami-values-domain.yml
@@ -19,6 +19,8 @@ global:
             # Override the issuer to match the Keycloak Operator hostname (https://camunda.example.com/auth).
             # Tokens issued by KC carry iss=https://camunda.example.com/auth/realms/camunda-platform.
             publicIssuerUrl: https://camunda.example.com/auth/realms/camunda-platform
+            identity:
+                redirectUrl: https://camunda.example.com/identity
             optimize:
                 redirectUrl: https://camunda.example.com/optimize
             console:

--- a/generic/kubernetes/operator-based/keycloak/camunda-keycloak-domain-values.yml
+++ b/generic/kubernetes/operator-based/keycloak/camunda-keycloak-domain-values.yml
@@ -49,6 +49,8 @@ orchestration:
 
 identityKeycloak:
     enabled: false
+    postgresql:
+        enabled: false
 
 identity:
     enabled: true

--- a/generic/kubernetes/operator-based/keycloak/camunda-keycloak-no-domain-values.yml
+++ b/generic/kubernetes/operator-based/keycloak/camunda-keycloak-no-domain-values.yml
@@ -52,6 +52,8 @@ orchestration:
 
 identityKeycloak:
     enabled: false
+    postgresql:
+        enabled: false
 
 identity:
     enabled: true

--- a/generic/kubernetes/operator-based/postgresql/deploy.sh
+++ b/generic/kubernetes/operator-based/postgresql/deploy.sh
@@ -60,13 +60,8 @@ else
     echo "Filtered deployment: $CLUSTER_FILTER"
     IFS=',' read -ra CLUSTERS <<< "$CLUSTER_FILTER"
     for cluster in "${CLUSTERS[@]}"; do
-        # pg-camunda is defined in a separate orchestration manifest
-        if [[ "$cluster" == "pg-camunda" ]]; then
-            kubectl apply --server-side -f postgresql-orchestration-cluster.yml -n "$CAMUNDA_NAMESPACE"
-        else
-            yq "select(.metadata.name == \"$cluster\")" postgresql-clusters.yml | \
-                kubectl apply -n "$CAMUNDA_NAMESPACE" --server-side -f -
-        fi
+        yq "select(.metadata.name == \"$cluster\")" postgresql-clusters.yml | \
+            kubectl apply -n "$CAMUNDA_NAMESPACE" --server-side -f -
     done
     for cluster in "${CLUSTERS[@]}"; do
         kubectl wait --for=condition=Ready --timeout=600s cluster "$cluster" -n "$CAMUNDA_NAMESPACE"

--- a/generic/kubernetes/operator-based/tests/utils/camunda-domain-values.yml
+++ b/generic/kubernetes/operator-based/tests/utils/camunda-domain-values.yml
@@ -23,6 +23,8 @@ global:
 
     identity:
         auth:
+            identity:
+                redirectUrl: https://${CAMUNDA_DOMAIN}/managementidentity
             console:
                 redirectUrl: https://${CAMUNDA_DOMAIN}/console
             webModeler:

--- a/generic/kubernetes/operator-based/tests/utils/camunda-no-domain-values.yml
+++ b/generic/kubernetes/operator-based/tests/utils/camunda-no-domain-values.yml
@@ -23,6 +23,8 @@ global:
 
     identity:
         auth:
+            identity:
+                redirectUrl: http://localhost:8085
             console:
                 redirectUrl: http://localhost:8087
             webModeler:

--- a/generic/kubernetes/single-region/tests/helm-values/registry-harbor.yml
+++ b/generic/kubernetes/single-region/tests/helm-values/registry-harbor.yml
@@ -8,3 +8,8 @@ global:
         pullSecrets:
             - name: registry-camunda-cloud
             - name: index-docker-io
+
+elasticsearch:
+    global:
+        imagePullSecrets:
+            - name: index-docker-io

--- a/generic/kubernetes/single-region/tests/helm-values/registry.yml
+++ b/generic/kubernetes/single-region/tests/helm-values/registry.yml
@@ -4,7 +4,17 @@
 
 # Auth to avoid Docker download rate limit.
 # https://docs.docker.com/docker-hub/download-rate-limit/
+identityKeycloak:
+    image:
+        pullSecrets:
+            - name: index-docker-io
+
 global:
     image:
         pullSecrets:
+            - name: index-docker-io
+
+elasticsearch:
+    global:
+        imagePullSecrets:
             - name: index-docker-io

--- a/generic/openshift/single-region/helm-values/base.yml
+++ b/generic/openshift/single-region/helm-values/base.yml
@@ -20,6 +20,7 @@ global:
             method: oidc
 
     identity:
+        enabled: true
         auth:
             enabled: true
 

--- a/local/kubernetes/kind-single-region/procedure/operators-deploy.sh
+++ b/local/kubernetes/kind-single-region/procedure/operators-deploy.sh
@@ -35,10 +35,14 @@ CAMUNDA_MODE=${CAMUNDA_MODE:-no-domain}
 CAMUNDA_DOMAIN="${CAMUNDA_DOMAIN:-camunda.example.com}"
 export CAMUNDA_DOMAIN
 
-# Both secondary-storage modes need the application PG clusters
-# (Keycloak, Identity, WebModeler). RDBMS (postgres) mode additionally needs the
-# orchestration cluster (pg-camunda), appended just before deployment below.
-CLUSTER_FILTER="pg-keycloak,pg-identity,pg-webmodeler"
+# Set CLUSTER_FILTER based on SECONDARY_STORAGE
+# When using Elasticsearch, only deploy PG clusters for Keycloak, Identity, and WebModeler
+# When using PostgreSQL (RDBMS mode), deploy all PG clusters including the Camunda database
+if [[ "$SECONDARY_STORAGE" == "elasticsearch" ]]; then
+    CLUSTER_FILTER="pg-keycloak,pg-identity,pg-webmodeler"
+else
+    CLUSTER_FILTER=""
+fi
 
 export CAMUNDA_NAMESPACE
 
@@ -65,13 +69,14 @@ echo ""
 echo "=== Deploying PostgreSQL (CloudNativePG) ==="
 (
     cd "$OPERATOR_BASE/postgresql"
+    CLUSTER_FILTER="$CLUSTER_FILTER" NAMESPACE="$CAMUNDA_NAMESPACE" ./deploy.sh
 
-    # When using RDBMS mode, also deploy the orchestration cluster (pg-camunda)
+    # Deploy orchestration PG cluster (only for RDBMS mode)
     if [[ "$SECONDARY_STORAGE" == "postgres" ]]; then
-        CLUSTER_FILTER="${CLUSTER_FILTER:+$CLUSTER_FILTER,}pg-camunda"
+        echo "Deploying orchestration PostgreSQL cluster (pg-camunda)..."
+        kubectl apply --server-side -f postgresql-orchestration-cluster.yml -n "$CAMUNDA_NAMESPACE"
+        kubectl wait --for=condition=Ready --timeout=600s cluster pg-camunda -n "$CAMUNDA_NAMESPACE"
     fi
-
-    CLUSTER_FILTER="$CLUSTER_FILTER" ./deploy.sh
 )
 
 # 3. Deploy Keycloak via Keycloak operator


### PR DESCRIPTION
Reverts #2345.

The agent merged #2345 automatically, which it must not do — merging is a human-only action on GitHub. This PR reverts that merge so the change can be re-analyzed and merged by a human.

**For a human to merge.** Once this revert is merged, the feature PR #2345 (branch `feat/rosa-hcp-rdbms-variant`, fully reviewed: 3/3 ROSA declinations green, Copilot-clean) can be reopened/re-proposed for analysis and a human-performed merge.

Ref: camunda/team-infrastructure-experience#1065 / #1145