### PR TITLE
fix(ci): prevent publishing empty version artifacts

### DIFF
--- a/.github/scripts/get_acm_versions.py
+++ b/.github/scripts/get_acm_versions.py
@@ -4,19 +4,42 @@
 Retrieve OpenShift ACM versions from the official documentation and save it as txt file in docs folder.
 """
 
+import os
 import sys
+import time
+
 import requests
 from bs4 import BeautifulSoup
-import os
 
 url = "https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/"
 
+# docs.redhat.com sits behind bot protection that returns 403 for requests
+# advertising a browser-like ("Mozilla/...") User-Agent from datacenter IPs
+# (such as GitHub-hosted runners). An honest, non-browser User-Agent is allowed
+# and the request is then redirected to the latest version page, so we identify
+# ourselves plainly and let requests follow the redirect.
 headers = {
-    "User-Agent": "Mozilla/5.0"
+    "User-Agent": "camunda-deployment-references-acm-version-bot "
+                  "(+https://github.com/camunda/camunda-deployment-references)"
 }
 
-response = requests.get(url, headers=headers)
-response.raise_for_status()
+
+def fetch(target_url, attempts=3, backoff_seconds=5):
+    last_error = None
+    for attempt in range(1, attempts + 1):
+        try:
+            response = requests.get(target_url, headers=headers, timeout=30)
+            response.raise_for_status()
+            return response
+        except requests.RequestException as error:
+            last_error = error
+            print(f"Attempt {attempt}/{attempts} failed: {error}", file=sys.stderr)
+            if attempt < attempts:
+                time.sleep(backoff_seconds * attempt)
+    raise SystemExit(f"ERROR: could not fetch {target_url}: {last_error}")
+
+
+response = fetch(url)
 soup = BeautifulSoup(response.text, "html.parser")
 
 versions = []
@@ -40,3 +63,5 @@ os.makedirs("docs", exist_ok=True)
 with open("docs/openshift_acm_versions.txt", "w") as f:
     for v in versions:
         f.write(f"{v}\n")
+
+print(f"Wrote {len(versions)} OpenShift ACM versions to docs/openshift_acm_versions.txt")

--- a/.github/scripts/get_acm_versions.py
+++ b/.github/scripts/get_acm_versions.py
@@ -4,6 +4,7 @@
 Retrieve OpenShift ACM versions from the official documentation and save it as txt file in docs folder.
 """
 
+import sys
 import requests
 from bs4 import BeautifulSoup
 import os
@@ -15,13 +16,24 @@ headers = {
 }
 
 response = requests.get(url, headers=headers)
+response.raise_for_status()
 soup = BeautifulSoup(response.text, "html.parser")
 
 versions = []
 select = soup.find("select", {"id": "product_version"})
 if select:
     for option in select.find_all("option"):
-        versions.append(option.get("value"))
+        value = option.get("value")
+        if value and value.strip():
+            versions.append(value.strip())
+
+# Fail loudly instead of overwriting the artifact with an empty list when the
+# documentation page structure changed or the request was throttled/blocked.
+if not versions:
+    sys.exit(
+        f"ERROR: no OpenShift ACM versions found at {url}. "
+        "The page structure may have changed; refusing to write an empty file."
+    )
 
 os.makedirs("docs", exist_ok=True)
 

--- a/.github/workflows/internal_aws_artifact_aurora_versions.yml
+++ b/.github/workflows/internal_aws_artifact_aurora_versions.yml
@@ -54,6 +54,12 @@ jobs:
                     > docs/aurora_postgres_versions.txt
                   cat docs/aurora_postgres_versions.txt
 
+                  # Guard: never publish an empty/invalid artifact (see commit fa56123).
+                  if [ ! -s docs/aurora_postgres_versions.txt ] || ! grep -qE '[0-9]' docs/aurora_postgres_versions.txt; then
+                    echo "::error::Generated 'docs/aurora_postgres_versions.txt' is empty or has no version numbers; aborting to avoid publishing an empty artifact."
+                    exit 1
+                  fi
+
             - name: Commit and push Aurora PostgreSQL versions file to gh-pages
               shell: bash
               run: |

--- a/.github/workflows/internal_aws_artifact_opensearch_versions.yml
+++ b/.github/workflows/internal_aws_artifact_opensearch_versions.yml
@@ -51,6 +51,12 @@ jobs:
                     > docs/opensearch_versions.txt
                   cat docs/opensearch_versions.txt
 
+                  # Guard: never publish an empty/invalid artifact (see commit fa56123).
+                  if [ ! -s docs/opensearch_versions.txt ] || ! grep -qE '[0-9]' docs/opensearch_versions.txt; then
+                    echo "::error::Generated 'docs/opensearch_versions.txt' is empty or has no version numbers; aborting to avoid publishing an empty artifact."
+                    exit 1
+                  fi
+
             - name: Commit and push OpenSearch versions file to gh-pages
               shell: bash
               run: |

--- a/.github/workflows/internal_openshift_artifact_acm_versions.yml
+++ b/.github/workflows/internal_openshift_artifact_acm_versions.yml
@@ -39,6 +39,12 @@ jobs:
                   echo "Printing: ./docs/openshift_acm_versions.txt"
                   cat "./docs/openshift_acm_versions.txt"
 
+                  # Guard: never publish an empty/invalid artifact (see commit fa56123).
+                  if [ ! -s ./docs/openshift_acm_versions.txt ] || ! grep -qE '[0-9]' ./docs/openshift_acm_versions.txt; then
+                    echo "::error::Generated './docs/openshift_acm_versions.txt' is empty or has no version numbers; aborting to avoid publishing an empty artifact."
+                    exit 1
+                  fi
+
             - name: Commit and push OpenShift ACM versions file to gh-pages
               shell: bash
               run: |

--- a/.github/workflows/internal_openshift_artifact_rosa_versions.yml
+++ b/.github/workflows/internal_openshift_artifact_rosa_versions.yml
@@ -76,6 +76,12 @@ jobs:
                   cat docs/rosa_versions.txt
                   echo "::endgroup::"
 
+                  # Guard: never publish an empty/invalid artifact (see commit fa56123).
+                  if [ ! -s docs/rosa_versions.txt ] || ! grep -qE '[0-9]' docs/rosa_versions.txt; then
+                    echo "::error::Generated 'docs/rosa_versions.txt' is empty or has no version numbers; aborting to avoid publishing an empty artifact."
+                    exit 1
+                  fi
+
             - name: Commit and push ROSA versions file to gh-pages
               shell: bash
               run: |


### PR DESCRIPTION
## Problem

The scheduled *Save OpenShift ACM Versions* workflow published an **empty** `openshift_acm_versions.txt` to `gh-pages` in fa561238bdf8368fe87dcbd8374fe1fed46f92e1 (17 versions → 0). This artifact feeds Renovate (https://camunda.github.io/camunda-deployment-references/openshift_acm_versions.txt), so an empty list breaks version resolution downstream.

## Root cause

`docs.redhat.com` sits behind bot protection that returns **403 Forbidden** for requests advertising a browser-like (`Mozilla/...`) `User-Agent` from datacenter IPs (GitHub-hosted runners). `get_acm_versions.py` forced `User-Agent: Mozilla/5.0`, so the scrape received an error page, found no `<select id="product_version">`, and **silently wrote an empty file** (exit 0). The workflow then committed/pushed the empty list.

Confirmed by probing the endpoint:

| User-Agent | Result |
|---|---|
| `Mozilla/5.0` (browser-like) | **403** |
| none / `curl/...` / `python-requests/...` / honest bot UA | 302 → **200** (full page with all versions) |

The three sibling workflows share the same failure class: a successful-but-empty CLI/API response (`rosa`, `aws rds`, `aws opensearch`) would wipe the published list.

## Fix

**`get_acm_versions.py`**
- Use an **honest, non-browser `User-Agent`** (allowed; the request is redirected to the latest version page, which `requests` follows by default) instead of the blocked `Mozilla/5.0`.
- `response.raise_for_status()` + retry transient failures with a request timeout.
- Skip empty/placeholder `<option>` values.
- `sys.exit(...)` (non-zero) when no versions are parsed → refuse to overwrite the artifact with an empty list.

**Defense in depth — guard in all four version workflows** (ACM, ROSA, Aurora, OpenSearch), right after the file is generated and before commit:

```bash
if [ ! -s docs/<file>.txt ] || ! grep -qE '[0-9]' docs/<file>.txt; then
  echo "::error::Generated '<file>' is empty or has no version numbers; aborting to avoid publishing an empty artifact."
  exit 1
fi
```

An empty or invalid result now fails the run (and triggers the existing Slack alert on `schedule`) instead of pushing an empty list to `gh-pages`.

## Validation
- Ran `get_acm_versions.py` end-to-end: retrieves all **17** ACM versions (`2.0`–`2.16`); guard passes.
- `python3 -m py_compile` on the script: OK
- `yamllint -c .lint/yamllint/.yamllint.yaml` + pre-commit `yamllint`/`yamlfmt` on the 4 workflows: clean (no reformat)