### PR TITLE
fix(ci): skip golden regen for modules without golden.tfvars

### DIFF
--- a/justfile
+++ b/justfile
@@ -163,6 +163,8 @@ regenerate-golden-file-all:
     # regeneration by providing test/golden/golden.tfvars; modules without it
     # (e.g. freshly added ones, or cross-state modules that cannot be planned
     # standalone) are skipped instead of failing the whole run.
+    # ECS dual-region modules currently lack golden coverage, tracked in:
+    # https://github.com/camunda/team-infrastructure-experience/issues/1158
     if [[ ! -f "${module_dir_abs}/test/golden/golden.tfvars" ]]; then
       echo "Skipping: ${module_dir_rel} (no test/golden/golden.tfvars)"
       continue

--- a/justfile
+++ b/justfile
@@ -159,6 +159,15 @@ regenerate-golden-file-all:
       continue
     fi
 
+    # Skip modules that are not golden-tracked. A module opts in to golden
+    # regeneration by providing test/golden/golden.tfvars; modules without it
+    # (e.g. freshly added ones, or cross-state modules that cannot be planned
+    # standalone) are skipped instead of failing the whole run.
+    if [[ ! -f "${module_dir_abs}/test/golden/golden.tfvars" ]]; then
+      echo "Skipping: ${module_dir_rel} (no test/golden/golden.tfvars)"
+      continue
+    fi
+
     backend_key="golden.tfstate"
 
     echo "[${count}] Regenerating golden for: ${module_dir_rel}"


### PR DESCRIPTION
## Problem

The scheduled maintenance job (`just regenerate-golden-file-all`) is [failing on main](https://github.com/camunda/camunda-deployment-references/actions/runs/27832898070/job/82373798348).

`regenerate-golden-file-all` discovers **every** `config.tf` and assumes a `test/golden/golden.tfvars` exists, running `terraform plan -var-file=test/golden/golden.tfvars` against it.

The newly merged ECS dual-region modules (#2277) ship **without** golden setup:

- `aws/containers/ecs-dual-region-fargate/terraform/{vpc,infra,app}` have no `test/golden/golden.tfvars`
- `app`/`infra` additionally read sibling `terraform_remote_state`, so they cannot be planned standalone (same constraint as `peering`)

The loop hit `app` first and exited 1:

```
Error: Failed to read variables file
  Given variables file test/golden/golden.tfvars does not exist.
Error: Unable to find remote state
```

(The failing run was on a Renovate branch, but the breakage is pre-existing on `main` — unrelated to the dependency bump.)

## Fix

Treat `test/golden/golden.tfvars` as the **opt-in marker** for golden tracking. Modules lacking it are skipped (with a log line) instead of failing the whole run.

- All existing tracked modules already provide `golden.tfvars` → behavior unchanged for them.
- `peering` stays excluded via the existing `IGNORE_WORDS` mechanism (it has `golden.tfvars` but is cross-state).
- New modules added without golden support no longer break the maintenance job.

## Verification

Simulated discovery locally:

```
SKIP(no-tfvars)       aws/containers/ecs-dual-region-fargate/terraform/app
SKIP(no-tfvars)       aws/containers/ecs-dual-region-fargate/terraform/infra
SKIP(no-tfvars)       aws/containers/ecs-dual-region-fargate/terraform/vpc
SKIP(ignore:peering)  aws/openshift/rosa-hcp-dual-region/terraform/peering
PLAN ...              (13 previously-working modules, unchanged)
```

## Follow-up

Wiring real golden support for the ECS dual-region modules (at least the plannable `vpc`) can be done separately.