### PR TITLE
fix(dual-region): mark Zeebe initial contact points as FQDNs (trailing dot)

### DIFF
--- a/aws/kubernetes/eks-dual-region/procedure/generate_zeebe_helm_values.sh
+++ b/aws/kubernetes/eks-dual-region/procedure/generate_zeebe_helm_values.sh
@@ -11,7 +11,12 @@ generate_initial_contact() {
     local ns_1=$2
     local release=$3
     local port_number=26502
-    echo "${release}-zeebe.${ns_0}.svc.cluster.local:${port_number},${release}-zeebe.${ns_1}.svc.cluster.local:${port_number}"
+    # Trailing dot marks each name as a fully-qualified domain name so the resolver
+    # queries it directly instead of walking the pod's ndots:5 search domains first.
+    # This 4-dot name is otherwise < ndots, so it is search-expanded first; if any
+    # search domain is slow/unresolvable the broker can hang at startup
+    # (camunda/camunda#55038).
+    echo "${release}-zeebe.${ns_0}.svc.cluster.local.:${port_number},${release}-zeebe.${ns_1}.svc.cluster.local.:${port_number}"
 }
 
 generate_exporter_elasticsearch_url() {

--- a/generic/openshift/dual-region/procedure/generate-zeebe-helm-values.sh
+++ b/generic/openshift/dual-region/procedure/generate-zeebe-helm-values.sh
@@ -13,7 +13,11 @@ generate_initial_contact() {
   local release=$5
   local port_number=${6:-26502}
 
-  echo "${cluster_0}.${release}-zeebe.${namespace_0}.svc.clusterset.local:${port_number},${cluster_1}.${release}-zeebe.${namespace_1}.svc.clusterset.local:${port_number}"
+  # Trailing dot marks each name as a fully-qualified domain name so the resolver
+  # queries it directly instead of walking the pod's ndots search domains. Guards
+  # against the search-domain startup hang (camunda/camunda#55038): it forces FQDN
+  # resolution regardless of the contact-point label count vs the pod's ndots.
+  echo "${cluster_0}.${release}-zeebe.${namespace_0}.svc.clusterset.local.:${port_number},${cluster_1}.${release}-zeebe.${namespace_1}.svc.clusterset.local.:${port_number}"
 }
 
 # Function to generate Elasticsearch URL


### PR DESCRIPTION
## What
Append a trailing dot to the Zeebe **initial contact points** generated for the dual-region scenarios, marking them as FQDNs:
- `aws/kubernetes/eks-dual-region/procedure/generate_zeebe_helm_values.sh`
- `generic/openshift/dual-region/procedure/generate-zeebe-helm-values.sh`

(The helm values only carry a `PLACEHOLDER`; the real string is built by these scripts.)

## Why
The contact points are headless-service FQDNs. The EKS name `camunda-zeebe.<ns>.svc.cluster.local` has **4 dots**, below the pod's `ndots:5`, so the resolver **appends the search domains first**. If a search-path query is slow/unresolvable, the broker's inline, probe-bounded resolver burns its budget on the search walk and **hangs at startup before it ever tries the bare name** — `camunda/camunda#55038`. A trailing dot makes the name absolute, so it is queried directly.

**Verified on a Kind reproduction:** a broker wedged for ~23 h (slow search domain present) recovered to `1/1` in **~20 s** once the contact point carried the dot — **0** search-expanded queries, **0** DNS timeouts. The `ndots:5` vs dot-count is the exact mechanism: 4-dot names walk the search list, ≥5-dot names are already absolute.

## Scope / notes
- EKS names are 4-dot → this is the direct fix. OpenShift names are 5-dot (already absolute) → the dot is defensive FQDN-marking for consistency and robustness against `ndots`/label-count changes.
- **Distinct from** the membership-timeout PRs (#2786 …, cross-region connection *flapping*). This targets the DNS *startup hang*.
- This is a more root, lower-cost fix than the `wait-clusterset-dns` init-container gate and could allow removing it later (not done here).

## Backports
Follow-ups: `stable/8.9` (EKS + OpenShift), `stable/8.8` and `stable/8.7` (OpenShift). Same one-line change (the env-var rename does not affect the generated string).