### PR TITLE
fix(ci): drop removed -a flag from helm list in debug action (Helm 4) [ready]

### DIFF
--- a/.github/actions/internal-debug-failed-pods/action.yml
+++ b/.github/actions/internal-debug-failed-pods/action.yml
@@ -37,7 +37,8 @@ runs:
               echo "::endgroup::"
 
               echo "::group::Helm releases"
-              helm list -n "$NAMESPACE" -a "${CTX_ARGS[@]/#--context=/--kube-context=}" || true
+              # Helm 4 dropped the `-a`/`--all` flag; every status is listed by default.
+              helm list -n "$NAMESPACE" "${CTX_ARGS[@]/#--context=/--kube-context=}" || true
               echo "::endgroup::"
 
               echo "::group::Namespace events (last 50)"
@@ -136,7 +137,7 @@ runs:
               kubectl "${CTX_ARGS[@]}" -n "$NAMESPACE" get svc,endpoints > "${DUMP_DIR}/services-endpoints.txt" 2>&1 || true
               kubectl "${CTX_ARGS[@]}" -n "$NAMESPACE" get pvc > "${DUMP_DIR}/pvcs.txt" 2>&1 || true
               kubectl "${CTX_ARGS[@]}" -n "$NAMESPACE" get configmaps,secrets > "${DUMP_DIR}/configmaps-secrets.txt" 2>&1 || true
-              helm list -n "$NAMESPACE" -a -o yaml "${CTX_ARGS[@]/#--context=/--kube-context=}" > "${DUMP_DIR}/helm-releases.yaml" 2>&1 || true
+              helm list -n "$NAMESPACE" -o yaml "${CTX_ARGS[@]/#--context=/--kube-context=}" > "${DUMP_DIR}/helm-releases.yaml" 2>&1 || true
               helm get values camunda -n "$NAMESPACE" -o yaml "${CTX_ARGS[@]/#--context=/--kube-context=}" > "${DUMP_DIR}/helm-values-camunda.yaml" 2>&1 || true
 
               # Dump info for all non-Completed pods (per container)


### PR DESCRIPTION
## Context

Spotted while triaging two failed scheduled runs (cc @infraex-medic):
- Tests - Integration - AWS Kubernetes EKS Dual Region — [run 27929824736](https://github.com/camunda/camunda-deployment-references/actions/runs/27929824736)
- Tests - Integration - AWS OpenShift ROSA HCP Single Region — [run 27929703824](https://github.com/camunda/camunda-deployment-references/actions/runs/27929703824)

Both failed-pod debug steps logged:

```
##[group]Helm releases
Error: unknown shorthand flag: 'a' in -a
##[endgroup]
```

## Root cause

Helm was bumped to **4.2.0** (#2454). Helm 4 **removed** the `-a` / `--all`
flag from `helm list` — it now lists releases of every status **by default**.
The `internal-debug-failed-pods` action still passes `-a`, so under Helm 4:

```
$ helm list -n camunda -a
Error: unknown shorthand flag: 'a' in -a
```

The calls are `|| true`-guarded, so this does **not** fail the job — but the
"Helm releases" log group and the `helm-releases.yaml` artifact were empty on
**every** failed integration-test run that collects pod debug, losing useful
triage information.

## Fix

Drop `-a` from both `helm list` calls in `internal-debug-failed-pods`
(interactive group + dump). The default Helm 4 output is equivalent to the old
`-a` behaviour.

## Scope / notes

- Debug-only helper; no impact on deployments or test outcomes.
- This is **not** the cause of either scheduled failure (those are the known
  `camunda/camunda#55038` cross-region DNS race for EKS dual-region, and a
  transient gRPC token-validation flake for ROSA HCP) — it only restores their
  debug output.
- Local `pre-commit`: all hooks pass; the Docker-based `update-action-readmes`
  hook was skipped locally (env-bound hang) — it is enforced in CI, and this
  change touches only an embedded `run:` script so the generated README is
  unaffected.