### PR TITLE
[Backport stable/8.8] fix(openshift-dual-region): mark Zeebe initial contact points as FQDNs (trailing dot) [ready]

### DIFF
--- a/generic/openshift/dual-region/procedure/generate-zeebe-helm-values.sh
+++ b/generic/openshift/dual-region/procedure/generate-zeebe-helm-values.sh
@@ -11,9 +11,13 @@ generate_initial_contact() {
   local port_number=${7:-26502}
   local result=()
 
+  # Trailing dot marks each name as a fully-qualified domain name so the resolver
+  # queries it directly instead of walking the pod's ndots search domains. Guards
+  # against the search-domain startup hang (camunda/camunda#55038): it forces FQDN
+  # resolution regardless of the contact-point label count vs the pod's ndots.
   for ((i = 0; i < count / 2; i++)); do
-    result+=("${release}-zeebe-${i}.${cluster_0}.${release}-zeebe.${namespace_0}.svc.clusterset.local:${port_number}")
-    result+=("${release}-zeebe-${i}.${cluster_1}.${release}-zeebe.${namespace_1}.svc.clusterset.local:${port_number}")
+    result+=("${release}-zeebe-${i}.${cluster_0}.${release}-zeebe.${namespace_0}.svc.clusterset.local.:${port_number}")
+    result+=("${release}-zeebe-${i}.${cluster_1}.${release}-zeebe.${namespace_1}.svc.clusterset.local.:${port_number}")
   done
 
   IFS=","; echo "${result[*]}"; unset IFS


### PR DESCRIPTION
Backport of #2793 to `stable/8.8` (OpenShift dual-region only).

Appends a trailing dot to the generated Zeebe initial contact points so the resolver treats them as FQDNs and skips the pod's `ndots:5` search-domain walk — the startup hang in camunda/camunda#55038.

Note: 8.8 uses the older **per-pod** format (`…-zeebe-<i>.<cluster>.<release>-zeebe.<ns>.svc.clusterset.local`, **6 dots**), which already exceeds `ndots:5` and is resolved absolute, so here the dot is **defensive / consistency** with the 8.9+ headless contact-point fix (the 4-dot EKS headless name is the one that actually hung). Verified on Kind for the 4-dot case.