### PR TITLE
[Backport stable/8.7] fix(openshift-dual-region): widen cross-region SWIM membership timeouts (align with ECS)

### DIFF
--- a/generic/openshift/dual-region/helm-values/values-base.yml
+++ b/generic/openshift/dual-region/helm-values/values-base.yml
@@ -82,10 +82,17 @@ zeebe:
           valueFrom:
               fieldRef:
                   fieldPath: metadata.namespace
+        # Cross-region SWIM membership tuning for stretched clusters. The default probe
+        # timeout (100ms) is too tight for cross-region latency: on a cold start brokers
+        # transiently see peers in the other region as unreachable, SWIM ejects them,
+        # membership churns, and brokers flap so the topology never converges. Matches
+        # the proven aws/containers/ecs-dual-region-fargate tuning.
         - name: ZEEBE_BROKER_CLUSTER_MEMBERSHIP_PROBETIMEOUT
-          value: 500ms
+          value: 1000ms
         - name: ZEEBE_BROKER_CLUSTER_MEMBERSHIP_PROBEINTERVAL
           value: 2s
+        - name: ZEEBE_BROKER_CLUSTER_MEMBERSHIP_FAILURETIMEOUT
+          value: 10000ms
         - name: ZEEBE_BROKER_EXPERIMENTAL_RAFT_SNAPSHOTREQUESTTIMEOUT
           value: 10s
         - name: ZEEBE_BROKER_CLUSTER_MESSAGECOMPRESSION
@@ -150,9 +157,11 @@ zeebeGateway:
         - name: ZEEBE_GATEWAY_CLUSTER_MESSAGECOMPRESSION
           value: GZIP
         - name: ZEEBE_GATEWAY_CLUSTER_MEMBERSHIP_PROBETIMEOUT
-          value: 500ms
+          value: 1000ms
         - name: ZEEBE_GATEWAY_CLUSTER_MEMBERSHIP_PROBEINTERVAL
           value: 2s
+        - name: ZEEBE_GATEWAY_CLUSTER_MEMBERSHIP_FAILURETIMEOUT
+          value: 10000ms
 
     resources:
         requests:

--- a/generic/openshift/dual-region/helm-values/values-base.yml
+++ b/generic/openshift/dual-region/helm-values/values-base.yml
@@ -85,8 +85,7 @@ zeebe:
         # Cross-region SWIM membership tuning for stretched clusters. The default probe
         # timeout (100ms) is too tight for cross-region latency: on a cold start brokers
         # transiently see peers in the other region as unreachable, SWIM ejects them,
-        # membership churns, and brokers flap so the topology never converges. Matches
-        # the proven aws/containers/ecs-dual-region-fargate tuning.
+        # membership churns, and brokers flap so the topology never converges.
         - name: ZEEBE_BROKER_CLUSTER_MEMBERSHIP_PROBETIMEOUT
           value: 1000ms
         - name: ZEEBE_BROKER_CLUSTER_MEMBERSHIP_PROBEINTERVAL


### PR DESCRIPTION
Backport of #2786 to `stable/8.7` (OpenShift dual-region only — EKS dual-region does not exist on 8.7).

8.7 runs a **separate standalone gateway** under the `ZEEBE_GATEWAY_*` prefix, so both membership blocks are tuned: `ZEEBE_BROKER_CLUSTER_MEMBERSHIP_*` and `ZEEBE_GATEWAY_CLUSTER_MEMBERSHIP_*` — `PROBETIMEOUT` 500ms → 1000ms, add `FAILURETIMEOUT=10000ms`. Matches the proven `aws/containers/ecs-dual-region-fargate` cross-region tuning. Needs dual-region CI to validate.