### PR TITLE
[Backport stable/8.8] fix(openshift-dual-region): widen cross-region SWIM membership timeouts (align with ECS)

### DIFF
--- a/generic/openshift/dual-region/helm-values/values-base.yml
+++ b/generic/openshift/dual-region/helm-values/values-base.yml
@@ -60,10 +60,17 @@ orchestration:
         # Zeebe cluster tuning
         - name: CAMUNDA_DATA_SNAPSHOTPERIOD
           value: 5m
+        # Cross-region SWIM membership tuning for stretched clusters. The default probe
+        # timeout (100ms) is too tight for cross-region latency: on a cold start brokers
+        # transiently see peers in the other region as unreachable, SWIM ejects them,
+        # membership churns, and brokers flap so the topology never converges. Matches
+        # the proven aws/containers/ecs-dual-region-fargate tuning.
         - name: ZEEBE_BROKER_CLUSTER_MEMBERSHIP_PROBETIMEOUT
-          value: 500ms
+          value: 1000ms
         - name: ZEEBE_BROKER_CLUSTER_MEMBERSHIP_PROBEINTERVAL
           value: 2s
+        - name: ZEEBE_BROKER_CLUSTER_MEMBERSHIP_FAILURETIMEOUT
+          value: 10000ms
         - name: ZEEBE_BROKER_EXPERIMENTAL_RAFT_SNAPSHOTREQUESTTIMEOUT
           value: 10s
         - name: ZEEBE_BROKER_CLUSTER_MESSAGECOMPRESSION
@@ -75,9 +82,11 @@ orchestration:
         - name: ZEEBE_BROKER_GATEWAY_CLUSTER_MESSAGECOMPRESSION
           value: GZIP
         - name: ZEEBE_BROKER_GATEWAY_CLUSTER_MEMBERSHIP_PROBETIMEOUT
-          value: 500ms
+          value: 1000ms
         - name: ZEEBE_BROKER_GATEWAY_CLUSTER_MEMBERSHIP_PROBEINTERVAL
           value: 2s
+        - name: ZEEBE_BROKER_GATEWAY_CLUSTER_MEMBERSHIP_FAILURETIMEOUT
+          value: 10000ms
     # TEMPORARY WORKAROUND — remove once the upstream Camunda fix is released.
     # A Zeebe broker resolves its initialContactPoints only once at startup; if a
     # cross-region "*.svc.clusterset.local" name is not yet published by Submariner

--- a/generic/openshift/dual-region/helm-values/values-base.yml
+++ b/generic/openshift/dual-region/helm-values/values-base.yml
@@ -63,8 +63,7 @@ orchestration:
         # Cross-region SWIM membership tuning for stretched clusters. The default probe
         # timeout (100ms) is too tight for cross-region latency: on a cold start brokers
         # transiently see peers in the other region as unreachable, SWIM ejects them,
-        # membership churns, and brokers flap so the topology never converges. Matches
-        # the proven aws/containers/ecs-dual-region-fargate tuning.
+        # membership churns, and brokers flap so the topology never converges.
         - name: ZEEBE_BROKER_CLUSTER_MEMBERSHIP_PROBETIMEOUT
           value: 1000ms
         - name: ZEEBE_BROKER_CLUSTER_MEMBERSHIP_PROBEINTERVAL


### PR DESCRIPTION
Backport of #2786 to `stable/8.8` (OpenShift dual-region only — EKS dual-region does not exist on 8.8).

8.8 predates the unified `CAMUNDA_*` prefix and runs a **separate gateway**, so both membership blocks are tuned: `ZEEBE_BROKER_CLUSTER_MEMBERSHIP_*` and `ZEEBE_BROKER_GATEWAY_CLUSTER_MEMBERSHIP_*` — `PROBETIMEOUT` 500ms → 1000ms, add `FAILURETIMEOUT=10000ms`. Matches the proven `aws/containers/ecs-dual-region-fargate` cross-region tuning. Needs dual-region CI to validate.