### PR TITLE
test(integration): retry zeebe gRPC connectivity check on transient auth flake [ready]

### DIFF
--- a/.github/actions/internal-camunda-chart-tests/action.yml
+++ b/.github/actions/internal-camunda-chart-tests/action.yml
@@ -596,6 +596,19 @@ runs:
               ZEEBE_CONNECTIVITY_RETRIES="${ZEEBE_CONNECTIVITY_RETRIES:-5}"
               ZEEBE_CONNECTIVITY_RETRY_DELAY="${ZEEBE_CONNECTIVITY_RETRY_DELAY:-15}"
 
+              # Validate the (overridable) tuning knobs up front: retries must be a
+              # positive integer and the delay a non-negative integer. Otherwise the
+              # `[[ ... -ge ... ]]` / `sleep` below would fail mid-loop with a terse
+              # bash error under `set -euo pipefail` that is harder to diagnose.
+              if ! [[ "$ZEEBE_CONNECTIVITY_RETRIES" =~ ^[1-9][0-9]*$ ]]; then
+                  echo "::error::ZEEBE_CONNECTIVITY_RETRIES must be a positive integer (got '$ZEEBE_CONNECTIVITY_RETRIES')."
+                  exit 1
+              fi
+              if ! [[ "$ZEEBE_CONNECTIVITY_RETRY_DELAY" =~ ^[0-9]+$ ]]; then
+                  echo "::error::ZEEBE_CONNECTIVITY_RETRY_DELAY must be a non-negative integer (got '$ZEEBE_CONNECTIVITY_RETRY_DELAY')."
+                  exit 1
+              fi
+
               attempt=1
               while true; do
                   if "$C8_SM_CHECKS_PATH/checks/zeebe/connectivity.sh" \

--- a/.github/actions/internal-camunda-chart-tests/action.yml
+++ b/.github/actions/internal-camunda-chart-tests/action.yml
@@ -585,11 +585,35 @@ runs:
               C8_SM_CHECKS_PATH="${{ inputs.tests-c8-sm-checks-repo-path }}"
               chmod +x "$C8_SM_CHECKS_PATH/checks/zeebe/connectivity.sh"
 
-              "$C8_SM_CHECKS_PATH/checks/zeebe/connectivity.sh" \
-                -H "$ZEEBE_ADDRESS" \
-                -p "$ZEEBE_DEFAULT_VERSION" \
-                -a "$ZEEBE_AUTHORIZATION_SERVER_URL" \
-                -i "$ZEEBE_CLIENT_ID" \
-                -s "$ZEEBE_CLIENT_SECRET" \
-                -u "$ZEEBE_TOKEN_AUDIENCE" \
-                -q grpc
+              # The gRPC probe mints a fresh Keycloak token and calls
+              # Gateway/Topology. Right after deployment the orchestration/Zeebe
+              # gateway can momentarily reject an otherwise valid token
+              # ("Unauthenticated: Invalid bearer token") until its OIDC issuer
+              # signing keys (JWKS) are fetched and cached. Retry the one-shot
+              # check a bounded number of times so this transient propagation
+              # window does not fail the smoke test; a genuine misconfiguration
+              # still fails after the budget is exhausted.
+              ZEEBE_CONNECTIVITY_RETRIES="${ZEEBE_CONNECTIVITY_RETRIES:-5}"
+              ZEEBE_CONNECTIVITY_RETRY_DELAY="${ZEEBE_CONNECTIVITY_RETRY_DELAY:-15}"
+
+              attempt=1
+              while true; do
+                  if "$C8_SM_CHECKS_PATH/checks/zeebe/connectivity.sh" \
+                    -H "$ZEEBE_ADDRESS" \
+                    -p "$ZEEBE_DEFAULT_VERSION" \
+                    -a "$ZEEBE_AUTHORIZATION_SERVER_URL" \
+                    -i "$ZEEBE_CLIENT_ID" \
+                    -s "$ZEEBE_CLIENT_SECRET" \
+                    -u "$ZEEBE_TOKEN_AUDIENCE" \
+                    -q grpc; then
+                      echo "✅ Zeebe gRPC connectivity check passed (attempt ${attempt}/${ZEEBE_CONNECTIVITY_RETRIES})."
+                      break
+                  fi
+                  if [[ "$attempt" -ge "$ZEEBE_CONNECTIVITY_RETRIES" ]]; then
+                      echo "::error::Zeebe gRPC connectivity check failed after ${ZEEBE_CONNECTIVITY_RETRIES} attempt(s)."
+                      exit 1
+                  fi
+                  echo "::warning::Zeebe gRPC connectivity check failed (attempt ${attempt}/${ZEEBE_CONNECTIVITY_RETRIES}); retrying in ${ZEEBE_CONNECTIVITY_RETRY_DELAY}s..."
+                  attempt=$(( attempt + 1 ))
+                  sleep "$ZEEBE_CONNECTIVITY_RETRY_DELAY"
+              done


### PR DESCRIPTION
## Problem

The ROSA HCP scheduled run [27929703824](https://github.com/camunda/camunda-deployment-references/actions/runs/27929703824) failed (cc @infraex-medic) at **🧪 Run C8 SM checks & Zeebe client tests**, on the gRPC leg only (`OpenShift latest / rosa-hcp-single-region / domain`; the `4.18` and `no-domain` legs of the same run passed):

```
[OK] ./.c8-sm-checks/checks/zeebe/token.sh: All test passed.
...
[INFO] Checking gRPC connectivity to zeebe-…apps.rosa…:443
[INFO] Running command: grpcurl -H 'Authorization: ***' -proto gateway.proto … Gateway/Topology
ERROR:
  Code: Unauthenticated
  Message: Invalid bearer token
[FAIL] gRPC connectivity
[FAIL] …/checks/zeebe/connectivity.sh: At least one of the tests failed (error code: 5).
##[error]Process completed with exit code 5.
```

## Root cause

`checks/zeebe/connectivity.sh` mints a **fresh** Keycloak token and immediately calls `Gateway/Topology` as a **single-shot** request. Right after deployment, the orchestration/Zeebe gateway can momentarily reject an otherwise-valid token until its OIDC issuer signing keys (JWKS) are fetched and cached. Evidence it is transient, not a misconfiguration:

- `token.sh` and the token minted *inside* `connectivity.sh` both succeed.
- The earlier **smoke test** and **Go integration tests** (same auth) pass minutes before.
- The `no-domain` and `4.18` legs of the **same** matrix pass.
- This step is historically flaky on schedule.

## Fix

Wrap the one-shot zeebe gRPC check in a **bounded retry** (default 5 attempts, 15 s apart; both overridable via `ZEEBE_CONNECTIVITY_RETRIES` / `ZEEBE_CONNECTIVITY_RETRY_DELAY`). A genuine auth/config error still fails once the budget is exhausted, so real regressions are **not** masked — same philosophy as the REST topology warmup and the gRPC-dial retry in #2721.

## Scope / notes

- Touches only the `🧪 C8-SM-CHECKS - Run Zeebe Connectivity Check` step in `internal-camunda-chart-tests` (used by ROSA HCP single-region, EKS single-region, AKS single-region, generic operator-based tests).
- Different file region than #2721 (kube-connectivity readiness gate); they do not conflict. Complementary connectivity-robustness change.
- Validated locally: `check-yaml` / `yamllint` / `yamlfmt` pass; embedded script passes `bash -n` and `shellcheck`. The Docker `update-action-readmes` hook (env-bound hang) was skipped locally and is enforced in CI; only an embedded `run:` script changed, so the generated README is unaffected.