### PR TITLE
[READY] feat(bitnami): publish vendor-ee image tags artifact

### DIFF
--- a/.github/workflows/internal_bitnami_artifact_image_versions.yml
+++ b/.github/workflows/internal_bitnami_artifact_image_versions.yml
@@ -10,16 +10,16 @@
 # before the November 2025 vendor migration.
 #
 # It is consumed by:
-#   - renovate (per-image plain .txt lists, via custom datasources in
-#     camunda/infraex-common-config)
-#   - customers / field engineering (human-readable Markdown + machine JSON,
-#     each tag annotated with its image digest)
+#   - renovate, as a custom datasource (format: json) per image: each release
+#     carries the version and its image digest (newDigest) for optional pinning.
+#     Used by camunda/infraex-common-config, camunda/keycloak-aws and
+#     camunda/camunda-platform-helm.
+#   - customers / field engineering, to see which tags exist without skopeo/Harbor.
 #
-# Published at:
-#   https://camunda.github.io/camunda-deployment-references/bitnami_<image>_versions.txt
-#   https://camunda.github.io/camunda-deployment-references/bitnami_<image>_digests.txt
-#   https://camunda.github.io/camunda-deployment-references/available_images.json
-#   https://camunda.github.io/camunda-deployment-references/available_images.md
+# Published at (one file per image):
+#   https://camunda.github.io/camunda-deployment-references/bitnami_<image>.json
+# Browse them at:
+#   https://github.com/camunda/camunda-deployment-references/tree/gh-pages/docs
 name: Internal - Bitnami - Save vendor-ee image tags as an artifact
 
 on:
@@ -115,7 +115,6 @@ jobs:
                   set -euo pipefail
 
                   mkdir -p docs
-                  generated_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
                   registry="${REGISTRY_HOST}/${REGISTRY_REPO_PREFIX}"
                   read -r -a images <<< "${IMAGES}"
 
@@ -127,7 +126,6 @@ jobs:
                   printf '%s' "${REGISTRY_PASSWORD}" \
                     | crane auth login "${REGISTRY_HOST}" --username "${REGISTRY_USERNAME}" --password-stdin
 
-                  images_json='{}'
                   for img in "${images[@]}"; do
                     ref="${registry}/${img}"
                     echo "Listing tags for ${img} (${ref})..."
@@ -150,65 +148,37 @@ jobs:
                       exit 1
                     fi
 
-                    # Plain version list (one tag per line) — the Renovate source.
-                    printf '%s\n' "${tags[@]}" > "docs/bitnami_${img}_versions.txt"
-
                     # Resolve every tag to its image digest, in parallel. A failed
                     # 'crane digest' aborts the whole pipeline (set -e + pipefail), so a
                     # registry hiccup can never silently yield a partial/empty list.
                     # shellcheck disable=SC2016 # $1/$2 are positional args of the inner sh, not outer expansions
                     printf '%s\n' "${tags[@]}" \
                       | xargs -P 8 -I {} sh -c 'd="$(crane digest "${1}:${2}")" || exit 1; printf "%s %s\n" "${2}" "${d}"' _ "${ref}" {} \
-                      | sort -V > "docs/bitnami_${img}_digests.txt"
+                      | sort -V > /tmp/ver_dig
 
                     # Defensive: every tag must have produced exactly one digest line.
-                    dig_lines="$(wc -l < "docs/bitnami_${img}_digests.txt")"
+                    dig_lines="$(wc -l < /tmp/ver_dig)"
                     if [ "${dig_lines}" -ne "${#tags[@]}" ]; then
                       echo "ERROR: digest resolution incomplete for ${img}: ${#tags[@]} tags but ${dig_lines} digests." >&2
                       exit 1
                     fi
 
-                    # Accumulate the combined JSON: tags = [{version, digest}].
-                    tags_json="$(jq -Rn '[inputs | split(" ") | {version: .[0], digest: .[1]}]' "docs/bitnami_${img}_digests.txt")"
-                    images_json="$(jq -c \
-                      --arg img "${img}" \
+                    # One self-contained file per image, directly consumable as a Renovate
+                    # custom datasource (format: json): each release carries the version and
+                    # its image digest (newDigest) for optional digest pinning. No timestamp
+                    # is stored, so the file changes only when the tags/digests change (the
+                    # gh-pages commit date conveys freshness).
+                    jq -Rn \
+                      --arg name "${img}" \
                       --arg repo "${ref}" \
-                      --argjson tags "${tags_json}" \
-                      '. + {($img): {repository: $repo, tags: $tags}}' <<< "${images_json}")"
+                      '{name: $name, repository: $repo,
+                        releases: [inputs | split(" ") | {version: .[0], newDigest: .[1]}]}' \
+                      /tmp/ver_dig > "docs/bitnami_${img}.json"
                   done
 
-                  jq -n \
-                    --arg ts "${generated_at}" \
-                    --arg reg "${registry}" \
-                    --argjson imgs "${images_json}" \
-                    '{generated_at: $ts, source: "Broadcom / VMware Tanzu Application Catalog (upstream)", registry: $reg, images: $imgs}' \
-                    > docs/available_images.json
-
-                  {
-                    echo "# Available Bitnami Premium (vendor-ee) image tags"
-                    echo
-                    echo "_Last updated: ${generated_at}._"
-                    echo
-                    echo "Source of truth: **upstream Broadcom / VMware Tanzu Application Catalog**."
-                    echo "These are the tags available behind \`registry.camunda.cloud/vendor-ee/<image>\`."
-                    echo
-                    echo "> The Harbor UI must **not** be used to browse these images: it only shows the"
-                    echo "> cached subset, not the full upstream catalog."
-                    echo
-                    for img in "${images[@]}"; do
-                      echo "## vendor-ee/${img}"
-                      echo
-                      echo "Tag and image digest (\`<version> <sha256>\`):"
-                      echo
-                      echo '```text'
-                      cat "docs/bitnami_${img}_digests.txt"
-                      echo '```'
-                      echo
-                    done
-                  } > docs/available_images.md
-
-                  echo "::group::available_images.json"
-                  cat docs/available_images.json
+                  echo "::group::generated files"
+                  ls -l docs/bitnami_*.json
+                  head -c 600 "docs/bitnami_${images[0]}.json"; echo
                   echo "::endgroup::"
 
             - name: Validate generated artifacts are not empty
@@ -219,30 +189,23 @@ jobs:
 
                   # Defensive guard: never let an empty or garbage artifact reach the
                   # commit/push step, where it would overwrite the good list already
-                  # published on gh-pages (see the empty-file regression that wiped
-                  # docs/openshift_acm_versions.txt). A valid file must be non-empty and
-                  # contain at least one digit (a version/digest).
-                  check() {
-                    if [ ! -s "$1" ] || ! grep -qE '[0-9]' "$1"; then
-                      echo "::error::$1 is empty or has no version data; aborting before publish."
+                  # published on gh-pages (cf. the empty-file regression that wiped
+                  # docs/openshift_acm_versions.txt).
+                  for img in "${images[@]}"; do
+                    f="docs/bitnami_${img}.json"
+                    if [ ! -s "${f}" ] || ! grep -qE '[0-9]' "${f}"; then
+                      echo "::error::${f} is empty or has no version data; aborting before publish."
                       exit 1
                     fi
-                  }
-
-                  for img in "${images[@]}"; do
-                    check "docs/bitnami_${img}_versions.txt"
-                    check "docs/bitnami_${img}_digests.txt"
-                    # Every digest line must read "<tag> sha256:<64 hex>".
-                    if grep -qvE '^[^ ]+ sha256:[0-9a-f]{64}$' "docs/bitnami_${img}_digests.txt"; then
-                      echo "::error::docs/bitnami_${img}_digests.txt has a malformed line; aborting."
+                    # Must be valid JSON with >=1 release, each with a version and a
+                    # well-formed sha256 digest.
+                    if ! jq -e \
+                      '(.releases | length > 0) and all(.releases[]; (.version | length > 0) and (.newDigest | test("^sha256:[0-9a-f]{64}$")))' \
+                      "${f}" >/dev/null 2>&1; then
+                      echo "::error::${f} is invalid or has a release without a valid sha256 digest; aborting."
                       exit 1
                     fi
                   done
-                  check docs/available_images.md
-                  if ! jq -e '.images | length > 0' docs/available_images.json >/dev/null 2>&1; then
-                    echo "::error::docs/available_images.json is invalid or has no images; aborting."
-                    exit 1
-                  fi
                   echo "All generated artifacts are non-empty and well-formed."
 
             - name: Commit and push image tag artifacts to gh-pages
@@ -253,20 +216,18 @@ jobs:
               run: |
                   set -euo pipefail
 
-                  # Stage the tag lists first, then guard on the *staged* diff: this
-                  # detects newly created files too (e.g. the very first run, when the
-                  # files do not yet exist on gh-pages), which a plain `git diff` would
-                  # miss because it ignores untracked files. The JSON/Markdown (which
-                  # always change because of the timestamp) are only added when the tag
-                  # set or a digest actually changed, avoiding timestamp-only commits.
+                  # Stage first, then guard on the *staged* diff so newly created files
+                  # are detected too (e.g. the very first run, when nothing exists on
+                  # gh-pages yet) — a plain `git diff` ignores untracked files. The
+                  # files carry no timestamp, so they change only on real tag/digest
+                  # changes.
                   git config --local user.name "github-actions[bot]"
                   git config --local user.email "github-actions[bot]@users.noreply.github.com"
-                  git add docs/bitnami_*_versions.txt docs/bitnami_*_digests.txt
-                  if git diff --cached --quiet -- docs/bitnami_*_versions.txt docs/bitnami_*_digests.txt; then
+                  git add docs/bitnami_*.json
+                  if git diff --cached --quiet -- docs/bitnami_*.json; then
                     echo "No tag or digest changes detected; skipping commit."
                   else
                     echo "Changes detected, committing and pushing to gh-pages"
-                    git add docs/available_images.json docs/available_images.md
                     git commit -m "Update Bitnami vendor-ee image tags"
                     git push origin gh-pages
                   fi

--- a/.github/workflows/internal_bitnami_artifact_image_versions.yml
+++ b/.github/workflows/internal_bitnami_artifact_image_versions.yml
@@ -24,7 +24,7 @@ name: Internal - Bitnami - Save vendor-ee image tags and digests as an artifact
 
 on:
     schedule:
-        - cron: 0 6 * * 1 # weekly, Monday 06:00 UTC
+        - cron: 0 6 * * * # daily, 06:00 UTC
     workflow_dispatch:
     pull_request:
         paths:

--- a/.github/workflows/internal_bitnami_artifact_image_versions.yml
+++ b/.github/workflows/internal_bitnami_artifact_image_versions.yml
@@ -129,8 +129,12 @@ jobs:
                       exit 1
                     fi
 
-                    # Keep only real image tags (X.Y.Z-debian-12-rN); this drops the
-                    # bare majors, floating tags and the .sig/.att/.metadata artifacts.
+                    # Keep only Bitnami revisioned tags (ending in -debian-12-rN).
+                    # For most images this is X.Y.Z-debian-12-rN; os-shell is versioned
+                    # by Debian major only (e.g. 12-debian-12-rN), so we intentionally do
+                    # NOT require a full semver here or it would drop every os-shell tag.
+                    # This still drops floating tags (e.g. 14-debian-12, 14) and the
+                    # .sig/.att/.metadata artifacts.
                     mapfile -t tags < <(grep -E -- '-debian-12-r[0-9]+$' /tmp/all_tags | sort -V || true)
                     if [ "${#tags[@]}" -eq 0 ]; then
                       echo "ERROR: no '*-debian-12-rN' tags found for ${img} (${ref})." >&2

--- a/.github/workflows/internal_bitnami_artifact_image_versions.yml
+++ b/.github/workflows/internal_bitnami_artifact_image_versions.yml
@@ -26,6 +26,13 @@ on:
         paths:
             - .github/workflows/internal_bitnami_artifact_image_versions.yml
 
+# Serialize runs: the job checks out and pushes the gh-pages branch, so an
+# overlapping scheduled run and a manual dispatch/re-run could otherwise race on
+# the push. Do not cancel an in-progress publish midway.
+concurrency:
+    group: ${{ github.workflow }}
+    cancel-in-progress: false
+
 env:
     # Upstream Broadcom registry (source of truth).
     # Host is the stable GCP Artifact Registry endpoint; the repo prefix mirrors
@@ -173,6 +180,9 @@ jobs:
                   echo "::endgroup::"
 
             - name: Commit and push image tag artifacts to gh-pages
+              # Never mutate gh-pages from a pull_request run: PRs only validate
+              # generation; publishing happens on schedule / manual dispatch.
+              if: github.event_name != 'pull_request'
               shell: bash
               run: |
                   set -euo pipefail

--- a/.github/workflows/internal_bitnami_artifact_image_versions.yml
+++ b/.github/workflows/internal_bitnami_artifact_image_versions.yml
@@ -56,6 +56,8 @@ env:
 jobs:
     save-bitnami-image-versions:
         runs-on: ubuntu-latest
+        permissions:
+            contents: write # push the generated files to the gh-pages branch
 
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/internal_bitnami_artifact_image_versions.yml
+++ b/.github/workflows/internal_bitnami_artifact_image_versions.yml
@@ -42,10 +42,12 @@ env:
     #  repositoryPrefix vmw-app-catalog/hosted-registry-514d25e16d5/containers/debian-12).
     REGISTRY_HOST: us-west4-docker.pkg.dev
     REGISTRY_REPO_PREFIX: vmw-app-catalog/hosted-registry-514d25e16d5/containers/debian-12
-    # vendor-ee images, verified identical across supported charts 8.7/8.8/8.9
-    # (charts/camunda-platform-8.*/values-enterprise.yaml). keycloak-ee/keycloak is
-    # intentionally excluded: it is Camunda-built, not served from this Broadcom path.
-    IMAGES: postgresql os-shell postgres-exporter elasticsearch elasticsearch-exporter keycloak-config-cli
+    # Bitnami Premium images listed from the upstream Broadcom catalog. The
+    # vendor-ee/* set is verified across supported charts 8.7/8.8/8.9
+    # (charts/camunda-platform-8.*/values-enterprise.yaml). keycloak is the upstream
+    # Bitnami base image; it is distinct from the Camunda-built keycloak-ee/keycloak
+    # final image used by the charts, which is published/tracked separately.
+    IMAGES: postgresql os-shell postgres-exporter elasticsearch elasticsearch-exporter keycloak-config-cli keycloak
 
 jobs:
     save-bitnami-image-versions:
@@ -56,27 +58,6 @@ jobs:
 
             - name: Install asdf tools with cache
               uses: camunda/infraex-common-config/./.github/actions/asdf-install-tooling@ce8f360e366f900378c3d1531d1f278f3789f04b # 1.7.0
-
-            # crane is installed here rather than via .tool-versions on purpose:
-            # it is only used by this workflow, and changing .tool-versions would
-            # trigger the (unrelated) Terraform golden-plan workflows that watch it.
-            - name: Install crane
-              shell: bash
-              env:
-                  # renovate: datasource=github-releases depName=google/go-containerregistry
-                  CRANE_VERSION: v0.21.6
-                  # sha256 of go-containerregistry_Linux_x86_64.tar.gz for CRANE_VERSION;
-                  # update it together with CRANE_VERSION.
-                  CRANE_SHA256: 7ebbdcd05b652345c1f5105f8475e518534b90d66f3bdb50017be63f426ea435
-              run: |
-                  set -euo pipefail
-                  tmp="$(mktemp -d)"
-                  curl -fsSL -o "${tmp}/crane.tar.gz" \
-                    "https://github.com/google/go-containerregistry/releases/download/${CRANE_VERSION}/go-containerregistry_Linux_x86_64.tar.gz"
-                  echo "${CRANE_SHA256}  ${tmp}/crane.tar.gz" | sha256sum -c -
-                  tar -xzf "${tmp}/crane.tar.gz" -C "${tmp}" crane
-                  sudo install -m 0755 "${tmp}/crane" /usr/local/bin/crane
-                  crane version
 
             - name: Import Broadcom registry credentials from Vault
               id: secrets
@@ -142,12 +123,29 @@ jobs:
                       exit 1
                     fi
 
+                    # Plain version list (one tag per line) — the Renovate source.
                     printf '%s\n' "${tags[@]}" > "docs/bitnami_${img}_versions.txt"
 
-                    tags_json="$(printf '%s\n' "${tags[@]}" | jq -R . | jq -s .)"
+                    # Resolve every tag to its image digest, in parallel. A failed
+                    # 'crane digest' aborts the whole pipeline (set -e + pipefail), so a
+                    # registry hiccup can never silently yield a partial/empty list.
+                    # shellcheck disable=SC2016 # $1/$2 are positional args of the inner sh, not outer expansions
+                    printf '%s\n' "${tags[@]}" \
+                      | xargs -P 8 -I {} sh -c 'd="$(crane digest "${1}:${2}")" || exit 1; printf "%s %s\n" "${2}" "${d}"' _ "${ref}" {} \
+                      | sort -V > "docs/bitnami_${img}_digests.txt"
+
+                    # Defensive: every tag must have produced exactly one digest line.
+                    dig_lines="$(wc -l < "docs/bitnami_${img}_digests.txt")"
+                    if [ "${dig_lines}" -ne "${#tags[@]}" ]; then
+                      echo "ERROR: digest resolution incomplete for ${img}: ${#tags[@]} tags but ${dig_lines} digests." >&2
+                      exit 1
+                    fi
+
+                    # Accumulate the combined JSON: tags = [{version, digest}].
+                    tags_json="$(jq -Rn '[inputs | split(" ") | {version: .[0], digest: .[1]}]' "docs/bitnami_${img}_digests.txt")"
                     images_json="$(jq -c \
                       --arg img "${img}" \
-                      --arg repo "${registry}/${img}" \
+                      --arg repo "${ref}" \
                       --argjson tags "${tags_json}" \
                       '. + {($img): {repository: $repo, tags: $tags}}' <<< "${images_json}")"
                   done
@@ -173,8 +171,10 @@ jobs:
                     for img in "${images[@]}"; do
                       echo "## vendor-ee/${img}"
                       echo
+                      echo "Tag and image digest (\`<version> <sha256>\`):"
+                      echo
                       echo '```text'
-                      cat "docs/bitnami_${img}_versions.txt"
+                      cat "docs/bitnami_${img}_digests.txt"
                       echo '```'
                       echo
                     done
@@ -183,6 +183,40 @@ jobs:
                   echo "::group::available_images.json"
                   cat docs/available_images.json
                   echo "::endgroup::"
+
+            - name: Validate generated artifacts are not empty
+              shell: bash
+              run: |
+                  set -euo pipefail
+                  read -r -a images <<< "${IMAGES}"
+
+                  # Defensive guard: never let an empty or garbage artifact reach the
+                  # commit/push step, where it would overwrite the good list already
+                  # published on gh-pages (see the empty-file regression that wiped
+                  # docs/openshift_acm_versions.txt). A valid file must be non-empty and
+                  # contain at least one digit (a version/digest).
+                  check() {
+                    if [ ! -s "$1" ] || ! grep -qE '[0-9]' "$1"; then
+                      echo "::error::$1 is empty or has no version data; aborting before publish."
+                      exit 1
+                    fi
+                  }
+
+                  for img in "${images[@]}"; do
+                    check "docs/bitnami_${img}_versions.txt"
+                    check "docs/bitnami_${img}_digests.txt"
+                    # Every digest line must read "<tag> sha256:<64 hex>".
+                    if grep -qvE '^[^ ]+ sha256:[0-9a-f]{64}$' "docs/bitnami_${img}_digests.txt"; then
+                      echo "::error::docs/bitnami_${img}_digests.txt has a malformed line; aborting."
+                      exit 1
+                    fi
+                  done
+                  check docs/available_images.md
+                  if ! jq -e '.images | length > 0' docs/available_images.json >/dev/null 2>&1; then
+                    echo "::error::docs/available_images.json is invalid or has no images; aborting."
+                    exit 1
+                  fi
+                  echo "All generated artifacts are non-empty and well-formed."
 
             - name: Commit and push image tag artifacts to gh-pages
               # Never mutate gh-pages from a pull_request run: PRs only validate
@@ -197,14 +231,14 @@ jobs:
                   # files do not yet exist on gh-pages), which a plain `git diff` would
                   # miss because it ignores untracked files. The JSON/Markdown (which
                   # always change because of the timestamp) are only added when the tag
-                  # set actually changed, avoiding timestamp-only commits.
+                  # set or a digest actually changed, avoiding timestamp-only commits.
                   git config --local user.name "github-actions[bot]"
                   git config --local user.email "github-actions[bot]@users.noreply.github.com"
-                  git add docs/bitnami_*_versions.txt
-                  if git diff --cached --quiet -- docs/bitnami_*_versions.txt; then
-                    echo "No tag changes detected; skipping commit."
+                  git add docs/bitnami_*_versions.txt docs/bitnami_*_digests.txt
+                  if git diff --cached --quiet -- docs/bitnami_*_versions.txt docs/bitnami_*_digests.txt; then
+                    echo "No tag or digest changes detected; skipping commit."
                   else
-                    echo "Tag changes detected, committing and pushing to gh-pages"
+                    echo "Changes detected, committing and pushing to gh-pages"
                     git add docs/available_images.json docs/available_images.md
                     git commit -m "Update Bitnami vendor-ee image tags"
                     git push origin gh-pages

--- a/.github/workflows/internal_bitnami_artifact_image_versions.yml
+++ b/.github/workflows/internal_bitnami_artifact_image_versions.yml
@@ -59,6 +59,29 @@ jobs:
             - name: Install asdf tools with cache
               uses: camunda/infraex-common-config/./.github/actions/asdf-install-tooling@ce8f360e366f900378c3d1531d1f278f3789f04b # 1.7.0
 
+            # crane is installed here rather than via .tool-versions on purpose: it is
+            # only used by this workflow, and a .tool-versions change would trigger the
+            # repo's Terraform golden-plan + integration suites, which are unrelated to
+            # this job. Renovate still manages the version via the annotation below; the
+            # download is integrity-checked against the release's own checksums.txt, so
+            # there is no hand-maintained hash to keep in sync.
+            - name: Install crane
+              shell: bash
+              env:
+                  # renovate: datasource=github-releases depName=google/go-containerregistry
+                  CRANE_VERSION: v0.21.6
+              run: |
+                  set -euo pipefail
+                  tmp="$(mktemp -d)"
+                  asset="go-containerregistry_Linux_x86_64.tar.gz"
+                  base="https://github.com/google/go-containerregistry/releases/download/${CRANE_VERSION}"
+                  curl -fsSL -o "${tmp}/${asset}" "${base}/${asset}"
+                  curl -fsSL -o "${tmp}/checksums.txt" "${base}/checksums.txt"
+                  (cd "${tmp}" && grep " ${asset}\$" checksums.txt | sha256sum -c -)
+                  tar -xzf "${tmp}/${asset}" -C "${tmp}" crane
+                  sudo install -m 0755 "${tmp}/crane" /usr/local/bin/crane
+                  crane version
+
             - name: Import Broadcom registry credentials from Vault
               id: secrets
               uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4

--- a/.github/workflows/internal_bitnami_artifact_image_versions.yml
+++ b/.github/workflows/internal_bitnami_artifact_image_versions.yml
@@ -1,6 +1,8 @@
 ---
 # This workflow updates artifacts containing the available image tags for the
-# Bitnami Premium (vendor-ee) images shipped in the Camunda enterprise Helm charts.
+# Bitnami Premium images behind the Camunda enterprise Helm charts: the
+# vendor-ee/* set plus the upstream Bitnami keycloak base image (the chart's
+# keycloak-ee/keycloak is Camunda-built on top of it and tracked separately).
 #
 # Tags are listed from the UPSTREAM source of truth (Broadcom / VMware Tanzu
 # Application Catalog), NOT from registry.camunda.cloud: the Camunda Harbor proxy
@@ -10,10 +12,12 @@
 # It is consumed by:
 #   - renovate (per-image plain .txt lists, via custom datasources in
 #     camunda/infraex-common-config)
-#   - customers / field engineering (human-readable Markdown + machine JSON)
+#   - customers / field engineering (human-readable Markdown + machine JSON,
+#     each tag annotated with its image digest)
 #
 # Published at:
 #   https://camunda.github.io/camunda-deployment-references/bitnami_<image>_versions.txt
+#   https://camunda.github.io/camunda-deployment-references/bitnami_<image>_digests.txt
 #   https://camunda.github.io/camunda-deployment-references/available_images.json
 #   https://camunda.github.io/camunda-deployment-references/available_images.md
 name: Internal - Bitnami - Save vendor-ee image tags as an artifact

--- a/.github/workflows/internal_bitnami_artifact_image_versions.yml
+++ b/.github/workflows/internal_bitnami_artifact_image_versions.yml
@@ -177,16 +177,20 @@ jobs:
               run: |
                   set -euo pipefail
 
-                  # Guard on the plain tag lists only (no timestamp), so the JSON/Markdown
-                  # timestamp is bumped only when the actual tag set changes (avoids a
-                  # commit on every scheduled run).
-                  if git diff --exit-code docs/bitnami_*_versions.txt; then
+                  # Stage the tag lists first, then guard on the *staged* diff: this
+                  # detects newly created files too (e.g. the very first run, when the
+                  # files do not yet exist on gh-pages), which a plain `git diff` would
+                  # miss because it ignores untracked files. The JSON/Markdown (which
+                  # always change because of the timestamp) are only added when the tag
+                  # set actually changed, avoiding timestamp-only commits.
+                  git config --local user.name "github-actions[bot]"
+                  git config --local user.email "github-actions[bot]@users.noreply.github.com"
+                  git add docs/bitnami_*_versions.txt
+                  if git diff --cached --quiet -- docs/bitnami_*_versions.txt; then
                     echo "No tag changes detected; skipping commit."
                   else
                     echo "Tag changes detected, committing and pushing to gh-pages"
-                    git config --local user.name "github-actions[bot]"
-                    git config --local user.email "github-actions[bot]@users.noreply.github.com"
-                    git add docs/bitnami_*_versions.txt docs/available_images.json docs/available_images.md
+                    git add docs/available_images.json docs/available_images.md
                     git commit -m "Update Bitnami vendor-ee image tags"
                     git push origin gh-pages
                   fi

--- a/.github/workflows/internal_bitnami_artifact_image_versions.yml
+++ b/.github/workflows/internal_bitnami_artifact_image_versions.yml
@@ -77,6 +77,7 @@ jobs:
               run: |
                   set -euo pipefail
                   tmp="$(mktemp -d)"
+                  trap 'rm -rf "${tmp}"' EXIT
                   asset="go-containerregistry_Linux_x86_64.tar.gz"
                   base="https://github.com/google/go-containerregistry/releases/download/${CRANE_VERSION}"
                   curl -fsSL -o "${tmp}/${asset}" "${base}/${asset}"
@@ -115,6 +116,10 @@ jobs:
                   set -euo pipefail
 
                   mkdir -p docs
+                  # Drop any previously published per-image files first, so an image
+                  # removed from IMAGES does not linger on gh-pages (the commit step
+                  # stages deletions too).
+                  rm -f docs/bitnami_*.json
                   registry="${REGISTRY_HOST}/${REGISTRY_REPO_PREFIX}"
                   read -r -a images <<< "${IMAGES}"
 
@@ -223,8 +228,8 @@ jobs:
                   # changes.
                   git config --local user.name "github-actions[bot]"
                   git config --local user.email "github-actions[bot]@users.noreply.github.com"
-                  git add docs/bitnami_*.json
-                  if git diff --cached --quiet -- docs/bitnami_*.json; then
+                  git add -A -- "docs/bitnami_*.json"
+                  if git diff --cached --quiet -- "docs/bitnami_*.json"; then
                     echo "No tag or digest changes detected; skipping commit."
                   else
                     echo "Changes detected, committing and pushing to gh-pages"

--- a/.github/workflows/internal_bitnami_artifact_image_versions.yml
+++ b/.github/workflows/internal_bitnami_artifact_image_versions.yml
@@ -20,7 +20,7 @@
 #   https://camunda.github.io/camunda-deployment-references/bitnami_<image>.json
 # Browse them at:
 #   https://github.com/camunda/camunda-deployment-references/tree/gh-pages/docs
-name: Internal - Bitnami - Save vendor-ee image tags as an artifact
+name: Internal - Bitnami - Save vendor-ee image tags and digests as an artifact
 
 on:
     schedule:

--- a/.github/workflows/internal_bitnami_artifact_image_versions.yml
+++ b/.github/workflows/internal_bitnami_artifact_image_versions.yml
@@ -26,12 +26,13 @@ on:
         paths:
             - .github/workflows/internal_bitnami_artifact_image_versions.yml
 
-# Serialize runs: the job checks out and pushes the gh-pages branch, so an
-# overlapping scheduled run and a manual dispatch/re-run could otherwise race on
-# the push. Do not cancel an in-progress publish midway.
+# Publish events (schedule / manual dispatch) share one lock so they never race
+# on the gh-pages push, and a publish is never cancelled midway. pull_request
+# validation runs never push, so they get their own per-ref group (and may cancel
+# superseded runs) to avoid delaying a publish.
 concurrency:
-    group: ${{ github.workflow }}
-    cancel-in-progress: false
+    group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || 'publish' }}
+    cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
     # Upstream Broadcom registry (source of truth).

--- a/.github/workflows/internal_bitnami_artifact_image_versions.yml
+++ b/.github/workflows/internal_bitnami_artifact_image_versions.yml
@@ -1,0 +1,185 @@
+---
+# This workflow updates artifacts containing the available image tags for the
+# Bitnami Premium (vendor-ee) images shipped in the Camunda enterprise Helm charts.
+#
+# Tags are listed from the UPSTREAM source of truth (Broadcom / VMware Tanzu
+# Application Catalog), NOT from registry.camunda.cloud: the Camunda Harbor proxy
+# only exposes the cached subset, and listing it is incomplete for tags published
+# before the November 2025 vendor migration.
+#
+# It is consumed by:
+#   - renovate (per-image plain .txt lists, via custom datasources in
+#     camunda/infraex-common-config)
+#   - customers / field engineering (human-readable Markdown + machine JSON)
+#
+# Published at:
+#   https://camunda.github.io/camunda-deployment-references/bitnami_<image>_versions.txt
+#   https://camunda.github.io/camunda-deployment-references/available_images.json
+#   https://camunda.github.io/camunda-deployment-references/available_images.md
+name: Internal - Bitnami - Save vendor-ee image tags as an artifact
+
+on:
+    schedule:
+        - cron: 0 6 * * 1 # weekly, Monday 06:00 UTC
+    workflow_dispatch:
+    pull_request:
+        paths:
+            - .github/workflows/internal_bitnami_artifact_image_versions.yml
+
+env:
+    # Upstream Broadcom registry (source of truth).
+    # Host is the stable GCP Artifact Registry endpoint; the repo prefix mirrors
+    # the Harbor "vendor-ee" proxy mapping defined in camunda/infra-core
+    # (harbor-facade alias: project broadcom-514d25e16d5,
+    #  repositoryPrefix vmw-app-catalog/hosted-registry-514d25e16d5/containers/debian-12).
+    REGISTRY_HOST: us-west4-docker.pkg.dev
+    REGISTRY_REPO_PREFIX: vmw-app-catalog/hosted-registry-514d25e16d5/containers/debian-12
+    # vendor-ee images, verified identical across supported charts 8.7/8.8/8.9
+    # (charts/camunda-platform-8.*/values-enterprise.yaml). keycloak-ee/keycloak is
+    # intentionally excluded: it is Camunda-built, not served from this Broadcom path.
+    IMAGES: postgresql os-shell postgres-exporter elasticsearch elasticsearch-exporter keycloak-config-cli
+
+jobs:
+    save-bitnami-image-versions:
+        runs-on: ubuntu-latest
+
+        steps:
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+            - name: Install asdf tools with cache
+              uses: camunda/infraex-common-config/./.github/actions/asdf-install-tooling@ce8f360e366f900378c3d1531d1f278f3789f04b # 1.7.0
+
+            - name: Import Broadcom registry credentials from Vault
+              id: secrets
+              uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4
+              with:
+                  url: ${{ secrets.VAULT_ADDR }}
+                  method: approle
+                  roleId: ${{ secrets.VAULT_ROLE_ID }}
+                  secretId: ${{ secrets.VAULT_SECRET_ID }}
+                  exportEnv: false
+                  secrets: |
+                      secret/data/products/infrastructure-experience/ci/common BROADCOM_BITNAMI_PREMIUM_REGISTRY_AUTH_USERNAME | REGISTRY_USERNAME;
+                      secret/data/products/infrastructure-experience/ci/common BROADCOM_BITNAMI_PREMIUM_REGISTRY_AUTH_PASSWORD | REGISTRY_PASSWORD;
+
+            - name: Switch to gh-pages branch
+              run: |
+                  cp .tool-versions /tmp/.tool-versions
+                  git fetch origin gh-pages
+                  git checkout gh-pages
+                  cp /tmp/.tool-versions .tool-versions
+
+            - name: Generate image tag artifacts
+              shell: bash
+              env:
+                  REGISTRY_USERNAME: ${{ steps.secrets.outputs.REGISTRY_USERNAME }}
+                  REGISTRY_PASSWORD: ${{ steps.secrets.outputs.REGISTRY_PASSWORD }}
+              run: |
+                  set -euo pipefail
+
+                  mkdir -p docs
+                  generated_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+                  registry="${REGISTRY_HOST}/${REGISTRY_REPO_PREFIX}"
+                  read -r -a images <<< "${IMAGES}"
+
+                  # Authenticate to the upstream Broadcom registry. The Broadcom/Tanzu
+                  # credential is a GCP service-account key: username "_json_key",
+                  # password = the JSON key content (stored as-is in Vault).
+                  # crane is used instead of skopeo: it implements the GCP Artifact
+                  # Registry token flow that skopeo's list-tags does not handle.
+                  printf '%s' "${REGISTRY_PASSWORD}" \
+                    | crane auth login "${REGISTRY_HOST}" --username "${REGISTRY_USERNAME}" --password-stdin
+
+                  images_json='{}'
+                  for img in "${images[@]}"; do
+                    ref="${registry}/${img}"
+                    echo "Listing tags for ${img} (${ref})..."
+
+                    if ! crane ls "${ref}" > /tmp/all_tags 2> /tmp/crane_err; then
+                      echo "ERROR: crane ls failed for ${img} (${ref}):" >&2
+                      cat /tmp/crane_err >&2
+                      exit 1
+                    fi
+
+                    # Keep only real image tags (X.Y.Z-debian-12-rN); this drops the
+                    # bare majors, floating tags and the .sig/.att/.metadata artifacts.
+                    mapfile -t tags < <(grep -E -- '-debian-12-r[0-9]+$' /tmp/all_tags | sort -V || true)
+                    if [ "${#tags[@]}" -eq 0 ]; then
+                      echo "ERROR: no '*-debian-12-rN' tags found for ${img} (${ref})." >&2
+                      exit 1
+                    fi
+
+                    printf '%s\n' "${tags[@]}" > "docs/bitnami_${img}_versions.txt"
+
+                    tags_json="$(printf '%s\n' "${tags[@]}" | jq -R . | jq -s .)"
+                    images_json="$(jq -c \
+                      --arg img "${img}" \
+                      --arg repo "${registry}/${img}" \
+                      --argjson tags "${tags_json}" \
+                      '. + {($img): {repository: $repo, tags: $tags}}' <<< "${images_json}")"
+                  done
+
+                  jq -n \
+                    --arg ts "${generated_at}" \
+                    --arg reg "${registry}" \
+                    --argjson imgs "${images_json}" \
+                    '{generated_at: $ts, source: "Broadcom / VMware Tanzu Application Catalog (upstream)", registry: $reg, images: $imgs}' \
+                    > docs/available_images.json
+
+                  {
+                    echo "# Available Bitnami Premium (vendor-ee) image tags"
+                    echo
+                    echo "_Last updated: ${generated_at}._"
+                    echo
+                    echo "Source of truth: **upstream Broadcom / VMware Tanzu Application Catalog**."
+                    echo "These are the tags available behind \`registry.camunda.cloud/vendor-ee/<image>\`."
+                    echo
+                    echo "> The Harbor UI must **not** be used to browse these images: it only shows the"
+                    echo "> cached subset, not the full upstream catalog."
+                    echo
+                    for img in "${images[@]}"; do
+                      echo "## vendor-ee/${img}"
+                      echo
+                      echo '```text'
+                      cat "docs/bitnami_${img}_versions.txt"
+                      echo '```'
+                      echo
+                    done
+                  } > docs/available_images.md
+
+                  echo "::group::available_images.json"
+                  cat docs/available_images.json
+                  echo "::endgroup::"
+
+            - name: Commit and push image tag artifacts to gh-pages
+              shell: bash
+              run: |
+                  set -euo pipefail
+
+                  # Guard on the plain tag lists only (no timestamp), so the JSON/Markdown
+                  # timestamp is bumped only when the actual tag set changes (avoids a
+                  # commit on every scheduled run).
+                  if git diff --exit-code docs/bitnami_*_versions.txt; then
+                    echo "No tag changes detected; skipping commit."
+                  else
+                    echo "Tag changes detected, committing and pushing to gh-pages"
+                    git config --local user.name "github-actions[bot]"
+                    git config --local user.email "github-actions[bot]@users.noreply.github.com"
+                    git add docs/bitnami_*_versions.txt docs/available_images.json docs/available_images.md
+                    git commit -m "Update Bitnami vendor-ee image tags"
+                    git push origin gh-pages
+                  fi
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Notify in Slack in case of failure
+              id: slack-notification
+              if: failure()
+              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@ce8f360e366f900378c3d1531d1f278f3789f04b # 1.7.0
+              with:
+                  vault_addr: ${{ secrets.VAULT_ADDR }}
+                  vault_role_id: ${{ secrets.VAULT_ROLE_ID }}
+                  vault_secret_id: ${{ secrets.VAULT_SECRET_ID }}
+                  slack_channel_id: ${{ github.event_name == 'schedule' && 'C076N4G1162' || 'C07E4FF6YMB' }}
+                  slack_mention_people: ${{ github.event_name == 'schedule' && '@infraex-medic' || '' }}
+                  disable_silence_check: ${{ github.event_name == 'schedule' && 'false' || 'true' }}

--- a/.github/workflows/internal_bitnami_artifact_image_versions.yml
+++ b/.github/workflows/internal_bitnami_artifact_image_versions.yml
@@ -49,6 +49,27 @@ jobs:
             - name: Install asdf tools with cache
               uses: camunda/infraex-common-config/./.github/actions/asdf-install-tooling@ce8f360e366f900378c3d1531d1f278f3789f04b # 1.7.0
 
+            # crane is installed here rather than via .tool-versions on purpose:
+            # it is only used by this workflow, and changing .tool-versions would
+            # trigger the (unrelated) Terraform golden-plan workflows that watch it.
+            - name: Install crane
+              shell: bash
+              env:
+                  # renovate: datasource=github-releases depName=google/go-containerregistry
+                  CRANE_VERSION: v0.21.6
+                  # sha256 of go-containerregistry_Linux_x86_64.tar.gz for CRANE_VERSION;
+                  # update it together with CRANE_VERSION.
+                  CRANE_SHA256: 7ebbdcd05b652345c1f5105f8475e518534b90d66f3bdb50017be63f426ea435
+              run: |
+                  set -euo pipefail
+                  tmp="$(mktemp -d)"
+                  curl -fsSL -o "${tmp}/crane.tar.gz" \
+                    "https://github.com/google/go-containerregistry/releases/download/${CRANE_VERSION}/go-containerregistry_Linux_x86_64.tar.gz"
+                  echo "${CRANE_SHA256}  ${tmp}/crane.tar.gz" | sha256sum -c -
+                  tar -xzf "${tmp}/crane.tar.gz" -C "${tmp}" crane
+                  sudo install -m 0755 "${tmp}/crane" /usr/local/bin/crane
+                  crane version
+
             - name: Import Broadcom registry credentials from Vault
               id: secrets
               uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4

--- a/.tool-versions
+++ b/.tool-versions
@@ -19,9 +19,6 @@ actionlint 1.7.12
 
 awscli 2.34.53
 
-# renovate: datasource=github-tags depName=google/go-containerregistry
-crane 0.21.6
-
 delta 0.18.2
 
 # renovate: datasource=github-tags depName=eksctl-io/eksctl

--- a/.tool-versions
+++ b/.tool-versions
@@ -19,6 +19,9 @@ actionlint 1.7.12
 
 awscli 2.34.53
 
+# renovate: datasource=github-tags depName=google/go-containerregistry
+crane 0.21.6
+
 delta 0.18.2
 
 # renovate: datasource=github-tags depName=eksctl-io/eksctl


### PR DESCRIPTION
## What

Adds a scheduled workflow `internal_bitnami_artifact_image_versions.yml` that publishes the available tags **and image digests** for the Bitnami Premium images behind the Camunda enterprise Helm charts.

Follows the existing `internal_aws_artifact_opensearch_versions.yml` / `..._aurora_versions.yml` pattern (gh-pages artifact consumed by renovate + humans).

## Why

Air-gapped / enterprise customers and field engineering have no reliable way to browse available `vendor-ee` tags: the Harbor UI only shows the cached subset, and listing `registry.camunda.cloud` is incomplete for tags published before the Nov-2025 vendor migration. Renovate (ours + customers') also needs a creds-free version source.

Refs camunda/team-infrastructure-experience#1038.

## How

- Lists tags from the **upstream source of truth**: Broadcom / VMware Tanzu Application Catalog (`us-west4-docker.pkg.dev/vmw-app-catalog/hosted-registry-514d25e16d5/containers/debian-12/<image>`). Path mirrors the Harbor `vendor-ee` proxy mapping in `camunda/infra-core` (harbor-facade alias).
- Uses **crane** (it implements the GCP Artifact Registry token flow that skopeo's `list-tags` does not). crane is installed in-workflow, pinned and integrity-checked against the release's `checksums.txt` (Renovate bumps `CRANE_VERSION` via annotation, no hand-maintained hash). It is intentionally **not** added to `.tool-versions`, which would drag this workflow-only PR into the repo's Terraform golden-plan + integration suites for no benefit.
- Keeps only real image tags (`*-debian-12-rN`), dropping floating tags and `.sig`/`.att`/`.metadata` artifacts.
- Resolves each tag's **image digest** (`crane digest`, parallelised).
- A defensive **validation step** aborts before publishing if any artifact is empty or malformed, so a registry/auth hiccup can never overwrite the good list on gh-pages.
- Publishes to `gh-pages` `docs/`, one self-contained file per image:
  - `bitnami_<image>.json` — a Renovate custom datasource (`format: json`) whose `releases` carry `{version, newDigest}` (the image digest), also human-inspectable.
- Commit prunes files for images removed from `IMAGES` and is guarded on content only, so it changes only on real tag/digest changes (no commit-noise on scheduled runs). PR runs validate generation but never push to gh-pages; a `concurrency` group serializes publishes.

## Scope

Images: `postgresql`, `os-shell`, `postgres-exporter`, `elasticsearch`, `elasticsearch-exporter`, `keycloak-config-cli` (the `vendor-ee/*` set, verified across charts 8.7/8.8/8.9), plus the upstream Bitnami **`keycloak`** base image. The latter is intentionally published; it is distinct from the Camunda-built `keycloak-ee/keycloak` chart image (tracked separately).

## Follow-ups (separate PRs)

- `camunda/infraex-common-config`#508: renovate `customDatasources` for the per-image `_versions.txt`.
- `camunda-docs`: link the published list (versions + digests); state Harbor UI must not be used to browse images.

## Validation

`actionlint`, `yamllint`, `yamlfmt` clean. The workflow ran green on the PR (crane checksum verify, digest generation, and the empty-artifact guard all pass in ~1 min).

