### PR TITLE
chore(ecs-dual-region): bump Camunda images to 8.10.0-alpha1

### DIFF
--- a/aws/containers/ecs-dual-region-fargate/terraform/app/README.md
+++ b/aws/containers/ecs-dual-region-fargate/terraform/app/README.md
@@ -21,8 +21,8 @@
 | Name | Description | Type | Default | Required |
 | ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_aws_profile"></a> [aws\_profile](#input\_aws\_profile) | AWS Profile to use (null = use default credential chain) | `string` | `null` | no |
-| <a name="input_camunda_image"></a> [camunda\_image](#input\_camunda\_image) | Container image for the Camunda orchestration cluster tasks (Zeebe broker + gateway + webapps) | `string` | `"camunda/camunda:8.10-SNAPSHOT"` | no |
-| <a name="input_connectors_image"></a> [connectors\_image](#input\_connectors\_image) | Container image for the Camunda connectors-bundle tasks. Separate from camunda\_image because connectors ship as a distinct artifact from the orchestration cluster. | `string` | `"camunda/connectors-bundle:8.10-SNAPSHOT"` | no |
+| <a name="input_camunda_image"></a> [camunda\_image](#input\_camunda\_image) | Container image for the Camunda orchestration cluster tasks (Zeebe broker + gateway + webapps) | `string` | `"camunda/camunda:8.10.0-alpha1"` | no |
+| <a name="input_connectors_image"></a> [connectors\_image](#input\_connectors\_image) | Container image for the Camunda connectors-bundle tasks. Separate from camunda\_image because connectors ship as a distinct artifact from the orchestration cluster. | `string` | `"camunda/connectors-bundle:8.10.0-alpha1"` | no |
 | <a name="input_default_tags"></a> [default\_tags](#input\_default\_tags) | Default tags to apply to all resources | `map(string)` | `{}` | no |
 | <a name="input_infra_state_path"></a> [infra\_state\_path](#input\_infra\_state\_path) | Path to the infra terraform state file (local backend) or S3 key | `string` | `"../infra/terraform.tfstate"` | no |
 ## Outputs

--- a/aws/containers/ecs-dual-region-fargate/terraform/app/variables.tf
+++ b/aws/containers/ecs-dual-region-fargate/terraform/app/variables.tf
@@ -26,12 +26,12 @@ variable "default_tags" {
 
 variable "camunda_image" {
   type        = string
-  default     = "camunda/camunda:8.10-SNAPSHOT"
+  default     = "camunda/camunda:8.10.0-alpha1"
   description = "Container image for the Camunda orchestration cluster tasks (Zeebe broker + gateway + webapps)"
 }
 
 variable "connectors_image" {
   type        = string
-  default     = "camunda/connectors-bundle:8.10-SNAPSHOT"
+  default     = "camunda/connectors-bundle:8.10.0-alpha1"
   description = "Container image for the Camunda connectors-bundle tasks. Separate from camunda_image because connectors ship as a distinct artifact from the orchestration cluster."
 }


### PR DESCRIPTION
## What

The `8.10.0-alpha1` images are now published on Docker Hub, so the ECS dual-region `app` module no longer needs the `SNAPSHOT` tags (flagged by the alpha-availability check / InfEx Slack notification).

```
camunda/camunda:8.10-SNAPSHOT             -> camunda/camunda:8.10.0-alpha1
camunda/connectors-bundle:8.10-SNAPSHOT   -> camunda/connectors-bundle:8.10.0-alpha1
```

## Scope

These two `app/variables.tf` defaults were the **only** `org/image:<version>-SNAPSHOT` references in the repo (confirmed with the same pattern `internal_global_alpha_availability_check` uses, across `*.tf/*.sh/*.yml/*.yaml/*.tfvars`). `README.md` regenerated via terraform-docs.

The EC2 / Debian all-in-one `8.10.0-SNAPSHOT` references are **distribution tarballs**, not container images — they are not flagged by the check and intentionally stay on `SNAPSHOT` until 8.10 GA (see their `[release-duty]` TODOs).

## Verification

- `rg` for `org/image:<ver>-SNAPSHOT` under the module: none remaining.
- pre-commit: `terraform_fmt`, `tflint`, `terraform_docs` pass (trivy / terraform-test skipped locally — no Docker daemon / bash 3.2; run in CI).