### PR TITLE
fix(install-chart): wait for Keycloak in domain mode (avoid OIDC startup crash-loop)

### DIFF
--- a/generic/kubernetes/single-region/procedure/install-chart.sh
+++ b/generic/kubernetes/single-region/procedure/install-chart.sh
@@ -5,6 +5,15 @@ helm upgrade --install \
     --version "$CAMUNDA_HELM_CHART_VERSION" --namespace "$CAMUNDA_NAMESPACE" \
     -f generated-values.yml
 
+# Domain + OIDC mode only: the app pods (orchestration, Connectors) fetch the OIDC
+# discovery document from the public Keycloak issuer at startup and CrashLoopBackOff
+# until it converges (realm provisioning + DNS + TLS cert + ingress) — which can
+# outlast their restart backoff. Wait (bounded, fail-open) for the issuer, then clear
+# the backoff. Skipped when CAMUNDA_DOMAIN is unset (no public issuer, e.g. no-domain).
+if [ -n "${CAMUNDA_DOMAIN:-}" ]; then
+    "$(dirname "$0")/wait-for-keycloak.sh"
+fi
+
 # TODO: [release-duty] before the release, update this by removing the oci pull above
 # and uncomment the installation instruction below
 

--- a/generic/openshift/single-region/procedure/install-chart.sh
+++ b/generic/openshift/single-region/procedure/install-chart.sh
@@ -6,6 +6,15 @@ helm upgrade --install \
     --version "$CAMUNDA_HELM_CHART_VERSION" --namespace "$CAMUNDA_NAMESPACE" \
     -f generated-values.yml
 
+# Domain + OIDC mode only: the app pods (orchestration, Connectors) fetch the OIDC
+# discovery document from the public Keycloak issuer at startup and CrashLoopBackOff
+# until it converges (realm provisioning + DNS + TLS cert + ingress) — which can
+# outlast their restart backoff. Wait (bounded, fail-open) for the issuer, then clear
+# the backoff. Skipped when CAMUNDA_DOMAIN is unset (no public issuer, e.g. no-domain).
+if [ -n "${CAMUNDA_DOMAIN:-}" ]; then
+    "$(dirname "$0")/../../../kubernetes/single-region/procedure/wait-for-keycloak.sh"
+fi
+
 # TODO: [release-duty] before the release, update this by removing the oci pull above
 # and uncomment the installation instruction below
 


### PR DESCRIPTION
**Stacked on #2718** (uses its `wait-for-keycloak.sh`; merge after #2718).

## What
After `helm upgrade --install`, both single-region `install-chart.sh` scripts now call `wait-for-keycloak.sh` **when `CAMUNDA_DOMAIN` is set** (domain mode):
- `generic/kubernetes/single-region/procedure/install-chart.sh`
- `generic/openshift/single-region/procedure/install-chart.sh`

## Why
In domain + OIDC mode the app pods (orchestration, Connectors) fetch the OIDC discovery document from the **public** Keycloak issuer at startup and `CrashLoopBackOff` until it converges (realm + DNS + TLS cert + ingress) — which can outlast their restart backoff (observed on ROSA: connectors/zeebe `Error`→`CrashLoopBackOff`, `Token fetch … Connect timed out`). `wait-for-keycloak.sh` waits (bounded, fail-open) for the issuer, then clears the backoff.

## Coverage
This is target **(a)**: putting the gate inside the shared `install-chart.sh` covers:
- **Customers** running the documented domain procedure, and
- **EKS / AKS / ROSA single-region CI**, which deploy via these scripts and set `CAMUNDA_DOMAIN`.

No-op when `CAMUNDA_DOMAIN` is unset (no-domain). The CI-only `KEYCLOAK_WAIT_INSECURE` wiring + EKS inline-step removal + ROSA dual-region come in a follow-up CI PR stacked on this.

Validated: `shellcheck` clean, relative path resolves to the script.