### PR TITLE
[Backport stable/8.9] fix(dual-region): widen cross-region SWIM membership timeouts (align with ECS)

### DIFF
--- a/aws/kubernetes/eks-dual-region/helm-values/camunda-values.yml
+++ b/aws/kubernetes/eks-dual-region/helm-values/camunda-values.yml
@@ -101,8 +101,7 @@ orchestration:
         # over VPN/transit-gateway). The default probe timeout (100ms) is too tight for
         # cross-region latency: on a cold start brokers transiently see peers in the
         # other region as unreachable, SWIM ejects them, membership churns, and brokers
-        # flap 1/1<->0/1 so the topology never converges within the test window. Matches
-        # the proven aws/containers/ecs-dual-region-fargate tuning (Transit Gateway).
+        # flap 1/1<->0/1 so the topology never converges within the test window.
         - name: CAMUNDA_CLUSTER_MEMBERSHIP_PROBETIMEOUT
           value: 1000ms
         - name: CAMUNDA_CLUSTER_MEMBERSHIP_PROBEINTERVAL

--- a/aws/kubernetes/eks-dual-region/helm-values/camunda-values.yml
+++ b/aws/kubernetes/eks-dual-region/helm-values/camunda-values.yml
@@ -97,10 +97,18 @@ orchestration:
         # Zeebe cluster tuning
         - name: CAMUNDA_DATA_SNAPSHOTPERIOD
           value: 5m
+        # Cross-region SWIM membership tuning for stretched clusters (London <-> Paris
+        # over VPN/transit-gateway). The default probe timeout (100ms) is too tight for
+        # cross-region latency: on a cold start brokers transiently see peers in the
+        # other region as unreachable, SWIM ejects them, membership churns, and brokers
+        # flap 1/1<->0/1 so the topology never converges within the test window. Matches
+        # the proven aws/containers/ecs-dual-region-fargate tuning (Transit Gateway).
         - name: CAMUNDA_CLUSTER_MEMBERSHIP_PROBETIMEOUT
-          value: 500ms
+          value: 1000ms
         - name: CAMUNDA_CLUSTER_MEMBERSHIP_PROBEINTERVAL
           value: 2s
+        - name: CAMUNDA_CLUSTER_MEMBERSHIP_FAILURETIMEOUT
+          value: 10000ms
         - name: CAMUNDA_CLUSTER_RAFT_SNAPSHOTREQUESTTIMEOUT
           value: 10s
         - name: CAMUNDA_CLUSTER_COMPRESSIONALGORITHM

--- a/generic/openshift/dual-region/helm-values/values-base.yml
+++ b/generic/openshift/dual-region/helm-values/values-base.yml
@@ -91,8 +91,7 @@ orchestration:
         # Cross-region SWIM membership tuning for stretched clusters. The default probe
         # timeout (100ms) is too tight for cross-region latency: on a cold start brokers
         # transiently see peers in the other region as unreachable, SWIM ejects them,
-        # membership churns, and brokers flap so the topology never converges. Matches
-        # the proven aws/containers/ecs-dual-region-fargate tuning.
+        # membership churns, and brokers flap so the topology never converges.
         - name: CAMUNDA_CLUSTER_MEMBERSHIP_PROBETIMEOUT
           value: 1000ms
         - name: CAMUNDA_CLUSTER_MEMBERSHIP_PROBEINTERVAL

--- a/generic/openshift/dual-region/helm-values/values-base.yml
+++ b/generic/openshift/dual-region/helm-values/values-base.yml
@@ -88,10 +88,17 @@ orchestration:
         # Zeebe cluster tuning
         - name: CAMUNDA_DATA_SNAPSHOTPERIOD
           value: 5m
+        # Cross-region SWIM membership tuning for stretched clusters. The default probe
+        # timeout (100ms) is too tight for cross-region latency: on a cold start brokers
+        # transiently see peers in the other region as unreachable, SWIM ejects them,
+        # membership churns, and brokers flap so the topology never converges. Matches
+        # the proven aws/containers/ecs-dual-region-fargate tuning.
         - name: CAMUNDA_CLUSTER_MEMBERSHIP_PROBETIMEOUT
-          value: 500ms
+          value: 1000ms
         - name: CAMUNDA_CLUSTER_MEMBERSHIP_PROBEINTERVAL
           value: 2s
+        - name: CAMUNDA_CLUSTER_MEMBERSHIP_FAILURETIMEOUT
+          value: 10000ms
         - name: CAMUNDA_CLUSTER_RAFT_SNAPSHOTREQUESTTIMEOUT
           value: 10s
         - name: CAMUNDA_CLUSTER_COMPRESSIONALGORITHM


### PR DESCRIPTION
Backport of #2786 to `stable/8.9`.

Same change (8.9 uses the `CAMUNDA_CLUSTER_MEMBERSHIP_*` prefix): on EKS + OpenShift dual-region, `PROBETIMEOUT` 500ms → 1000ms and add `FAILURETIMEOUT=10000ms`, matching the proven `aws/containers/ecs-dual-region-fargate` cross-region tuning. Addresses the membership flapping seen in EKS Dual Region run 28134151776 (distinct from camunda/camunda#55038). Needs dual-region CI to validate.