### PR TITLE
fix(ecs-dual-region): revert alpha1 image bump, keep SNAPSHOT until alpha3

### DIFF
--- a/.github/workflows/internal_global_alpha_availability_check.yml
+++ b/.github/workflows/internal_global_alpha_availability_check.yml
@@ -64,12 +64,19 @@ jobs:
                   # Scan for Docker image references like "org/image:X.Y-SNAPSHOT" or "org/image:X.Y.Z-SNAPSHOT"
                   # The pattern requires a version number before -SNAPSHOT to avoid matching
                   # file paths, variable names, or comments that happen to contain "SNAPSHOT"
+                  #
+                  # A line can opt out of this check with an inline "alpha-availability-check:ignore"
+                  # marker. Use it for images intentionally pinned to SNAPSHOT until a feature lands in
+                  # a later alpha (e.g. ECS dual-region region-awareness, shipping in 8.10 alpha3).
+                  # Such lines are dropped before image names are extracted.
                   while IFS= read -r image; do
                     if [[ -n "$image" ]] && ! printf '%s\n' "${SNAPSHOT_IMAGES[@]}" 2>/dev/null | grep -qxF "$image"; then
                       SNAPSHOT_IMAGES+=("$image")
                     fi
-                  done < <(grep -rohP '[a-z0-9._-]+/[a-z0-9._-]+(?=:\d+\.\d+[^\s"'"'"']*SNAPSHOT)' \
-                    --include="*.tf" --include="*.sh" --include="*.yml" --include="*.yaml" --include="*.tfvars" . || true)
+                  done < <(grep -rhP '[a-z0-9._-]+/[a-z0-9._-]+:\d+\.\d+[^\s"'"'"']*SNAPSHOT' \
+                    --include="*.tf" --include="*.sh" --include="*.yml" --include="*.yaml" --include="*.tfvars" . \
+                    | grep -vF 'alpha-availability-check:ignore' \
+                    | grep -ohP '[a-z0-9._-]+/[a-z0-9._-]+(?=:\d+\.\d+[^\s"'"'"']*SNAPSHOT)' || true)
 
                   if [[ ${#SNAPSHOT_IMAGES[@]} -eq 0 ]]; then
                     echo "No SNAPSHOT image references found in the repository."

--- a/aws/containers/ecs-dual-region-fargate/terraform/app/README.md
+++ b/aws/containers/ecs-dual-region-fargate/terraform/app/README.md
@@ -21,8 +21,8 @@
 | Name | Description | Type | Default | Required |
 | ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_aws_profile"></a> [aws\_profile](#input\_aws\_profile) | AWS Profile to use (null = use default credential chain) | `string` | `null` | no |
-| <a name="input_camunda_image"></a> [camunda\_image](#input\_camunda\_image) | Container image for the Camunda orchestration cluster tasks (Zeebe broker + gateway + webapps) | `string` | `"camunda/camunda:8.10.0-alpha1"` | no |
-| <a name="input_connectors_image"></a> [connectors\_image](#input\_connectors\_image) | Container image for the Camunda connectors-bundle tasks. Separate from camunda\_image because connectors ship as a distinct artifact from the orchestration cluster. | `string` | `"camunda/connectors-bundle:8.10.0-alpha1"` | no |
+| <a name="input_camunda_image"></a> [camunda\_image](#input\_camunda\_image) | Container image for the Camunda orchestration cluster tasks (Zeebe broker + gateway + webapps) | `string` | `"camunda/camunda:8.10-SNAPSHOT"` | no |
+| <a name="input_connectors_image"></a> [connectors\_image](#input\_connectors\_image) | Container image for the Camunda connectors-bundle tasks. Separate from camunda\_image because connectors ship as a distinct artifact from the orchestration cluster. | `string` | `"camunda/connectors-bundle:8.10-SNAPSHOT"` | no |
 | <a name="input_default_tags"></a> [default\_tags](#input\_default\_tags) | Default tags to apply to all resources | `map(string)` | `{}` | no |
 | <a name="input_infra_state_path"></a> [infra\_state\_path](#input\_infra\_state\_path) | Path to the infra terraform state file (local backend) or S3 key | `string` | `"../infra/terraform.tfstate"` | no |
 ## Outputs

--- a/aws/containers/ecs-dual-region-fargate/terraform/app/variables.tf
+++ b/aws/containers/ecs-dual-region-fargate/terraform/app/variables.tf
@@ -25,13 +25,23 @@ variable "default_tags" {
 }
 
 variable "camunda_image" {
-  type        = string
-  default     = "camunda/camunda:8.10-SNAPSHOT"
+  type = string
+  # Dual-region requires the SNAPSHOT build: zone-aware partition distribution
+  # (cross-region "region awareness") is only available there and ships in the
+  # 8.10 alpha3 image. Keep SNAPSHOT until then; the trailing marker tells the
+  # alpha-availability check to skip this line (see internal_global_alpha_availability_check.yml).
+  # TODO: [release-duty] at 8.10 alpha3, bump to the published alpha image tag
+  # and remove the "alpha-availability-check:ignore" markers in this file.
+  default     = "camunda/camunda:8.10-SNAPSHOT" # alpha-availability-check:ignore
   description = "Container image for the Camunda orchestration cluster tasks (Zeebe broker + gateway + webapps)"
 }
 
 variable "connectors_image" {
-  type        = string
-  default     = "camunda/connectors-bundle:8.10-SNAPSHOT"
+  type = string
+  # Pinned to SNAPSHOT for the same reason as camunda_image above (dual-region
+  # region awareness ships in 8.10 alpha3).
+  # TODO: [release-duty] at 8.10 alpha3, bump to the published alpha image tag
+  # and remove the "alpha-availability-check:ignore" marker.
+  default     = "camunda/connectors-bundle:8.10-SNAPSHOT" # alpha-availability-check:ignore
   description = "Container image for the Camunda connectors-bundle tasks. Separate from camunda_image because connectors ship as a distinct artifact from the orchestration cluster."
 }

--- a/aws/containers/ecs-dual-region-fargate/terraform/app/variables.tf
+++ b/aws/containers/ecs-dual-region-fargate/terraform/app/variables.tf
@@ -26,12 +26,12 @@ variable "default_tags" {
 
 variable "camunda_image" {
   type        = string
-  default     = "camunda/camunda:8.10.0-alpha1"
+  default     = "camunda/camunda:8.10-SNAPSHOT"
   description = "Container image for the Camunda orchestration cluster tasks (Zeebe broker + gateway + webapps)"
 }
 
 variable "connectors_image" {
   type        = string
-  default     = "camunda/connectors-bundle:8.10.0-alpha1"
+  default     = "camunda/connectors-bundle:8.10-SNAPSHOT"
   description = "Container image for the Camunda connectors-bundle tasks. Separate from camunda_image because connectors ship as a distinct artifact from the orchestration cluster."
 }


### PR DESCRIPTION
## Why

Reverts #2762. Per @marcel-dias, the **ECS dual-region** setup requires the `SNAPSHOT` build: cross-region zone-aware partition distribution ("region awareness") only lands in the **8.10 alpha3** image. Bumping to `8.10.0-alpha1` broke dual-region.

> Dual region requires snapshot version, the region awareness will be released in alpha3 — Marcel Dias

## What

1. **Revert** the alpha1 bump (commit reverts #2762): `app/variables.tf` + generated `README.md` back to:
   - `camunda/camunda:8.10-SNAPSHOT`
   - `camunda/connectors-bundle:8.10-SNAPSHOT`
2. **Opt-out mechanism** in `internal_global_alpha_availability_check.yml`: a line may carry an inline `alpha-availability-check:ignore` marker; marked lines are dropped before image names are extracted, so the check no longer re-flags these intentionally pinned images (which would otherwise re-trigger the same broken bump).
3. The two ECS dual-region image defaults carry that marker plus a co-located `# TODO: [release-duty]` to bump to the alpha tag and remove the marker at **8.10 alpha3**.

## Verification

Simulated the updated scan pipeline locally:

```
candidate lines (image:<ver>-SNAPSHOT):
  camunda/camunda:8.10-SNAPSHOT            # alpha-availability-check:ignore
  camunda/connectors-bundle:8.10-SNAPSHOT  # alpha-availability-check:ignore
after dropping marked lines -> flagged images: 0
```

pre-commit: `terraform_fmt`, `tflint`, `terraform_docs`, `yamllint` pass (trivy / terraform-test / actionlint skipped locally — no Docker daemon; run in CI).

## Note

This is a revert PR to undo a merged change — leaving merge to a human.