### PR TITLE
[Backport stable/8.8] test(integration): wait for every Zeebe broker to load its partitions [ready]

### DIFF
--- a/.github/actions/internal-camunda-chart-tests/action.yml
+++ b/.github/actions/internal-camunda-chart-tests/action.yml
@@ -458,6 +458,14 @@ runs:
 
               golden_zeebe_topology_cluster_size=$(jq '.clusterSize' < "$reference_file")
               golden_zeebe_topology_partitions_count=$(jq '.partitionsCount' < "$reference_file")
+              # Total partition replicas the golden topology expects (sum of every
+              # broker's partitions). A broker can join the cluster (so clusterSize
+              # already matches) before it has loaded its partitions, reporting
+              # "partitions": []. That empty broker is invisible to the flattened
+              # health/partitions-count checks below, so without this total the
+              # loop would exit "ready" against a still-converging topology and the
+              # golden-file diff would then flake.
+              golden_zeebe_topology_total_replicas=$(jq '[.brokers[].partitions[]] | length' < "$reference_file")
 
               # The Zeebe cluster can take a while to fully form after the Helm
               # release reports ready. Retry fetching the topology until it
@@ -496,16 +504,19 @@ runs:
                 check_zeebe_topology_all_healthy=$(echo "$check_zeebe_topology_output" | jq -r "$healthy_filter" 2>/dev/null || echo "false")
                 check_zeebe_topology_cluster_size=$(echo "$check_zeebe_topology_output" | jq -r '.clusterSize // empty' 2>/dev/null || echo "")
                 check_zeebe_topology_partitions_count=$(echo "$check_zeebe_topology_output" | jq -r '.partitionsCount // empty' 2>/dev/null || echo "")
+                check_zeebe_topology_total_replicas=$(echo "$check_zeebe_topology_output" | jq -r '[.brokers[]?.partitions[]?] | length' 2>/dev/null || echo "0")
 
                 if [ "$check_zeebe_topology_all_healthy" = "true" ] \
                   && [ "$check_zeebe_topology_cluster_size" = "$golden_zeebe_topology_cluster_size" ] \
-                  && [ "$check_zeebe_topology_partitions_count" = "$golden_zeebe_topology_partitions_count" ]; then
+                  && [ "$check_zeebe_topology_partitions_count" = "$golden_zeebe_topology_partitions_count" ] \
+                  && [ "$check_zeebe_topology_total_replicas" = "$golden_zeebe_topology_total_replicas" ]; then
                   echo "✅ Zeebe topology is ready."
                   break
                 fi
 
                 echo "Topology not ready yet (size='${check_zeebe_topology_cluster_size:-<empty>}'," \
                   "partitions='${check_zeebe_topology_partitions_count:-<empty>}'," \
+                  "replicas='${check_zeebe_topology_total_replicas:-<empty>}'/'${golden_zeebe_topology_total_replicas}'," \
                   "healthy='${check_zeebe_topology_all_healthy}')."
                 # Only sleep when another attempt will follow, to avoid an
                 # unnecessary delay after the final attempt.
@@ -546,6 +557,14 @@ runs:
                 echo "✅ Partitions count is $check_zeebe_topology_partitions_count."
               else
                 echo "❌ Partitions count is not $golden_zeebe_topology_partitions_count (got '${check_zeebe_topology_partitions_count:-<empty>}')."
+                error_found=true
+              fi
+
+              if [[ "$check_zeebe_topology_total_replicas" =~ ^[0-9]+$ ]] && [ "$check_zeebe_topology_total_replicas" -eq "$golden_zeebe_topology_total_replicas" ]; then
+                echo "✅ Partition replicas total is $check_zeebe_topology_total_replicas (every broker loaded its partitions)."
+              else
+                echo "❌ Partition replicas total is not $golden_zeebe_topology_total_replicas" \
+                  "(got '${check_zeebe_topology_total_replicas:-<empty>}'); a broker joined the cluster without loading its partitions."
                 error_found=true
               fi
 

--- a/.github/actions/internal-camunda-chart-tests/action.yml
+++ b/.github/actions/internal-camunda-chart-tests/action.yml
@@ -461,10 +461,11 @@ runs:
               # Total partition replicas the golden topology expects (sum of every
               # broker's partitions). A broker can join the cluster (so clusterSize
               # already matches) before it has loaded its partitions, reporting
-              # "partitions": []. That empty broker is invisible to the flattened
-              # health/partitions-count checks below, so without this total the
-              # loop would exit "ready" against a still-converging topology and the
-              # golden-file diff would then flake.
+              # "partitions": []. That empty broker contributes nothing to the
+              # flattened health check and is still counted by clusterSize, so the
+              # aggregate checks below all pass; without this total the loop would
+              # exit "ready" against a still-converging topology and then flake on
+              # the golden-file diff.
               golden_zeebe_topology_total_replicas=$(jq '[.brokers[].partitions[]] | length' < "$reference_file")
 
               # The Zeebe cluster can take a while to fully form after the Helm
@@ -564,7 +565,8 @@ runs:
                 echo "✅ Partition replicas total is $check_zeebe_topology_total_replicas (every broker loaded its partitions)."
               else
                 echo "❌ Partition replicas total is not $golden_zeebe_topology_total_replicas" \
-                  "(got '${check_zeebe_topology_total_replicas:-<empty>}'); a broker joined the cluster without loading its partitions."
+                  "(got '${check_zeebe_topology_total_replicas:-<empty>}');" \
+                  "topology not fully converged (a broker is missing partitions or the output was incomplete)."
                 error_found=true
               fi
 


### PR DESCRIPTION
Backport of #2778 to stable/8.8 — this is the branch the flake was actually reported on ([run 28061678364](https://github.com/camunda/camunda-deployment-references/actions/runs/28061678364), scheduled EKS single-region IRSA / domain).

Same gap here: the topology readiness loop exits on the flattened `all_healthy` + clusterSize + partitionsCount, so a broker reporting `"partitions": []` slips through and the golden diff flakes. Require the total partition-replica count to match the golden file before declaring ready, plus a readable assertion.

Cherry-picked cleanly from main (`bb86e53d`). See #2778 for full analysis.