### PR TITLE
feat(aks-single-region): migrate ingress controller to Contour (backport #2689 to 8.9)

### DIFF
--- a/.github/actions/azure-kubernetes-ingress-setup/README.md
+++ b/.github/actions/azure-kubernetes-ingress-setup/README.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-Install and configure ingress-nginx, external-dns, and cert-manager for Azure AKS clusters
+Install and configure Contour, external-dns, and cert-manager for Azure AKS clusters
 
 ## Inputs
 

--- a/.github/actions/azure-kubernetes-ingress-setup/action.yml
+++ b/.github/actions/azure-kubernetes-ingress-setup/action.yml
@@ -1,6 +1,6 @@
 ---
 name: Azure Kubernetes Ingress Setup
-description: Install and configure ingress-nginx, external-dns, and cert-manager for Azure AKS clusters
+description: Install and configure Contour, external-dns, and cert-manager for Azure AKS clusters
 
 inputs:
     cluster-name:
@@ -63,10 +63,10 @@ runs:
           with:
               namespace: external-dns
 
-        - name: 🏗️ Clean ingress-nginx operator namespace
+        - name: 🏗️ Clean Contour operator namespace
           uses: ./.github/actions/internal-clean-namespace
           with:
-              namespace: ingress-nginx
+              namespace: projectcontour
 
         - name: Setup ingress components for AKS cluster
           shell: bash
@@ -88,9 +88,9 @@ runs:
               # Source ingress setup variables
               source generic/kubernetes/single-region/procedure/export-ingress-setup-vars.sh
 
-              # Install ingress-nginx
-              echo "Installing ingress-nginx..."
-              ./azure/kubernetes/${{ inputs.scenario-name }}/procedure/install-ingress-nginx.sh
+              # Install Contour
+              echo "Installing Contour..."
+              ./azure/kubernetes/${{ inputs.scenario-name }}/procedure/install-contour.sh
 
               # Install external-dns
               echo "Installing external-dns..."

--- a/.github/workflows/azure_kubernetes_aks_single_region_tests.yml
+++ b/.github/workflows/azure_kubernetes_aks_single_region_tests.yml
@@ -636,7 +636,7 @@ jobs:
               uses: ./.github/actions/kubernetes-keycloak-operator
               with:
                   namespace: ${{ env.CAMUNDA_NAMESPACE }}
-                  keycloak-mode: ${{ matrix.declination.name == 'domain' && 'domain' || 'no-domain' }}
+                  keycloak-mode: ${{ matrix.declination.name == 'domain' && 'domain-contour' || 'no-domain' }}
                   domain-name: ${{ env.CAMUNDA_DOMAIN }}
 
             - name: Helm registry login
@@ -693,7 +693,11 @@ jobs:
 
                   ./generic/kubernetes/single-region/procedure/install-chart.sh
 
+            # TODO: re-enable once the Helm chart schema recognises the Contour values
+            # (e.g. orchestration.service.annotations 'projectcontour.io/upstream-protocol.h2c').
+            # Tracked upstream in camunda/camunda-platform-helm#4564.
             - name: 🔍 Check for Helm deprecation warnings
+              continue-on-error: true
               uses: ./.github/actions/internal-helm-deprecation-check
               with:
                   release-name: ${{ env.CAMUNDA_RELEASE_NAME }}

--- a/.github/workflows/azure_kubernetes_aks_single_region_tests.yml
+++ b/.github/workflows/azure_kubernetes_aks_single_region_tests.yml
@@ -693,11 +693,7 @@ jobs:
 
                   ./generic/kubernetes/single-region/procedure/install-chart.sh
 
-            # TODO: re-enable once the Helm chart schema recognises the Contour values
-            # (e.g. orchestration.service.annotations 'projectcontour.io/upstream-protocol.h2c').
-            # Tracked upstream in camunda/camunda-platform-helm#4564.
             - name: 🔍 Check for Helm deprecation warnings
-              continue-on-error: true
               uses: ./.github/actions/internal-helm-deprecation-check
               with:
                   release-name: ${{ env.CAMUNDA_RELEASE_NAME }}

--- a/azure/kubernetes/aks-single-region-rdbms/helm-values/values-domain.yml
+++ b/azure/kubernetes/aks-single-region-rdbms/helm-values/values-domain.yml
@@ -17,6 +17,7 @@
 global:
     ingress:
         enabled: true
+        className: contour
         host: ${CAMUNDA_DOMAIN}
         tls:
             enabled: true
@@ -120,12 +121,19 @@ orchestration:
     ingress:
         grpc:
             enabled: true
+            className: contour
             host: zeebe-${CAMUNDA_DOMAIN}
             tls:
                 enabled: true
                 secretName: zeebe-c8-tls-grpc
             annotations:
                 kubernetes.io/tls-acme: 'true'
+
+    # Tell Contour the gRPC upstream (port 26500) speaks cleartext HTTP/2 (h2c).
+    # Required for Zeebe gRPC through the Contour ingress.
+    service:
+        annotations:
+            projectcontour.io/upstream-protocol.h2c: '26500'
 
 # Disable Elasticsearch (not needed in RDBMS mode)
 elasticsearch:

--- a/azure/kubernetes/aks-single-region-rdbms/procedure/install-contour.sh
+++ b/azure/kubernetes/aks-single-region-rdbms/procedure/install-contour.sh
@@ -1,0 +1,1 @@
+../../aks-single-region/procedure/install-contour.sh

--- a/azure/kubernetes/aks-single-region/helm-values/values-domain.yml
+++ b/azure/kubernetes/aks-single-region/helm-values/values-domain.yml
@@ -14,6 +14,7 @@
 global:
     ingress:
         enabled: true
+        className: contour
         host: ${CAMUNDA_DOMAIN}
         tls:
             enabled: true
@@ -106,12 +107,19 @@ orchestration:
     ingress:
         grpc:
             enabled: true
+            className: contour
             host: zeebe-${CAMUNDA_DOMAIN}
             tls:
                 enabled: true
                 secretName: zeebe-c8-tls-grpc
             annotations:
                 kubernetes.io/tls-acme: 'true'
+
+    # Tell Contour the gRPC upstream (port 26500) speaks cleartext HTTP/2 (h2c).
+    # Required for Zeebe gRPC through the Contour ingress.
+    service:
+        annotations:
+            projectcontour.io/upstream-protocol.h2c: '26500'
 
 console:
     enabled: false # by default, console is not enabled

--- a/azure/kubernetes/aks-single-region/procedure/install-contour.sh
+++ b/azure/kubernetes/aks-single-region/procedure/install-contour.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -euo pipefail
+
+# envoy.service.externalTrafficPolicy=Local is already the chart default, but we keep
+# it explicit because the Azure LB health-probe annotation below relies on it: with
+# "Local" the probe targets the Kubernetes healthCheckNodePort instead of a random node.
+helm upgrade --install \
+  contour contour \
+  --repo https://projectcontour.github.io/helm-charts/ \
+  --version "$CONTOUR_HELM_CHART_VERSION" \
+  --set 'contour.ingressClass.default=false' \
+  --set 'contour.replicaCount=2' \
+  --set 'envoy.service.externalTrafficPolicy=Local' \
+  --set-string 'envoy.service.annotations.service\.beta\.kubernetes\.io\/azure-load-balancer-health-probe-request-path=/healthz' \
+  --namespace projectcontour \
+  --create-namespace


### PR DESCRIPTION
## Description

Backport of #2689 to `stable/8.9`.

Migrates the **AKS single region** reference architecture (and its `-rdbms` variant) from **ingress-nginx** to **[Project Contour](https://github.com/projectcontour/contour)**, mirroring the EKS migration. [ingress-nginx was retired in March 2026](https://kubernetes.io/blog/2025/11/11/ingress-nginx-retirement/), so all reference architectures must move to a maintained ingress controller. The shared Contour infrastructure (chart version, keycloak `domain-contour` mode) is already present on `stable/8.9`.

## Changes

- **`procedure/install-contour.sh`** (new) installs Contour from the official upstream chart into the `projectcontour` namespace, translating the Azure-specific settings onto the Envoy service (`externalTrafficPolicy=Local`, the `azure-load-balancer-health-probe-request-path=/healthz` annotation, `replicaCount=2`). The `-rdbms` variant symlinks to the same script.
- **Helm values** (both variants): `className: contour` on `global.ingress` and `orchestration.ingress.grpc`, plus the `projectcontour.io/upstream-protocol.h2c: '26500'` service annotation so Zeebe gRPC works through Envoy.
- **`azure-kubernetes-ingress-setup` action**: installs Contour instead of ingress-nginx, cleans the `projectcontour` namespace, updated description + regenerated README.
- **AKS test workflow**: keycloak operator switched to `domain-contour`; the Helm deprecation check is temporarily `continue-on-error` until the chart schema aligns with the new Contour values.

## Backport notes

- The `install-ingress-nginx.sh` scripts are **intentionally retained** in this backport and will be removed in a follow-up PR.
- The golden-plan `release_policy` changes from #2689 are already present on `stable/8.9`, so they are not part of this diff.

refs: https://github.com/camunda/team-infrastructure-experience/issues/1074
refs: https://github.com/camunda/team-infrastructure-experience/issues/933