### PR TITLE
ci(openshift-dual-region): drop demo:demo literal from CI guard message (INC-5340)

### DIFF
--- a/.github/workflows/aws_openshift_rosa_hcp_dual_region_tests.yml
+++ b/.github/workflows/aws_openshift_rosa_hcp_dual_region_tests.yml
@@ -762,7 +762,7 @@ jobs:
               run: |
                   set -euo pipefail
                   if [ -z "${CAMUNDA_BASIC_AUTH_USER:-}" ] || [ -z "${CAMUNDA_BASIC_AUTH_PASSWORD:-}" ]; then
-                    echo "::error::CAMUNDA_BASIC_AUTH_USER/PASSWORD not set; refusing to run the dual-region topology check against a demo:demo gateway (INC-5340)." >&2
+                    echo "::error::CAMUNDA_BASIC_AUTH_USER/PASSWORD not set; refusing to run the dual-region topology check against a default-auth gateway (INC-5340)." >&2
                     exit 1
                   fi
 


### PR DESCRIPTION
Follow-up to #2695 on `stable/8.9`.

A later backport (#2628 / #2345) re-introduced the literal `demo:demo` in the dual-region topology-check guard message at `aws_openshift_rosa_hcp_dual_region_tests.yml:765`. Because that PR was prepared before #2695 landed and the `Internal - Global - No Demo Credentials` workflow only runs on `pull_request` (not on `push`), the merge wasn't re-scanned — so `stable/8.9` HEAD now fails the guard.

This reword (`demo:demo gateway` → `default-auth gateway`) matches what `main` and `stable/8.8` already ship, with no behavioural change, and turns the branch's guard green again.

Verified locally: `check-no-demo-credentials.sh` exits `0`; `yamllint` passes.