### PR TITLE
docs(architecture): use stable docs.camunda.io links in RDBMS note [ready]

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -55,7 +55,7 @@ Camunda 8 deployments consist of two logical clusters:
 - Elasticsearch / OpenSearch (search-heavy / analytics workloads)
 - RDBMS / PostgreSQL (relational preference; Optimize still requires Elasticsearch/OpenSearch)
 
-RDBMS secondary storage is available since 8.9 for the Orchestration Cluster (Operate, Tasklist, v2 REST API). For backend trade-offs and benchmarks, see [secondary storage architecture](https://docs.camunda.io/docs/next/self-managed/reference-architecture/reference-architecture/#secondary-storage-architecture) and [RDBMS benchmark results](https://docs.camunda.io/docs/next/self-managed/concepts/secondary-storage/rdbms-benchmark-results/) in the product documentation. Reference implementations with a dedicated RDBMS variant: `azure/kubernetes/aks-single-region-rdbms` (the `*-rdbms` declination of a ref-arch uses a relational database instead of a document store).
+RDBMS secondary storage is available since 8.9 for the Orchestration Cluster (Operate, Tasklist, v2 REST API). For backend trade-offs and benchmarks, see [secondary storage architecture](https://docs.camunda.io/docs/self-managed/reference-architecture/reference-architecture/#secondary-storage-architecture) and [RDBMS benchmark results](https://docs.camunda.io/docs/self-managed/concepts/secondary-storage/rdbms-benchmark-results/) in the product documentation. Reference implementations with a dedicated RDBMS variant: `azure/kubernetes/aks-single-region-rdbms` (the `*-rdbms` declination of a ref-arch uses a relational database instead of a document store).
 
 **Production baseline:** Minimum 3 Zeebe brokers across 3 availability zones.
 


### PR DESCRIPTION
Follow-up to #2729 (merged): switch the two product-doc links added to `docs/architecture.md` from `/docs/next/...` to the stable `/docs/self-managed/...` paths, matching the convention used elsewhere in the file (Copilot review finding on #2729).

Part of camunda/team-infrastructure-experience#1066