### PR TITLE
[Backport stable/8.9] fix(dual-region): mark Zeebe initial contact points as FQDNs (trailing dot) [ready]

### DIFF
--- a/aws/kubernetes/eks-dual-region/procedure/generate_zeebe_helm_values.sh
+++ b/aws/kubernetes/eks-dual-region/procedure/generate_zeebe_helm_values.sh
@@ -11,7 +11,12 @@ generate_initial_contact() {
     local ns_1=$2
     local release=$3
     local port_number=26502
-    echo "${release}-zeebe.${ns_0}.svc.cluster.local:${port_number},${release}-zeebe.${ns_1}.svc.cluster.local:${port_number}"
+    # Trailing dot marks each name as a fully-qualified domain name so the resolver
+    # queries it directly instead of walking the pod's ndots:5 search domains first.
+    # This 4-dot name is otherwise < ndots, so it is search-expanded first; if any
+    # search domain is slow/unresolvable the broker can hang at startup
+    # (camunda/camunda#55038).
+    echo "${release}-zeebe.${ns_0}.svc.cluster.local.:${port_number},${release}-zeebe.${ns_1}.svc.cluster.local.:${port_number}"
 }
 
 generate_exporter_elasticsearch_url() {

--- a/generic/openshift/dual-region/procedure/generate-zeebe-helm-values.sh
+++ b/generic/openshift/dual-region/procedure/generate-zeebe-helm-values.sh
@@ -13,7 +13,11 @@ generate_initial_contact() {
   local release=$5
   local port_number=${6:-26502}
 
-  echo "${cluster_0}.${release}-zeebe.${namespace_0}.svc.clusterset.local:${port_number},${cluster_1}.${release}-zeebe.${namespace_1}.svc.clusterset.local:${port_number}"
+  # Trailing dot marks each name as a fully-qualified domain name so the resolver
+  # queries it directly instead of walking the pod's ndots search domains. Guards
+  # against the search-domain startup hang (camunda/camunda#55038): it forces FQDN
+  # resolution regardless of the contact-point label count vs the pod's ndots.
+  echo "${cluster_0}.${release}-zeebe.${namespace_0}.svc.clusterset.local.:${port_number},${cluster_1}.${release}-zeebe.${namespace_1}.svc.clusterset.local.:${port_number}"
 }
 
 # Function to generate Elasticsearch URL


### PR DESCRIPTION
Backport of #2793 to `stable/8.9` (EKS + OpenShift dual-region). Appends a trailing dot to the generated Zeebe initial contact points so the resolver queries the FQDN directly instead of walking the pod's `ndots:5` search domains — fixes the startup hang in camunda/camunda#55038. Verified on Kind (23h-wedged broker → 1/1 in ~20s, 0 search-expanded queries). Same one-line change in the generate_* scripts.