### PR TITLE
fix(dual-region): widen cross-region SWIM membership timeouts (align with ECS)

### DIFF
--- a/aws/kubernetes/eks-dual-region/helm-values/camunda-values.yml
+++ b/aws/kubernetes/eks-dual-region/helm-values/camunda-values.yml
@@ -94,10 +94,18 @@ orchestration:
         # Zeebe cluster tuning
         - name: CAMUNDA_DATA_SNAPSHOTPERIOD
           value: 5m
+        # Cross-region SWIM membership tuning for stretched clusters (London <-> Paris
+        # over VPN/transit-gateway). The default probe timeout (100ms) is too tight for
+        # cross-region latency: on a cold start brokers transiently see peers in the
+        # other region as unreachable, SWIM ejects them, membership churns, and brokers
+        # flap 1/1<->0/1 so the topology never converges within the test window. Matches
+        # the proven aws/containers/ecs-dual-region-fargate tuning (Transit Gateway).
         - name: CAMUNDA_CLUSTER_MEMBERSHIP_PROBETIMEOUT
-          value: 500ms
+          value: 1000ms
         - name: CAMUNDA_CLUSTER_MEMBERSHIP_PROBEINTERVAL
           value: 2s
+        - name: CAMUNDA_CLUSTER_MEMBERSHIP_FAILURETIMEOUT
+          value: 10000ms
         - name: CAMUNDA_CLUSTER_RAFT_SNAPSHOTREQUESTTIMEOUT
           value: 10s
         - name: CAMUNDA_CLUSTER_COMPRESSIONALGORITHM

--- a/aws/kubernetes/eks-dual-region/helm-values/camunda-values.yml
+++ b/aws/kubernetes/eks-dual-region/helm-values/camunda-values.yml
@@ -98,8 +98,7 @@ orchestration:
         # over VPN/transit-gateway). The default probe timeout (100ms) is too tight for
         # cross-region latency: on a cold start brokers transiently see peers in the
         # other region as unreachable, SWIM ejects them, membership churns, and brokers
-        # flap 1/1<->0/1 so the topology never converges within the test window. Matches
-        # the proven aws/containers/ecs-dual-region-fargate tuning (Transit Gateway).
+        # flap 1/1<->0/1 so the topology never converges within the test window.
         - name: CAMUNDA_CLUSTER_MEMBERSHIP_PROBETIMEOUT
           value: 1000ms
         - name: CAMUNDA_CLUSTER_MEMBERSHIP_PROBEINTERVAL

--- a/generic/openshift/dual-region/helm-values/values-base.yml
+++ b/generic/openshift/dual-region/helm-values/values-base.yml
@@ -91,8 +91,7 @@ orchestration:
         # Cross-region SWIM membership tuning for stretched clusters. The default probe
         # timeout (100ms) is too tight for cross-region latency: on a cold start brokers
         # transiently see peers in the other region as unreachable, SWIM ejects them,
-        # membership churns, and brokers flap so the topology never converges. Matches
-        # the proven aws/containers/ecs-dual-region-fargate tuning.
+        # membership churns, and brokers flap so the topology never converges.
         - name: CAMUNDA_CLUSTER_MEMBERSHIP_PROBETIMEOUT
           value: 1000ms
         - name: CAMUNDA_CLUSTER_MEMBERSHIP_PROBEINTERVAL

--- a/generic/openshift/dual-region/helm-values/values-base.yml
+++ b/generic/openshift/dual-region/helm-values/values-base.yml
@@ -88,10 +88,17 @@ orchestration:
         # Zeebe cluster tuning
         - name: CAMUNDA_DATA_SNAPSHOTPERIOD
           value: 5m
+        # Cross-region SWIM membership tuning for stretched clusters. The default probe
+        # timeout (100ms) is too tight for cross-region latency: on a cold start brokers
+        # transiently see peers in the other region as unreachable, SWIM ejects them,
+        # membership churns, and brokers flap so the topology never converges. Matches
+        # the proven aws/containers/ecs-dual-region-fargate tuning.
         - name: CAMUNDA_CLUSTER_MEMBERSHIP_PROBETIMEOUT
-          value: 500ms
+          value: 1000ms
         - name: CAMUNDA_CLUSTER_MEMBERSHIP_PROBEINTERVAL
           value: 2s
+        - name: CAMUNDA_CLUSTER_MEMBERSHIP_FAILURETIMEOUT
+          value: 10000ms
         - name: CAMUNDA_CLUSTER_RAFT_SNAPSHOTREQUESTTIMEOUT
           value: 10s
         - name: CAMUNDA_CLUSTER_COMPRESSIONALGORITHM


### PR DESCRIPTION
## What

Widen the cross-region SWIM membership timeouts for the **dual-region** Camunda deployments so a cold-started, region-stretched broker cluster converges instead of flapping.

- `aws/kubernetes/eks-dual-region`: `CAMUNDA_CLUSTER_MEMBERSHIP_PROBETIMEOUT` `500ms` → **`1000ms`**, add `CAMUNDA_CLUSTER_MEMBERSHIP_FAILURETIMEOUT=10000ms`.
- `generic/openshift/dual-region`: same change (consistency — same stretched-cluster architecture).

## Why

The **AWS EKS Dual Region** integration test (run `28134151776`, 8.9 schedule) failed with the 8-broker cluster never converging: brokers in one region transiently saw peers in the other as unreachable, SWIM marked them suspect/dead, membership churned, and pods flapped `1/1`↔`0/1`. Errors: `MessagingException$ConnectionClosed … closed unexpectedly`, `ConnectException: Connection refused`, and `atomix-membership-probe … timed out in PT0.1S` (the default 100 ms probe budget — too tight for the inter-region hop). The test client's gRPC to the gateway then hit `DEADLINE_EXCEEDED`. A post-mortem connectivity probe showed the cross-cluster port **open** — i.e. the cluster *does* converge, it just churns past the test window.

`aws/containers/ecs-dual-region-fargate` already solved the identical problem and documents it: *"Increase SWIM probe timeout for cross-region latency (default 100ms is too tight for Transit Gateway)"* → `ZEEBE_BROKER_CLUSTER_MEMBERSHIP_PROBETIMEOUT=1000ms`, `FAILURETIMEOUT=10000ms`. This PR brings the EKS and OpenShift dual-region values in line with that proven tuning.

## Not this

Distinct from `camunda/camunda#55038` (the cross-region **DNS** startup hang). Here the names resolve; the problem is membership *convergence* under cross-region latency.

## Validation

Deploy-layer tuning only; cannot be reproduced locally without a real cross-region cluster — needs the dual-region CI to validate.

## Backports

Follow-ups: `stable/8.9` (EKS + OpenShift), `stable/8.8` and `stable/8.7` (OpenShift only — pre-8.9 uses the `ZEEBE_BROKER_*` prefix and a separate gateway membership block).