### PR TITLE
fix(ci): skip CI-events filter view when the sheet has a native table [ready]

### DIFF
--- a/.github/actions/internal-report-event-to-sheet/bootstrap_sheet.py
+++ b/.github/actions/internal-report-event-to-sheet/bootstrap_sheet.py
@@ -575,16 +575,39 @@ def _apply_events_filter(service, spreadsheet_id, events_id):
     # branch / type / date without disturbing others.
     meta = (
         service.spreadsheets()
-        .get(spreadsheetId=spreadsheet_id, fields="sheets(properties.sheetId,filterViews)")
+        .get(
+            spreadsheetId=spreadsheet_id,
+            fields="sheets(properties.sheetId,tables,filterViews)",
+        )
         .execute()
     )
-    requests = []
-    for sheet in meta.get("sheets", []):
-        if sheet["properties"]["sheetId"] != events_id:
-            continue
-        for view in sheet.get("filterViews", []) or []:
-            if view.get("title") == "CI events":
-                requests.append({"deleteFilterView": {"filterId": view["filterViewId"]}})
+    events_sheet = next(
+        (s for s in meta.get("sheets", []) if s["properties"]["sheetId"] == events_id),
+        None,
+    )
+    if events_sheet is None:
+        return
+
+    # Always drop a stale "CI events" view first so repeated bootstraps stay clean.
+    requests = [
+        {"deleteFilterView": {"filterId": view["filterViewId"]}}
+        for view in events_sheet.get("filterViews", []) or []
+        if view.get("title") == "CI events"
+    ]
+
+    # A native Sheets table on the events sheet already provides per-column
+    # filtering, and Sheets rejects a filter view whose range partially
+    # intersects a table ("You can't apply a filter to a range that partially
+    # intersects a table"). When a table is present, just clean up our view and
+    # skip re-adding it rather than failing the step.
+    if events_sheet.get("tables"):
+        if requests:
+            service.spreadsheets().batchUpdate(
+                spreadsheetId=spreadsheet_id, body={"requests": requests}
+            ).execute()
+        print("Events sheet has a native table (own filter); skipped 'CI events' filter view.")
+        return
+
     requests.append(
         {
             "addFilterView": {


### PR DESCRIPTION
## What

Make the CI-events Sheets bootstrap robust when the `events` tab has been converted to a **native Google Sheets table**.

## Why

Re-running the bootstrap (`workflow_dispatch`) failed the filter step with:

```
events filter step failed: addFilterView: You can't apply a filter to a range
that partially intersects a table.
```

If someone converts the `events` data into a native Sheets table (the table then provides its own per-column filtering), Sheets rejects a filter view whose full-column range straddles the table boundary. The step is best-effort so it only warned, but it warned on every run.

## How

`_apply_events_filter` is now table-aware:
- it still drops a stale `CI events` filter view first (idempotent re-bootstrap);
- when the events sheet has a native table, it **skips re-adding** the view (logging why) instead of erroring;
- behaviour is unchanged when no table exists.

## Validation

- `python3 -m py_compile` on the script.
- Unit-stubbed `_apply_events_filter` across the four cases: no-table/no-stale (adds view), no-table/stale (delete+add), table/stale (delete only, **no add**), table/no-stale (no API call). All correct.
- `pre-commit run --files <changed>` clean.

## Context

Follow-up to #2771 (timestamps stored as native date-times), which is already merged. Independent change, same bootstrap script.
