### PR TITLE
fix(ci): wire keycloak wait into EKS/AKS/ROSA-single domain deploys

### DIFF
--- a/.github/workflows/aws_kubernetes_eks_single_region_tests.yml
+++ b/.github/workflows/aws_kubernetes_eks_single_region_tests.yml
@@ -842,7 +842,16 @@ jobs:
                   vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
 
             - name: 🏁 Install Camunda 8 using the generic/kubernetes helm chart procedure
-              timeout-minutes: 10
+              # Bumped from 10m: in domain mode install-chart.sh now also waits
+              # (bounded, fail-open) for the public Keycloak issuer to converge
+              # before returning, so the step needs room for the helm install plus
+              # that wait.
+              timeout-minutes: 22
+              env:
+                  # install-chart.sh waits for the public Keycloak issuer in domain
+                  # mode; the CI cert is the Vault wildcard (internal CA), so skip TLS
+                  # verification for that readiness probe when that cert is in use.
+                  KEYCLOAK_WAIT_INSECURE: ${{ steps.cert-config.outputs.use-wildcard-cert == 'true' && 'true' || '' }}
               run: |
                   set -euo pipefail
 
@@ -890,41 +899,6 @@ jobs:
                   vault-addr: ${{ secrets.VAULT_ADDR }}
                   vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
                   vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
-
-            # In domain + OIDC mode the Camunda app pods (Zeebe, Connectors, …)
-            # contact the public Keycloak URL at startup to fetch the OIDC
-            # discovery document. The public ingress (DNS + cert-manager + LB
-            # provisioning) typically takes several minutes to converge after
-            # `helm install`, during which time the app pods crash-loop. With
-            # exponential backoff the next restart can be delayed up to 5 min,
-            # so the deployment can fail to ever become healthy within the
-            # `Wait for the deployment` timeout. Wait for the public Keycloak
-            # URL to answer 200 first, then bounce the crash-looping
-            # statefulsets so they restart immediately instead of after the
-            # next backoff window.
-            - name: ⏳ Wait for Keycloak external URL reachable
-              if: matrix.declination.name == 'domain'
-              timeout-minutes: 12
-              run: |
-                  set -uo pipefail
-                  KC_URL="https://${CAMUNDA_DOMAIN}/auth/realms/camunda-platform/.well-known/openid-configuration"
-                  echo "Waiting for Keycloak OIDC discovery: $KC_URL"
-                  ATTEMPTS=120 # 120 * 5s = 10 minutes
-                  for i in $(seq 1 "$ATTEMPTS"); do
-                      CODE=$(curl -ksS -o /dev/null -w '%{http_code}' --max-time 5 "$KC_URL" || echo "000")
-                      if [[ "$CODE" == "200" ]]; then
-                          echo "✅ Keycloak reachable (HTTP $CODE) after $i attempt(s)"
-                          # Bounce crash-looping app pods so they restart now
-                          # instead of waiting on exponential backoff.
-                          kubectl -n "$CAMUNDA_NAMESPACE" rollout restart \
-                              statefulset/camunda-zeebe \
-                              deployment/camunda-connectors 2>/dev/null || true
-                          exit 0
-                      fi
-                      echo "[$i/$ATTEMPTS] not ready yet (HTTP $CODE), sleeping 5s…"
-                      sleep 5
-                  done
-                  echo "::warning::Keycloak external URL did not respond 200 within ${ATTEMPTS}*5s; continuing anyway."
 
             - name: 👀⏳ Wait for the deployment to be healthy using generic/kubernetes/single-region
               timeout-minutes: 20

--- a/.github/workflows/aws_openshift_rosa_hcp_single_region_tests.yml
+++ b/.github/workflows/aws_openshift_rosa_hcp_single_region_tests.yml
@@ -586,7 +586,16 @@ jobs:
                   vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
 
             - name: 🏁 Install Camunda 8 using the generic/openshift helm chart procedure
-              timeout-minutes: 10
+              # Bumped from 10m: in domain mode install-chart.sh now also waits
+              # (bounded, fail-open) for the public Keycloak issuer to converge
+              # before returning, so the step needs room for the helm install plus
+              # that wait.
+              timeout-minutes: 22
+              env:
+                  # install-chart.sh waits for the public Keycloak issuer in domain
+                  # mode; the ROSA CI cert is the Vault wildcard (internal CA), so skip
+                  # TLS verification for that readiness probe.
+                  KEYCLOAK_WAIT_INSECURE: 'true'
               run: |
                   set -euo pipefail
 

--- a/.github/workflows/azure_kubernetes_aks_single_region_tests.yml
+++ b/.github/workflows/azure_kubernetes_aks_single_region_tests.yml
@@ -640,7 +640,16 @@ jobs:
                   vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
 
             - name: 🏁 Install Camunda 8 using the generic/kubernetes helm chart procedure
-              timeout-minutes: 10
+              # Bumped from 10m: in domain mode install-chart.sh now also waits
+              # (bounded, fail-open) for the public Keycloak issuer to converge
+              # before returning, so the step needs room for the helm install plus
+              # that wait.
+              timeout-minutes: 22
+              env:
+                  # install-chart.sh waits for the public Keycloak issuer in domain
+                  # mode; the CI cert is the Vault wildcard (internal CA), so skip TLS
+                  # verification for that readiness probe when that cert is in use.
+                  KEYCLOAK_WAIT_INSECURE: ${{ steps.cert-config.outputs.use-wildcard-cert == 'true' && 'true' || '' }}
               run: |
                   set -euo pipefail
 


### PR DESCRIPTION
**Stacked on #2735** (which is stacked on #2718). Merge after both.

## What
Makes the in-`install-chart.sh` Keycloak wait (#2735) effective in CI for the single-region domain tests:
- **EKS / AKS**: add `KEYCLOAK_WAIT_INSECURE` to the deploy step (keyed off `cert-config.use-wildcard-cert`), bump the deploy `timeout-minutes` to fit the bounded wait.
- **ROSA-single**: same, with `KEYCLOAK_WAIT_INSECURE: 'true'` (ROSA always uses the Vault wildcard / internal CA).
- **EKS**: remove the now-redundant inline `⏳ Wait for Keycloak external URL reachable` step (its poll-then-rollout-restart logic now lives in `wait-for-keycloak.sh`, called by `install-chart.sh`).

## Why insecure in CI
The CI public cert is the Vault wildcard (internal CA); the readiness probe must skip TLS verification (matches EKS's old `curl -k`).

## Not included
- **ROSA dual-region**: uses **basic auth** (`values-base.yml`: *Management Identity (Keycloak) is not deployed in dual-region*) — no public OIDC issuer, so the crash-loop can't occur there; no keycloak-wait needed. (Its flake is Submariner — separate.)

Validated: `actionlint` clean, `yamllint`/`yamlfmt` pass; EKS/AKS/ROSA single-region CI deploy via `install-chart.sh` + set `CAMUNDA_DOMAIN`, so the wait runs.