### PR TITLE
test(integration): wait for every Zeebe broker to load its partitions [ready]

### DIFF
--- a/.github/actions/internal-camunda-chart-tests/action.yml
+++ b/.github/actions/internal-camunda-chart-tests/action.yml
@@ -250,6 +250,14 @@ runs:
 
               golden_zeebe_topology_cluster_size=$(jq '.clusterSize' < "$reference_file")
               golden_zeebe_topology_partitions_count=$(jq '.partitionsCount' < "$reference_file")
+              # Total partition replicas the golden topology expects (sum of every
+              # broker's partitions). A broker can join the cluster (so clusterSize
+              # already matches) before it has loaded its partitions, reporting
+              # "partitions": []. That empty broker is invisible to the flattened
+              # health/partitions-count checks below, so without this total the
+              # loop would exit "ready" against a still-converging topology and the
+              # golden-file diff would then flake.
+              golden_zeebe_topology_total_replicas=$(jq '[.brokers[].partitions[]] | length' < "$reference_file")
 
               # The Zeebe cluster can take a while to fully form after the Helm
               # release reports ready. Retry fetching the topology until it
@@ -288,16 +296,19 @@ runs:
                 check_zeebe_topology_all_healthy=$(echo "$check_zeebe_topology_output" | jq -r "$healthy_filter" 2>/dev/null || echo "false")
                 check_zeebe_topology_cluster_size=$(echo "$check_zeebe_topology_output" | jq -r '.clusterSize // empty' 2>/dev/null || echo "")
                 check_zeebe_topology_partitions_count=$(echo "$check_zeebe_topology_output" | jq -r '.partitionsCount // empty' 2>/dev/null || echo "")
+                check_zeebe_topology_total_replicas=$(echo "$check_zeebe_topology_output" | jq -r '[.brokers[]?.partitions[]?] | length' 2>/dev/null || echo "0")
 
                 if [ "$check_zeebe_topology_all_healthy" = "true" ] \
                   && [ "$check_zeebe_topology_cluster_size" = "$golden_zeebe_topology_cluster_size" ] \
-                  && [ "$check_zeebe_topology_partitions_count" = "$golden_zeebe_topology_partitions_count" ]; then
+                  && [ "$check_zeebe_topology_partitions_count" = "$golden_zeebe_topology_partitions_count" ] \
+                  && [ "$check_zeebe_topology_total_replicas" = "$golden_zeebe_topology_total_replicas" ]; then
                   echo "✅ Zeebe topology is ready."
                   break
                 fi
 
                 echo "Topology not ready yet (size='${check_zeebe_topology_cluster_size:-<empty>}'," \
                   "partitions='${check_zeebe_topology_partitions_count:-<empty>}'," \
+                  "replicas='${check_zeebe_topology_total_replicas:-<empty>}'/'${golden_zeebe_topology_total_replicas}'," \
                   "healthy='${check_zeebe_topology_all_healthy}')."
                 # Only sleep when another attempt will follow, to avoid an
                 # unnecessary delay after the final attempt.
@@ -338,6 +349,14 @@ runs:
                 echo "✅ Partitions count is $check_zeebe_topology_partitions_count."
               else
                 echo "❌ Partitions count is not $golden_zeebe_topology_partitions_count (got '${check_zeebe_topology_partitions_count:-<empty>}')."
+                error_found=true
+              fi
+
+              if [[ "$check_zeebe_topology_total_replicas" =~ ^[0-9]+$ ]] && [ "$check_zeebe_topology_total_replicas" -eq "$golden_zeebe_topology_total_replicas" ]; then
+                echo "✅ Partition replicas total is $check_zeebe_topology_total_replicas (every broker loaded its partitions)."
+              else
+                echo "❌ Partition replicas total is not $golden_zeebe_topology_total_replicas" \
+                  "(got '${check_zeebe_topology_total_replicas:-<empty>}'); a broker joined the cluster without loading its partitions."
                 error_found=true
               fi
 

--- a/.github/actions/internal-camunda-chart-tests/action.yml
+++ b/.github/actions/internal-camunda-chart-tests/action.yml
@@ -253,10 +253,11 @@ runs:
               # Total partition replicas the golden topology expects (sum of every
               # broker's partitions). A broker can join the cluster (so clusterSize
               # already matches) before it has loaded its partitions, reporting
-              # "partitions": []. That empty broker is invisible to the flattened
-              # health/partitions-count checks below, so without this total the
-              # loop would exit "ready" against a still-converging topology and the
-              # golden-file diff would then flake.
+              # "partitions": []. That empty broker contributes nothing to the
+              # flattened health check and is still counted by clusterSize, so the
+              # aggregate checks below all pass; without this total the loop would
+              # exit "ready" against a still-converging topology and then flake on
+              # the golden-file diff.
               golden_zeebe_topology_total_replicas=$(jq '[.brokers[].partitions[]] | length' < "$reference_file")
 
               # The Zeebe cluster can take a while to fully form after the Helm
@@ -356,7 +357,8 @@ runs:
                 echo "✅ Partition replicas total is $check_zeebe_topology_total_replicas (every broker loaded its partitions)."
               else
                 echo "❌ Partition replicas total is not $golden_zeebe_topology_total_replicas" \
-                  "(got '${check_zeebe_topology_total_replicas:-<empty>}'); a broker joined the cluster without loading its partitions."
+                  "(got '${check_zeebe_topology_total_replicas:-<empty>}');" \
+                  "topology not fully converged (a broker is missing partitions or the output was incomplete)."
                 error_found=true
               fi
 


### PR DESCRIPTION
## Problem

Recurring flake in the shared Zeebe **topology golden check** (`internal-camunda-chart-tests`), seen on scheduled **stable/8.8 EKS single-region (IRSA) — domain** runs ([run 28061678364](https://github.com/camunda/camunda-deployment-references/actions/runs/28061678364)) and on PR branches (e.g. #2721's EKS-IRSA domain leg):

```
❌ Error: The golden files of zeebe topology files do not match.
```

The live topology when it failed:
```
broker 0 (camunda-zeebe-0): "partitions": []   ← joined but empty, readiness still failing
broker 1 / 2:               partitions 1,2,3 healthy
clusterSize=3, partitionsCount=3
```

## Root cause

The readiness retry loop exits as soon as `all_healthy && clusterSize && partitionsCount` match. `all_healthy` uses a **flattened** filter:

```jq
[.brokers[]?.partitions[]?.health == "healthy"] | (length > 0 and all)
```

A broker that has joined the cluster (so `clusterSize` already = 3) but not yet loaded its partitions contributes **nothing** to that flattened list, so it's invisible: the loop declares "ready" with only 6 of 9 replicas present, and the golden-file diff then mismatches → flaky failure. zeebe-0 here had `Restart Count: 0` and the OIDC wait passed — it was a pure partition-distribution timing gap, not a crash.

## Fix

Also require the **total partition-replica count** (sum across every broker) to equal the golden file's before declaring the topology ready, plus a readable assertion. The loop now keeps retrying until the empty broker has loaded its partitions instead of racing into the golden comparison.

Behaviorally verified: the failing topology (6 replicas) now yields `RETRY`, a full topology (9) yields `READY`.

## Scope

- Touches only the topology readiness loop in `internal-camunda-chart-tests` (used by EKS/AKS/ROSA single-region + operator-based + Kind). No golden files or product changes.
- Backports to follow: stable/8.9, stable/8.8 (same gap exists there).
- Local: `check-yaml` / `yamllint` / `yamlfmt` pass; jq logic behaviorally tested. Docker `update-action-readmes` hook skipped locally (env hang); enforced in CI; only an embedded `run:` script changed so the README is unaffected.