### PR TITLE
fix(ci): wire keycloak wait into EKS/AKS/ROSA-single domain deploys (backport #2736, 8.9)

### DIFF
--- a/.github/workflows/aws_kubernetes_eks_single_region_tests.yml
+++ b/.github/workflows/aws_kubernetes_eks_single_region_tests.yml
@@ -838,7 +838,16 @@ jobs:
                   vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
 
             - name: 🏁 Install Camunda 8 using the generic/kubernetes helm chart procedure
-              timeout-minutes: 10
+              # Bumped from 10m: in domain mode install-chart.sh now also waits
+              # (bounded, fail-open) for the public Keycloak issuer to converge
+              # before returning, so the step needs room for the helm install plus
+              # that wait.
+              timeout-minutes: 22
+              env:
+                  # install-chart.sh waits for the public Keycloak issuer in domain
+                  # mode; the CI cert is the Vault wildcard (internal CA), so skip TLS
+                  # verification for that readiness probe when that cert is in use.
+                  KEYCLOAK_WAIT_INSECURE: ${{ steps.cert-config.outputs.use-wildcard-cert == 'true' && 'true' || '' }}
               run: |
                   set -euo pipefail
 
@@ -886,41 +895,6 @@ jobs:
                   vault-addr: ${{ secrets.VAULT_ADDR }}
                   vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
                   vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
-
-            # In domain + OIDC mode the Camunda app pods (Zeebe, Connectors, …)
-            # contact the public Keycloak URL at startup to fetch the OIDC
-            # discovery document. The public ingress (DNS + cert-manager + LB
-            # provisioning) typically takes several minutes to converge after
-            # `helm install`, during which time the app pods crash-loop. With
-            # exponential backoff the next restart can be delayed up to 5 min,
-            # so the deployment can fail to ever become healthy within the
-            # `Wait for the deployment` timeout. Wait for the public Keycloak
-            # URL to answer 200 first, then bounce the crash-looping
-            # statefulsets so they restart immediately instead of after the
-            # next backoff window.
-            - name: ⏳ Wait for Keycloak external URL reachable
-              if: matrix.declination.name == 'domain'
-              timeout-minutes: 12
-              run: |
-                  set -uo pipefail
-                  KC_URL="https://${CAMUNDA_DOMAIN}/auth/realms/camunda-platform/.well-known/openid-configuration"
-                  echo "Waiting for Keycloak OIDC discovery: $KC_URL"
-                  ATTEMPTS=120 # 120 * 5s = 10 minutes
-                  for i in $(seq 1 "$ATTEMPTS"); do
-                      CODE=$(curl -ksS -o /dev/null -w '%{http_code}' --max-time 5 "$KC_URL" || echo "000")
-                      if [[ "$CODE" == "200" ]]; then
-                          echo "✅ Keycloak reachable (HTTP $CODE) after $i attempt(s)"
-                          # Bounce crash-looping app pods so they restart now
-                          # instead of waiting on exponential backoff.
-                          kubectl -n "$CAMUNDA_NAMESPACE" rollout restart \
-                              statefulset/camunda-zeebe \
-                              deployment/camunda-connectors 2>/dev/null || true
-                          exit 0
-                      fi
-                      echo "[$i/$ATTEMPTS] not ready yet (HTTP $CODE), sleeping 5s…"
-                      sleep 5
-                  done
-                  echo "::warning::Keycloak external URL did not respond 200 within ${ATTEMPTS}*5s; continuing anyway."
 
             - name: 👀⏳ Wait for the deployment to be healthy using generic/kubernetes/single-region
               timeout-minutes: 20

--- a/.github/workflows/aws_openshift_rosa_hcp_single_region_tests.yml
+++ b/.github/workflows/aws_openshift_rosa_hcp_single_region_tests.yml
@@ -583,7 +583,16 @@ jobs:
                   vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
 
             - name: 🏁 Install Camunda 8 using the generic/openshift helm chart procedure
-              timeout-minutes: 10
+              # Bumped from 10m: in domain mode install-chart.sh now also waits
+              # (bounded, fail-open) for the public Keycloak issuer to converge
+              # before returning, so the step needs room for the helm install plus
+              # that wait.
+              timeout-minutes: 22
+              env:
+                  # install-chart.sh waits for the public Keycloak issuer in domain
+                  # mode; the ROSA CI cert is the Vault wildcard (internal CA), so skip
+                  # TLS verification for that readiness probe.
+                  KEYCLOAK_WAIT_INSECURE: 'true'
               run: |
                   set -euo pipefail
 

--- a/.github/workflows/azure_kubernetes_aks_single_region_tests.yml
+++ b/.github/workflows/azure_kubernetes_aks_single_region_tests.yml
@@ -648,7 +648,16 @@ jobs:
                   vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
 
             - name: 🏁 Install Camunda 8 using the generic/kubernetes helm chart procedure
-              timeout-minutes: 10
+              # Bumped from 10m: in domain mode install-chart.sh now also waits
+              # (bounded, fail-open) for the public Keycloak issuer to converge
+              # before returning, so the step needs room for the helm install plus
+              # that wait.
+              timeout-minutes: 22
+              env:
+                  # install-chart.sh waits for the public Keycloak issuer in domain
+                  # mode; the CI cert is the Vault wildcard (internal CA), so skip TLS
+                  # verification for that readiness probe when that cert is in use.
+                  KEYCLOAK_WAIT_INSECURE: ${{ steps.cert-config.outputs.use-wildcard-cert == 'true' && 'true' || '' }}
               run: |
                   set -euo pipefail
 


### PR DESCRIPTION
Backport of #2736 to `stable/8.9`. **Stacked on #2737** (8.9 backport of #2735). Same changes as #2736 (8.9 structure is identical): KEYCLOAK_WAIT_INSECURE + timeout bump on EKS/AKS/ROSA-single deploy steps; remove EKS's redundant inline keycloak step. actionlint clean.