### PR TITLE
fix(install-chart): wait for Keycloak in domain mode (backport #2735, 8.8)

### DIFF
--- a/generic/kubernetes/single-region/procedure/install-chart.sh
+++ b/generic/kubernetes/single-region/procedure/install-chart.sh
@@ -6,3 +6,12 @@ helm upgrade --install \
    --version "$CAMUNDA_HELM_CHART_VERSION" \
    --namespace "$CAMUNDA_NAMESPACE" \
    -f generated-values.yml
+
+# Domain + OIDC mode only: the app pods (orchestration, Connectors) fetch the OIDC
+# discovery document from the public Keycloak issuer at startup and CrashLoopBackOff
+# until it converges (realm provisioning + DNS + TLS cert + ingress) — which can
+# outlast their restart backoff. Wait (bounded, fail-open) for the issuer, then clear
+# the backoff. Skipped when CAMUNDA_DOMAIN is unset (no public issuer, e.g. no-domain).
+if [ -n "${CAMUNDA_DOMAIN:-}" ]; then
+    "$(dirname "$0")/wait-for-keycloak.sh"
+fi

--- a/generic/openshift/single-region/procedure/install-chart.sh
+++ b/generic/openshift/single-region/procedure/install-chart.sh
@@ -6,3 +6,12 @@ helm upgrade --install \
   --version "$CAMUNDA_HELM_CHART_VERSION" \
   --namespace "$CAMUNDA_NAMESPACE" \
   -f generated-values.yml
+
+# Domain + OIDC mode only: the app pods (orchestration, Connectors) fetch the OIDC
+# discovery document from the public Keycloak issuer at startup and CrashLoopBackOff
+# until it converges (realm provisioning + DNS + TLS cert + ingress) — which can
+# outlast their restart backoff. Wait (bounded, fail-open) for the issuer, then clear
+# the backoff. Skipped when CAMUNDA_DOMAIN is unset (no public issuer, e.g. no-domain).
+if [ -n "${CAMUNDA_DOMAIN:-}" ]; then
+    "$(dirname "$0")/../../../kubernetes/single-region/procedure/wait-for-keycloak.sh"
+fi


### PR DESCRIPTION
Backport of #2735 to `stable/8.8`. **Stacked on #2720**. Adds the `CAMUNDA_DOMAIN`-guarded `wait-for-keycloak.sh` call to both single-region `install-chart.sh` scripts. shellcheck clean; path resolves.