### PR TITLE
test(integration): warm up component-API reachability probes for startup 5xx [ready]

### DIFF
--- a/generic/kubernetes/single-region/tests/integration/core/component_apis_test.go
+++ b/generic/kubernetes/single-region/tests/integration/core/component_apis_test.go
@@ -12,13 +12,15 @@ import (
 )
 
 // componentReadyTimeout is the minimum time the component reachability probes
-// keep retrying a transient 5xx before giving up. Satellite components (reached
-// via the ingress) can briefly return 5xx while they finish starting — even
-// after their readiness probe is green — until the orchestration's domain-mode
-// OIDC startup settles. (Observed on a ROSA HCP domain run: a component's API
-// returned 500 for ~45s, just past the short cfg.RetryAttempts budget.) A
-// larger configured cfg.RetryAttempts/cfg.RetryDelay still wins; either way the
-// probe stays finite and fails a component that never becomes reachable.
+// keep retrying before giving up. The loop retries on any status outside the
+// per-case acceptCodes; satellite components (reached via the ingress) can
+// briefly return such a status — typically a 5xx — while they finish starting,
+// even after their readiness probe is green, until the orchestration's
+// domain-mode OIDC startup settles. (Observed on a ROSA HCP domain run: a
+// component's API returned 500 for ~45s, past the short cfg.RetryAttempts
+// budget.) A larger configured cfg.RetryAttempts/cfg.RetryDelay still wins;
+// either way the probe stays finite and fails a component that never becomes
+// reachable.
 const componentReadyTimeout = 3 * time.Minute
 
 // TestComponentAPIs verifies the authenticated API endpoints exposed by the
@@ -87,12 +89,19 @@ func TestComponentAPIs(t *testing.T) {
 				t.Skipf("%s URL not configured", tc.name)
 			}
 			fullURL := tc.url + tc.path
-			// Reachability probes: warm up for at least componentReadyTimeout
-			// to absorb a component's transient startup 5xx, taking the larger
-			// of that and the configured per-request budget.
+			// Reachability probe: warm up for at least componentReadyTimeout to
+			// absorb a component's transient startup errors, taking the larger of
+			// that and the configured per-request budget. The window is the
+			// (readyAttempts-1) sleeps between attempts, so round the division up
+			// so it is never shorter than componentReadyTimeout.
 			readyAttempts := cfg.RetryAttempts
 			if cfg.RetryDelay > 0 {
-				if want := int(componentReadyTimeout/cfg.RetryDelay) + 1; readyAttempts < want {
+				want := int(componentReadyTimeout / cfg.RetryDelay)
+				if componentReadyTimeout%cfg.RetryDelay != 0 {
+					want++
+				}
+				want++ // the first attempt has no preceding sleep
+				if readyAttempts < want {
 					readyAttempts = want
 				}
 			}

--- a/generic/kubernetes/single-region/tests/integration/core/component_apis_test.go
+++ b/generic/kubernetes/single-region/tests/integration/core/component_apis_test.go
@@ -11,20 +11,20 @@ import (
 	"github.com/camunda/camunda-deployment-references/tests/integration/helpers"
 )
 
-// componentReadyTimeout is the minimum time the component reachability probes
-// keep retrying before giving up. The loop retries on any status outside the
-// per-case acceptCodes; satellite components (reached via the ingress) can
-// briefly return such a status — typically a 5xx — while they finish starting,
-// even after their readiness probe is green, until the orchestration's
-// domain-mode OIDC startup settles. (Observed on a ROSA HCP domain run: a
-// component's API returned 500 for ~45s, past the short cfg.RetryAttempts
-// budget.) A larger configured cfg.RetryAttempts/cfg.RetryDelay still wins;
-// either way the probe stays finite and fails a component that never becomes
-// reachable.
-const componentReadyTimeout = 3 * time.Minute
+// componentReadyTimeout is the target warm-up window for the component
+// reachability probes when a positive cfg.RetryDelay is configured. The loop
+// retries on any status outside the per-case acceptCodes; satellite components
+// (reached via the ingress) can briefly return such a status — typically a 5xx
+// — while they finish starting, even after their readiness probe is green,
+// until the orchestration's domain-mode OIDC startup settles. (Observed on a
+// ROSA HCP domain run: a component's API returned 500 for ~45s, past the short
+// cfg.RetryAttempts budget.) Transient startup errors answer quickly, so a
+// probe rarely costs the whole window; a larger configured cfg.RetryAttempts /
+// cfg.RetryDelay still wins, and the probe stays finite either way.
+const componentReadyTimeout = 2 * time.Minute
 
 // TestComponentAPIs verifies the authenticated API endpoints exposed by the
-// satellite components (Console, Identity, Connectors). Mirrors the venom
+// satellite components reachable through the ingress. Mirrors the venom
 // "TEST - Interacting with Web API" suite.
 //
 // Each sub-test is skipped when the corresponding component is disabled or
@@ -89,11 +89,11 @@ func TestComponentAPIs(t *testing.T) {
 				t.Skipf("%s URL not configured", tc.name)
 			}
 			fullURL := tc.url + tc.path
-			// Reachability probe: warm up for at least componentReadyTimeout to
-			// absorb a component's transient startup errors, taking the larger of
-			// that and the configured per-request budget. The window is the
-			// (readyAttempts-1) sleeps between attempts, so round the division up
-			// so it is never shorter than componentReadyTimeout.
+			// Reachability probe: with a positive retry delay, warm up for at
+			// least componentReadyTimeout (rounding the attempt count up so the
+			// inter-attempt sleeps cover it), taking the larger of that and the
+			// configured per-request budget. With cfg.RetryDelay <= 0 the retries
+			// are back-to-back, so only the configured count applies.
 			readyAttempts := cfg.RetryAttempts
 			if cfg.RetryDelay > 0 {
 				want := int(componentReadyTimeout / cfg.RetryDelay)

--- a/generic/kubernetes/single-region/tests/integration/core/component_apis_test.go
+++ b/generic/kubernetes/single-region/tests/integration/core/component_apis_test.go
@@ -11,12 +11,14 @@ import (
 	"github.com/camunda/camunda-deployment-references/tests/integration/helpers"
 )
 
-// componentReadyTimeout bounds how long the component reachability probes keep
-// retrying a transient 5xx. Satellite components (reached via the ingress) can
-// briefly return 5xx while they finish starting — even after their readiness
-// probe is green — until the orchestration's domain-mode OIDC startup settles.
-// (Observed: Identity's /api/users returned 500 for ~45s on a ROSA HCP domain
-// run.) Bounded so a component that stays unreachable past it still fails.
+// componentReadyTimeout is the minimum time the component reachability probes
+// keep retrying a transient 5xx before giving up. Satellite components (reached
+// via the ingress) can briefly return 5xx while they finish starting — even
+// after their readiness probe is green — until the orchestration's domain-mode
+// OIDC startup settles. (Observed on a ROSA HCP domain run: a component's API
+// returned 500 for ~45s, just past the short cfg.RetryAttempts budget.) A
+// larger configured cfg.RetryAttempts/cfg.RetryDelay still wins; either way the
+// probe stays finite and fails a component that never becomes reachable.
 const componentReadyTimeout = 3 * time.Minute
 
 // TestComponentAPIs verifies the authenticated API endpoints exposed by the
@@ -85,9 +87,9 @@ func TestComponentAPIs(t *testing.T) {
 				t.Skipf("%s URL not configured", tc.name)
 			}
 			fullURL := tc.url + tc.path
-			// These are reachability probes, so allow a longer bounded warm-up
-			// than the short per-request cfg.RetryAttempts to absorb a
-			// component's transient startup 5xx (see componentReadyTimeout).
+			// Reachability probes: warm up for at least componentReadyTimeout
+			// to absorb a component's transient startup 5xx, taking the larger
+			// of that and the configured per-request budget.
 			readyAttempts := cfg.RetryAttempts
 			if cfg.RetryDelay > 0 {
 				if want := int(componentReadyTimeout/cfg.RetryDelay) + 1; readyAttempts < want {

--- a/generic/kubernetes/single-region/tests/integration/core/component_apis_test.go
+++ b/generic/kubernetes/single-region/tests/integration/core/component_apis_test.go
@@ -10,16 +10,20 @@ import (
 )
 
 // componentReadyTimeout bounds, in wall-clock time, how long a component
-// reachability probe keeps retrying. Satellite components (reached via the
-// ingress) can briefly return a status outside the per-case acceptCodes —
-// typically a 5xx — while they finish starting, even after their readiness
-// probe is green, until the orchestration's domain-mode OIDC startup settles.
-// (Observed on a ROSA HCP domain run: a component's API returned 500 for ~45s,
-// past the short cfg.RetryAttempts budget.) The bound is wall-clock — not an
-// attempt count — so a hung component cannot stretch the run by cfg.HTTPTimeout
-// per try; transient startup errors answer quickly, so a probe usually settles
-// well under it.
-const componentReadyTimeout = 90 * time.Second
+// reachability probe keeps retrying; componentReadyPollInterval is the wait
+// between tries. Satellite components (reached via the ingress) can briefly
+// return a status outside the per-case acceptCodes — typically a 5xx — while
+// they finish starting, even after their readiness probe is green, until the
+// orchestration's domain-mode OIDC startup settles. (Observed on a ROSA HCP
+// domain run: a component's API returned 500 for ~45s, past the short
+// cfg.RetryAttempts budget.) The probe stops at the deadline plus at most one
+// in-flight request — however many tries fit in between — so a slow or hung
+// component cannot stretch the run open-endedly; transient startup errors answer
+// quickly, so a healthy probe settles well under the window.
+const (
+	componentReadyTimeout      = 90 * time.Second
+	componentReadyPollInterval = 5 * time.Second
+)
 
 // TestComponentAPIs verifies the authenticated API endpoints exposed by the
 // satellite components reachable through the ingress. Mirrors the venom
@@ -100,14 +104,22 @@ func TestComponentAPIs(t *testing.T) {
 				}
 				return fmt.Errorf("GET %s: unexpected status %d (accepted: %v)", fullURL, resp.StatusCode, tc.acceptCodes)
 			}
-			// Retry until the component answers an accepted status or
-			// componentReadyTimeout of wall-clock elapses, sleeping cfg.RetryDelay
-			// between tries, to absorb a transient startup status (see
-			// componentReadyTimeout).
+			// Retry the reachability probe until it returns an accepted status or
+			// componentReadyTimeout of wall-clock elapses, waiting
+			// componentReadyPollInterval between tries (clamped so a sleep never
+			// runs past the deadline). See the consts for the rationale.
 			deadline := time.Now().Add(componentReadyTimeout)
 			err := probe()
-			for err != nil && time.Now().Before(deadline) {
-				time.Sleep(cfg.RetryDelay)
+			for err != nil {
+				remaining := time.Until(deadline)
+				if remaining <= 0 {
+					break
+				}
+				sleep := componentReadyPollInterval
+				if sleep > remaining {
+					sleep = remaining
+				}
+				time.Sleep(sleep)
 				err = probe()
 			}
 			assert.NoError(t, err, "%s API endpoint %s should be reachable", tc.name, tc.path)

--- a/generic/kubernetes/single-region/tests/integration/core/component_apis_test.go
+++ b/generic/kubernetes/single-region/tests/integration/core/component_apis_test.go
@@ -7,21 +7,19 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-
-	"github.com/camunda/camunda-deployment-references/tests/integration/helpers"
 )
 
-// componentReadyTimeout is the target warm-up window for the component
-// reachability probes when a positive cfg.RetryDelay is configured. The loop
-// retries on any status outside the per-case acceptCodes; satellite components
-// (reached via the ingress) can briefly return such a status — typically a 5xx
-// — while they finish starting, even after their readiness probe is green,
-// until the orchestration's domain-mode OIDC startup settles. (Observed on a
-// ROSA HCP domain run: a component's API returned 500 for ~45s, past the short
-// cfg.RetryAttempts budget.) Transient startup errors answer quickly, so a
-// probe rarely costs the whole window; a larger configured cfg.RetryAttempts /
-// cfg.RetryDelay still wins, and the probe stays finite either way.
-const componentReadyTimeout = 2 * time.Minute
+// componentReadyTimeout bounds, in wall-clock time, how long a component
+// reachability probe keeps retrying. Satellite components (reached via the
+// ingress) can briefly return a status outside the per-case acceptCodes —
+// typically a 5xx — while they finish starting, even after their readiness
+// probe is green, until the orchestration's domain-mode OIDC startup settles.
+// (Observed on a ROSA HCP domain run: a component's API returned 500 for ~45s,
+// past the short cfg.RetryAttempts budget.) The bound is wall-clock — not an
+// attempt count — so a hung component cannot stretch the run by cfg.HTTPTimeout
+// per try; transient startup errors answer quickly, so a probe usually settles
+// well under it.
+const componentReadyTimeout = 90 * time.Second
 
 // TestComponentAPIs verifies the authenticated API endpoints exposed by the
 // satellite components reachable through the ingress. Mirrors the venom
@@ -89,23 +87,7 @@ func TestComponentAPIs(t *testing.T) {
 				t.Skipf("%s URL not configured", tc.name)
 			}
 			fullURL := tc.url + tc.path
-			// Reachability probe: with a positive retry delay, warm up for at
-			// least componentReadyTimeout (rounding the attempt count up so the
-			// inter-attempt sleeps cover it), taking the larger of that and the
-			// configured per-request budget. With cfg.RetryDelay <= 0 the retries
-			// are back-to-back, so only the configured count applies.
-			readyAttempts := cfg.RetryAttempts
-			if cfg.RetryDelay > 0 {
-				want := int(componentReadyTimeout / cfg.RetryDelay)
-				if componentReadyTimeout%cfg.RetryDelay != 0 {
-					want++
-				}
-				want++ // the first attempt has no preceding sleep
-				if readyAttempts < want {
-					readyAttempts = want
-				}
-			}
-			err := helpers.Retry(readyAttempts, cfg.RetryDelay, func() error {
+			probe := func() error {
 				resp, err := client.Get(fullURL)
 				if err != nil {
 					return fmt.Errorf("GET %s failed: %w", fullURL, err)
@@ -117,7 +99,17 @@ func TestComponentAPIs(t *testing.T) {
 					}
 				}
 				return fmt.Errorf("GET %s: unexpected status %d (accepted: %v)", fullURL, resp.StatusCode, tc.acceptCodes)
-			})
+			}
+			// Retry until the component answers an accepted status or
+			// componentReadyTimeout of wall-clock elapses, sleeping cfg.RetryDelay
+			// between tries, to absorb a transient startup status (see
+			// componentReadyTimeout).
+			deadline := time.Now().Add(componentReadyTimeout)
+			err := probe()
+			for err != nil && time.Now().Before(deadline) {
+				time.Sleep(cfg.RetryDelay)
+				err = probe()
+			}
 			assert.NoError(t, err, "%s API endpoint %s should be reachable", tc.name, tc.path)
 		})
 	}

--- a/generic/kubernetes/single-region/tests/integration/core/component_apis_test.go
+++ b/generic/kubernetes/single-region/tests/integration/core/component_apis_test.go
@@ -4,11 +4,20 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/camunda/camunda-deployment-references/tests/integration/helpers"
 )
+
+// componentReadyTimeout bounds how long the component reachability probes keep
+// retrying a transient 5xx. Satellite components (reached via the ingress) can
+// briefly return 5xx while they finish starting — even after their readiness
+// probe is green — until the orchestration's domain-mode OIDC startup settles.
+// (Observed: Identity's /api/users returned 500 for ~45s on a ROSA HCP domain
+// run.) Bounded so a component that stays unreachable past it still fails.
+const componentReadyTimeout = 3 * time.Minute
 
 // TestComponentAPIs verifies the authenticated API endpoints exposed by the
 // satellite components (Console, Identity, Connectors). Mirrors the venom
@@ -76,7 +85,16 @@ func TestComponentAPIs(t *testing.T) {
 				t.Skipf("%s URL not configured", tc.name)
 			}
 			fullURL := tc.url + tc.path
-			err := helpers.Retry(cfg.RetryAttempts, cfg.RetryDelay, func() error {
+			// These are reachability probes, so allow a longer bounded warm-up
+			// than the short per-request cfg.RetryAttempts to absorb a
+			// component's transient startup 5xx (see componentReadyTimeout).
+			readyAttempts := cfg.RetryAttempts
+			if cfg.RetryDelay > 0 {
+				if want := int(componentReadyTimeout/cfg.RetryDelay) + 1; readyAttempts < want {
+					readyAttempts = want
+				}
+			}
+			err := helpers.Retry(readyAttempts, cfg.RetryDelay, func() error {
 				resp, err := client.Get(fullURL)
 				if err != nil {
 					return fmt.Errorf("GET %s failed: %w", fullURL, err)


### PR DESCRIPTION
Backport of #2784 to stable/8.9 — this is the branch the flake was reported on ([run 28134151780](https://github.com/camunda/camunda-deployment-references/actions/runs/28134151780), scheduled ROSA HCP single-region / domain).

Gives the satellite component reachability probes (Console/Identity/Connectors) a bounded ~90s warm-up so a transient startup 5xx (Identity `/api/users` 500'd ~45s past the 5×10s budget) is absorbed, while a component still unreachable past the budget fails. Cherry-picked cleanly from main (`7ad31b92`). See #2784 for full analysis.

Note: not applicable to stable/8.8 — the Go integration test suite (`tests/integration/core`) does not exist there.