### PR TITLE
fix(ci): wire keycloak wait into EKS/AKS/ROSA-single domain deploys (backport #2736, 8.8)

### DIFF
--- a/.github/workflows/aws_kubernetes_eks_single_region_tests.yml
+++ b/.github/workflows/aws_kubernetes_eks_single_region_tests.yml
@@ -683,7 +683,16 @@ jobs:
                   kubectl delete secret setup-os-secret --namespace "$CAMUNDA_NAMESPACE"
 
             - name: 🏁 Install Camunda 8 using the generic/kubernetes helm chart procedure
-              timeout-minutes: 10
+              # Bumped from 10m: in domain mode install-chart.sh now also waits
+              # (bounded, fail-open) for the public Keycloak issuer to converge
+              # before returning, so the step needs room for the helm install plus
+              # that wait.
+              timeout-minutes: 22
+              env:
+                  # install-chart.sh waits for the public Keycloak issuer in domain
+                  # mode; the CI cert is the Vault wildcard (internal CA), so skip TLS
+                  # verification for that readiness probe when that cert is in use.
+                  KEYCLOAK_WAIT_INSECURE: ${{ steps.cert-config.outputs.use-wildcard-cert == 'true' && 'true' || '' }}
               run: |
                   set -euo pipefail
 

--- a/.github/workflows/aws_openshift_rosa_hcp_single_region_tests.yml
+++ b/.github/workflows/aws_openshift_rosa_hcp_single_region_tests.yml
@@ -497,7 +497,16 @@ jobs:
 
 
             - name: 🏁 Install Camunda 8 using the generic/openshift helm chart procedure
-              timeout-minutes: 10
+              # Bumped from 10m: in domain mode install-chart.sh now also waits
+              # (bounded, fail-open) for the public Keycloak issuer to converge
+              # before returning, so the step needs room for the helm install plus
+              # that wait.
+              timeout-minutes: 22
+              env:
+                  # install-chart.sh waits for the public Keycloak issuer in domain
+                  # mode; the ROSA CI cert is the Vault wildcard (internal CA), so skip
+                  # TLS verification for that readiness probe.
+                  KEYCLOAK_WAIT_INSECURE: 'true'
               run: |
                   set -euo pipefail
 

--- a/.github/workflows/azure_kubernetes_aks_single_region_tests.yml
+++ b/.github/workflows/azure_kubernetes_aks_single_region_tests.yml
@@ -595,7 +595,16 @@ jobs:
                   ./azure/kubernetes/${{ matrix.scenario.name }}/procedure/create-external-db-secrets.sh
 
             - name: 🏁 Install Camunda 8 using the generic/kubernetes helm chart procedure
-              timeout-minutes: 10
+              # Bumped from 10m: in domain mode install-chart.sh now also waits
+              # (bounded, fail-open) for the public Keycloak issuer to converge
+              # before returning, so the step needs room for the helm install plus
+              # that wait.
+              timeout-minutes: 22
+              env:
+                  # install-chart.sh waits for the public Keycloak issuer in domain
+                  # mode; the CI cert is the Vault wildcard (internal CA), so skip TLS
+                  # verification for that readiness probe when that cert is in use.
+                  KEYCLOAK_WAIT_INSECURE: ${{ steps.cert-config.outputs.use-wildcard-cert == 'true' && 'true' || '' }}
               run: |
                   set -euo pipefail
 


### PR DESCRIPTION
Backport of #2736 to `stable/8.8`. **Stacked on #2738** (8.8 backport of #2735). 8.8 has no inline EKS keycloak step, so this only adds KEYCLOAK_WAIT_INSECURE + deploy-step timeout bump to EKS/AKS/ROSA-single. actionlint clean.