### PR TITLE
[ABANDONED - do not merge] feat(bitnami): add human-readable digest alias next to newDigest

### DIFF
--- a/.github/workflows/internal_bitnami_artifact_image_versions.yml
+++ b/.github/workflows/internal_bitnami_artifact_image_versions.yml
@@ -171,15 +171,16 @@ jobs:
                     fi
 
                     # One self-contained file per image, directly consumable as a Renovate
-                    # custom datasource (format: json): each release carries the version and
-                    # its image digest (newDigest) for optional digest pinning. No timestamp
-                    # is stored, so the file changes only when the tags/digests change (the
-                    # gh-pages commit date conveys freshness).
+                    # custom datasource (format: json): each release carries the version
+                    # and its image digest. "newDigest" is the field Renovate reads for
+                    # digest pinning; "digest" is the same value under a human-readable
+                    # name. No timestamp is stored, so the file changes only when the
+                    # tags/digests change (the gh-pages commit date conveys freshness).
                     jq -Rn \
                       --arg name "${img}" \
                       --arg repo "${ref}" \
                       '{name: $name, repository: $repo,
-                        releases: [inputs | split(" ") | {version: .[0], newDigest: .[1]}]}' \
+                        releases: [inputs | split(" ") | {version: .[0], digest: .[1], newDigest: .[1]}]}' \
                       /tmp/ver_dig > "docs/bitnami_${img}.json"
                   done
 


### PR DESCRIPTION
## What

Each release in `bitnami_<image>.json` now also carries a `digest` field (same value as the Renovate-facing `newDigest`):

```json
{ "version": "18.4.0-debian-12-r9", "digest": "sha256:…", "newDigest": "sha256:…" }
```

## Why

`newDigest` is the field Renovate's `format: json` custom datasource reads, but it reads oddly when a human browses the raw file. `digest` is the same value under a clear name; Renovate keeps using `newDigest`.

## Context

Follow-up to #2765 — this change was pushed to the branch **after** that PR had already merged, so it didn't land in `main`. Without it, the daily scheduled run would regenerate the published files without the `digest` field. (The live gh-pages files already carry it from a manual `workflow_dispatch`; this keeps `main` consistent so the next run doesn't drop it.)