### PR TITLE
fix(ci): wait for the OIDC issuer before health check on domain tests (backport #2741, 8.8)

### DIFF
--- a/.github/actions/internal-wait-oidc-issuer/README.md
+++ b/.github/actions/internal-wait-oidc-issuer/README.md
@@ -1,0 +1,78 @@
+# Wait for the OIDC issuer to be reachable
+
+## Description
+
+CI-only helper for domain / TLS test runs.
+
+In domain mode the Camunda app pods (orchestration / Zeebe and Connectors)
+fetch the OIDC discovery document from the configured issuer at startup. On a
+freshly provisioned cluster that issuer only converges minutes after
+`helm install` — DNS, the TLS certificate and the ingress have to settle, and
+a self-hosted IdP also has to provision its realm — during which the app pods
+`CrashLoopBackOff`. Their exponential restart backoff can outlast the
+readiness window, so the deployment can look broken for a while.
+
+This action waits (bounded, fail-open) for the issuer's discovery document to
+answer `200`, then bounces the affected workloads so they restart immediately
+instead of after the next backoff window.
+
+It is **IdP-agnostic**: it polls whatever `issuer-url` the caller provides and
+is a quick no-op for an already-reachable issuer (e.g. an external IdP). It is
+deliberately a CI-only composite action — the customer-facing reference
+procedures stay free of this environment-specific workaround.
+
+
+## Inputs
+
+| name | description | required | default |
+| --- | --- | --- | --- |
+| `issuer-url` | <p>OIDC issuer base URL. The discovery document polled is <code>&lt;issuer-url&gt;/.well-known/openid-configuration</code>.</p> | `true` | `""` |
+| `namespace` | <p>Kubernetes namespace of the deployed release.</p> | `false` | `camunda` |
+| `release-name` | <p>Helm release name, used to target the workloads to bounce (<code>statefulset/&lt;release&gt;-zeebe</code>, <code>deployment/&lt;release&gt;-connectors</code>).</p> | `false` | `camunda` |
+| `insecure` | <p>Set to 'true' to skip TLS verification of the issuer (e.g. when the public endpoint uses a CI internal-CA / Vault wildcard certificate).</p> | `false` | `""` |
+| `timeout-seconds` | <p>Total wall-clock budget in seconds. Fail-open: on timeout the action emits a warning and exits 0 so it never blocks the pipeline.</p> | `false` | `600` |
+
+
+## Runs
+
+This action is a `composite` action.
+
+## Usage
+
+```yaml
+- uses: camunda/camunda-deployment-references/.github/actions/internal-wait-oidc-issuer@main
+  with:
+    issuer-url:
+    # OIDC issuer base URL. The discovery document polled is
+    # `<issuer-url>/.well-known/openid-configuration`.
+    #
+    # Required: true
+    # Default: ""
+
+    namespace:
+    # Kubernetes namespace of the deployed release.
+    #
+    # Required: false
+    # Default: camunda
+
+    release-name:
+    # Helm release name, used to target the workloads to bounce
+    # (`statefulset/<release>-zeebe`, `deployment/<release>-connectors`).
+    #
+    # Required: false
+    # Default: camunda
+
+    insecure:
+    # Set to 'true' to skip TLS verification of the issuer (e.g. when the
+    # public endpoint uses a CI internal-CA / Vault wildcard certificate).
+    #
+    # Required: false
+    # Default: ""
+
+    timeout-seconds:
+    # Total wall-clock budget in seconds. Fail-open: on timeout the action
+    # emits a warning and exits 0 so it never blocks the pipeline.
+    #
+    # Required: false
+    # Default: 600
+```

--- a/.github/actions/internal-wait-oidc-issuer/README.md
+++ b/.github/actions/internal-wait-oidc-issuer/README.md
@@ -17,9 +17,10 @@ answer `200`, then bounces the affected workloads so they restart immediately
 instead of after the next backoff window.
 
 It is **IdP-agnostic**: it polls whatever `issuer-url` the caller provides and
-is a quick no-op for an already-reachable issuer (e.g. an external IdP). It is
-deliberately a CI-only composite action — the customer-facing reference
-procedures stay free of this environment-specific workaround.
+completes quickly (no waiting) when the issuer is already reachable, e.g. an
+external IdP. It is deliberately a CI-only composite action — the
+customer-facing reference procedures stay free of this environment-specific
+workaround.
 
 
 ## Inputs

--- a/.github/actions/internal-wait-oidc-issuer/action.yml
+++ b/.github/actions/internal-wait-oidc-issuer/action.yml
@@ -16,9 +16,10 @@ description: |
     instead of after the next backoff window.
 
     It is **IdP-agnostic**: it polls whatever `issuer-url` the caller provides and
-    is a quick no-op for an already-reachable issuer (e.g. an external IdP). It is
-    deliberately a CI-only composite action — the customer-facing reference
-    procedures stay free of this environment-specific workaround.
+    completes quickly (no waiting) when the issuer is already reachable, e.g. an
+    external IdP. It is deliberately a CI-only composite action — the
+    customer-facing reference procedures stay free of this environment-specific
+    workaround.
 
 inputs:
     issuer-url:

--- a/.github/actions/internal-wait-oidc-issuer/action.yml
+++ b/.github/actions/internal-wait-oidc-issuer/action.yml
@@ -103,10 +103,15 @@ runs:
                       # (missing kubeconfig / RBAC) stay visible; '|| true' keeps
                       # the bounce best-effort (fail-open).
                       for workload in "statefulset/${RELEASE_NAME}-zeebe" "deployment/${RELEASE_NAME}-connectors"; do
-                          if kubectl -n "${NAMESPACE}" get "${workload}" >/dev/null 2>&1; then
+                          # --ignore-not-found keeps a genuine "absent" quiet
+                          # (empty + exit 0) while real failures (no kubeconfig /
+                          # RBAC) exit non-zero and surface as a warning.
+                          if ! found=$(kubectl -n "${NAMESPACE}" get "${workload}" --ignore-not-found -o name 2>&1); then
+                              echo "::warning::Could not query ${workload}: ${found}"
+                          elif [ -n "${found}" ]; then
                               kubectl -n "${NAMESPACE}" rollout restart "${workload}" || true
                           else
-                              echo "Skipping ${workload}: not found in namespace ${NAMESPACE}."
+                              echo "Skipping ${workload}: not present in namespace ${NAMESPACE}."
                           fi
                       done
                       exit 0

--- a/.github/actions/internal-wait-oidc-issuer/action.yml
+++ b/.github/actions/internal-wait-oidc-issuer/action.yml
@@ -1,0 +1,104 @@
+---
+name: Wait for the OIDC issuer to be reachable
+description: |
+    CI-only helper for domain / TLS test runs.
+
+    In domain mode the Camunda app pods (orchestration / Zeebe and Connectors)
+    fetch the OIDC discovery document from the configured issuer at startup. On a
+    freshly provisioned cluster that issuer only converges minutes after
+    `helm install` — DNS, the TLS certificate and the ingress have to settle, and
+    a self-hosted IdP also has to provision its realm — during which the app pods
+    `CrashLoopBackOff`. Their exponential restart backoff can outlast the
+    readiness window, so the deployment can look broken for a while.
+
+    This action waits (bounded, fail-open) for the issuer's discovery document to
+    answer `200`, then bounces the affected workloads so they restart immediately
+    instead of after the next backoff window.
+
+    It is **IdP-agnostic**: it polls whatever `issuer-url` the caller provides and
+    is a quick no-op for an already-reachable issuer (e.g. an external IdP). It is
+    deliberately a CI-only composite action — the customer-facing reference
+    procedures stay free of this environment-specific workaround.
+
+inputs:
+    issuer-url:
+        description: |
+            OIDC issuer base URL. The discovery document polled is
+            `<issuer-url>/.well-known/openid-configuration`.
+        required: true
+    namespace:
+        description: Kubernetes namespace of the deployed release.
+        required: false
+        default: camunda
+    release-name:
+        description: |
+            Helm release name, used to target the workloads to bounce
+            (`statefulset/<release>-zeebe`, `deployment/<release>-connectors`).
+        required: false
+        default: camunda
+    insecure:
+        description: |
+            Set to 'true' to skip TLS verification of the issuer (e.g. when the
+            public endpoint uses a CI internal-CA / Vault wildcard certificate).
+        required: false
+        default: ''
+    timeout-seconds:
+        description: |
+            Total wall-clock budget in seconds. Fail-open: on timeout the action
+            emits a warning and exits 0 so it never blocks the pipeline.
+        required: false
+        default: '600'
+
+runs:
+    using: composite
+    steps:
+        - name: ⏳ Wait for the OIDC issuer, then bounce crash-looping workloads
+          shell: bash
+          env:
+              ISSUER_URL: ${{ inputs.issuer-url }}
+              NAMESPACE: ${{ inputs.namespace }}
+              RELEASE_NAME: ${{ inputs.release-name }}
+              INSECURE: ${{ inputs.insecure }}
+              TIMEOUT_SECONDS: ${{ inputs.timeout-seconds }}
+          run: |
+              set -uo pipefail
+
+              if [ -z "${ISSUER_URL}" ]; then
+                  echo "::warning::No issuer-url provided; skipping OIDC issuer wait."
+                  exit 0
+              fi
+
+              discovery="${ISSUER_URL%/}/.well-known/openid-configuration"
+
+              curl_opts=(--silent --output /dev/null --max-time 5)
+              if [ "${INSECURE}" = "true" ]; then
+                  curl_opts+=(--insecure)
+              fi
+
+              echo "Waiting up to ${TIMEOUT_SECONDS}s for the OIDC discovery document: ${discovery}"
+              deadline=$(( $(date +%s) + TIMEOUT_SECONDS ))
+              attempt=0
+              while :; do
+                  attempt=$(( attempt + 1 ))
+                  code=$(curl "${curl_opts[@]}" -w '%{http_code}' "${discovery}" 2>/dev/null || echo "000")
+
+                  if [ "${code}" = "200" ]; then
+                      echo "✅ OIDC issuer reachable (HTTP 200) after ${attempt} attempt(s)."
+                      # Clear any first-start CrashLoopBackOff so the app pods
+                      # restart now instead of after the next (long) backoff window.
+                      # '|| true' keeps this best-effort across chart versions /
+                      # disabled components.
+                      kubectl -n "${NAMESPACE}" rollout restart \
+                          "statefulset/${RELEASE_NAME}-zeebe" \
+                          "deployment/${RELEASE_NAME}-connectors" 2>/dev/null || true
+                      exit 0
+                  fi
+
+                  if [ "$(date +%s)" -ge "${deadline}" ]; then
+                      echo "::warning::OIDC issuer ${discovery} did not return 200 within ${TIMEOUT_SECONDS}s; continuing anyway."
+                      exit 0
+                  fi
+
+                  echo "[attempt ${attempt}] not ready yet (HTTP ${code}); retrying in 5s..."
+                  sleep 5
+              done

--- a/.github/actions/internal-wait-oidc-issuer/action.yml
+++ b/.github/actions/internal-wait-oidc-issuer/action.yml
@@ -97,12 +97,18 @@ runs:
                   if [ "${code}" = "200" ]; then
                       echo "✅ OIDC issuer reachable (HTTP 200) after ${attempt} attempt(s)."
                       # Clear any first-start CrashLoopBackOff so the app pods
-                      # restart now instead of after the next (long) backoff window.
-                      # '|| true' keeps this best-effort across chart versions /
-                      # disabled components.
-                      kubectl -n "${NAMESPACE}" rollout restart \
-                          "statefulset/${RELEASE_NAME}-zeebe" \
-                          "deployment/${RELEASE_NAME}-connectors" 2>/dev/null || true
+                      # restart now instead of after the next (long) backoff
+                      # window. Bounce each workload only if it exists, so a
+                      # disabled/renamed component stays quiet while real errors
+                      # (missing kubeconfig / RBAC) stay visible; '|| true' keeps
+                      # the bounce best-effort (fail-open).
+                      for workload in "statefulset/${RELEASE_NAME}-zeebe" "deployment/${RELEASE_NAME}-connectors"; do
+                          if kubectl -n "${NAMESPACE}" get "${workload}" >/dev/null 2>&1; then
+                              kubectl -n "${NAMESPACE}" rollout restart "${workload}" || true
+                          else
+                              echo "Skipping ${workload}: not found in namespace ${NAMESPACE}."
+                          fi
+                      done
                       exit 0
                   fi
 

--- a/.github/actions/internal-wait-oidc-issuer/action.yml
+++ b/.github/actions/internal-wait-oidc-issuer/action.yml
@@ -75,6 +75,17 @@ runs:
                   curl_opts+=(--insecure)
               fi
 
+              # Fail-open safety: coerce timeout-seconds to a positive base-10
+              # integer so the deadline arithmetic can never error out on an
+              # empty / non-numeric / leading-zero (octal) value.
+              if [[ "${TIMEOUT_SECONDS}" =~ ^[0-9]+$ ]]; then
+                  TIMEOUT_SECONDS=$(( 10#${TIMEOUT_SECONDS} ))
+              fi
+              if ! [[ "${TIMEOUT_SECONDS}" =~ ^[1-9][0-9]*$ ]]; then
+                  echo "::warning::Invalid timeout-seconds value; falling back to 600s."
+                  TIMEOUT_SECONDS=600
+              fi
+
               echo "Waiting up to ${TIMEOUT_SECONDS}s for the OIDC discovery document: ${discovery}"
               deadline=$(( $(date +%s) + TIMEOUT_SECONDS ))
               attempt=0

--- a/.github/workflows/aws_kubernetes_eks_single_region_tests.yml
+++ b/.github/workflows/aws_kubernetes_eks_single_region_tests.yml
@@ -715,7 +715,7 @@ jobs:
                   issuer-url: https://${{ env.DOMAIN_NAME }}/auth/realms/camunda-platform
                   namespace: ${{ env.CAMUNDA_NAMESPACE }}
                   release-name: ${{ env.CAMUNDA_RELEASE_NAME }}
-                  insecure: ${{ steps.cert-config.outputs.use-wildcard-cert == 'true' && 'true' || '' }}
+                  insecure: ${{ steps.cert-config.outputs.use-wildcard-cert }}
 
             - name: 👀⏳ Wait for the deployment to be healthy using generic/kubernetes/single-region
               timeout-minutes: 20

--- a/.github/workflows/aws_kubernetes_eks_single_region_tests.yml
+++ b/.github/workflows/aws_kubernetes_eks_single_region_tests.yml
@@ -708,6 +708,15 @@ jobs:
 
                   ./generic/kubernetes/single-region/procedure/install-chart.sh
 
+            - name: ⏳ Wait for the OIDC issuer to be reachable
+              if: matrix.declination.name == 'domain'
+              uses: ./.github/actions/internal-wait-oidc-issuer
+              with:
+                  issuer-url: https://${{ env.DOMAIN_NAME }}/auth/realms/camunda-platform
+                  namespace: ${{ env.CAMUNDA_NAMESPACE }}
+                  release-name: ${{ env.CAMUNDA_RELEASE_NAME }}
+                  insecure: ${{ steps.cert-config.outputs.use-wildcard-cert == 'true' && 'true' || '' }}
+
             - name: 👀⏳ Wait for the deployment to be healthy using generic/kubernetes/single-region
               timeout-minutes: 20
               run: |

--- a/.github/workflows/aws_openshift_rosa_hcp_single_region_tests.yml
+++ b/.github/workflows/aws_openshift_rosa_hcp_single_region_tests.yml
@@ -522,6 +522,15 @@ jobs:
 
                   ./generic/openshift/single-region/procedure/install-chart.sh
 
+            - name: ⏳ Wait for the OIDC issuer to be reachable
+              if: matrix.declination.name == 'domain'
+              uses: ./.github/actions/internal-wait-oidc-issuer
+              with:
+                  issuer-url: https://${{ env.CAMUNDA_DOMAIN }}/auth/realms/camunda-platform
+                  namespace: ${{ env.CAMUNDA_NAMESPACE }}
+                  release-name: ${{ env.CAMUNDA_RELEASE_NAME }}
+                  insecure: 'true'
+
             - name: 👀⏳ Wait for the deployment to be healthy using generic/kubernetes/single-region
               timeout-minutes: 20
               run: |

--- a/.github/workflows/azure_kubernetes_aks_single_region_tests.yml
+++ b/.github/workflows/azure_kubernetes_aks_single_region_tests.yml
@@ -638,7 +638,7 @@ jobs:
                   issuer-url: https://${{ env.DOMAIN_NAME }}/auth/realms/camunda-platform
                   namespace: ${{ env.CAMUNDA_NAMESPACE }}
                   release-name: ${{ env.CAMUNDA_RELEASE_NAME }}
-                  insecure: ${{ steps.cert-config.outputs.use-wildcard-cert == 'true' && 'true' || '' }}
+                  insecure: ${{ steps.cert-config.outputs.use-wildcard-cert }}
 
             - name: 👀⏳ Wait for the deployment to be healthy using generic/kubernetes/single-region
               timeout-minutes: 20

--- a/.github/workflows/azure_kubernetes_aks_single_region_tests.yml
+++ b/.github/workflows/azure_kubernetes_aks_single_region_tests.yml
@@ -631,6 +631,15 @@ jobs:
 
                   ./generic/kubernetes/single-region/procedure/install-chart.sh
 
+            - name: ⏳ Wait for the OIDC issuer to be reachable
+              if: matrix.declination.name == 'domain'
+              uses: ./.github/actions/internal-wait-oidc-issuer
+              with:
+                  issuer-url: https://${{ env.DOMAIN_NAME }}/auth/realms/camunda-platform
+                  namespace: ${{ env.CAMUNDA_NAMESPACE }}
+                  release-name: ${{ env.CAMUNDA_RELEASE_NAME }}
+                  insecure: ${{ steps.cert-config.outputs.use-wildcard-cert == 'true' && 'true' || '' }}
+
             - name: 👀⏳ Wait for the deployment to be healthy using generic/kubernetes/single-region
               timeout-minutes: 20
               run: |


### PR DESCRIPTION
Backport of #2741 to `stable/8.8` (decoupled — no #2718 dependency). Adds the CI-only, IdP-agnostic `internal-wait-oidc-issuer` action and gates it on EKS/AKS/ROSA single-region **domain** tests, before the health check.

8.8 has no inline Keycloak step, so the action is **added** on all three (not replacing). Domain wiring adapted per workflow: EKS/AKS poll `${{ env.DOMAIN_NAME }}`, ROSA polls `${{ env.CAMUNDA_DOMAIN }}`; `insecure` keyed off cert-config (EKS/AKS) / `'true'` (ROSA). The action README is byte-identical to #2741/#2742.

Validated locally: yamllint (repo config) + actionlint 1.7.12 (`-ignore=SC2155`, same as CI) clean.