### PR TITLE
fix(keycloak): pin Netty-fixed image 26.6.4, drop HTTP/2 workaround

### DIFF
--- a/.github/workflows/generic_kubernetes_operator_based_test.yml
+++ b/.github/workflows/generic_kubernetes_operator_based_test.yml
@@ -706,7 +706,7 @@ jobs:
             # has no such workaround and is not user-affected (ingress speaks HTTP/1.1 upstream).
             - name: 🧪 Keycloak H2C regression probe
               if: matrix.declination.name != 'domain'
-              timeout-minutes: 5
+              timeout-minutes: 8
               working-directory: ./generic/kubernetes/operator-based/
               run: ./tests/check-keycloak-h2c.sh
 

--- a/.github/workflows/generic_kubernetes_operator_based_test.yml
+++ b/.github/workflows/generic_kubernetes_operator_based_test.yml
@@ -699,11 +699,13 @@ jobs:
 
                   echo "All operator-based infrastructure deployed successfully."
 
-            # Regression guard for the Keycloak quay-optimized H2C crash (issue #2809): an
-            # HTTP/2 cleartext upgrade throws NoSuchMethodError and terminates the process on an
-            # affected image. The no-domain CR disables HTTP/2 (QUARKUS_HTTP_HTTP2=false) to avoid
-            # it; this probe fails if that regresses. Scoped to no-domain — the domain declination
-            # has no such workaround and is not user-affected (ingress speaks HTTP/1.1 upstream).
+            # Regression guard for the Keycloak quay-optimized H2C crash (issue #2809): on an
+            # affected image an HTTP/2 cleartext (h2c) upgrade throws NoSuchMethodError and
+            # terminates the process. The fix ships in the pinned image (the conflicting Netty is
+            # removed from /opt/keycloak/providers, camunda/keycloak#596); this probe sends an h2c
+            # request and fails if that regresses. Scoped to no-domain, where Keycloak is reached
+            # directly over cleartext (the domain declination sits behind ingress speaking HTTP/1.1
+            # upstream, so it never exercises the h2c path).
             - name: 🧪 Keycloak H2C regression probe
               if: matrix.declination.name == 'no-domain'
               timeout-minutes: 8

--- a/.github/workflows/generic_kubernetes_operator_based_test.yml
+++ b/.github/workflows/generic_kubernetes_operator_based_test.yml
@@ -699,6 +699,17 @@ jobs:
 
                   echo "All operator-based infrastructure deployed successfully."
 
+            # Regression guard for the Keycloak quay-optimized H2C crash (issue #2809): an
+            # HTTP/2 cleartext upgrade throws NoSuchMethodError and terminates the process on an
+            # affected image. The no-domain CR disables HTTP/2 (QUARKUS_HTTP_HTTP2=false) to avoid
+            # it; this probe fails if that regresses. Scoped to no-domain — the domain declination
+            # has no such workaround and is not user-affected (ingress speaks HTTP/1.1 upstream).
+            - name: 🧪 Keycloak H2C regression probe
+              if: matrix.declination.name != 'domain'
+              timeout-minutes: 5
+              working-directory: ./generic/kubernetes/operator-based/
+              run: ./tests/check-keycloak-h2c.sh
+
             - name: 🔑 Create Camunda credentials and export test tokens
               timeout-minutes: 5
               run: |

--- a/.github/workflows/generic_kubernetes_operator_based_test.yml
+++ b/.github/workflows/generic_kubernetes_operator_based_test.yml
@@ -705,7 +705,7 @@ jobs:
             # it; this probe fails if that regresses. Scoped to no-domain — the domain declination
             # has no such workaround and is not user-affected (ingress speaks HTTP/1.1 upstream).
             - name: 🧪 Keycloak H2C regression probe
-              if: matrix.declination.name != 'domain'
+              if: matrix.declination.name == 'no-domain'
               timeout-minutes: 8
               working-directory: ./generic/kubernetes/operator-based/
               run: ./tests/check-keycloak-h2c.sh

--- a/generic/kubernetes/operator-based/keycloak/keycloak-instance-domain-contour.yml
+++ b/generic/kubernetes/operator-based/keycloak/keycloak-instance-domain-contour.yml
@@ -5,7 +5,7 @@ metadata:
     name: keycloak
 spec:
     # renovate: datasource=docker depName=camunda/keycloak versioning=regex:^quay-optimized-(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)$
-    image: docker.io/camunda/keycloak:quay-optimized-26.6.3
+    image: docker.io/camunda/keycloak:quay-optimized-26.6.4
     instances: 1
     db:
         # Use official url parameter instead of individual host/port/database

--- a/generic/kubernetes/operator-based/keycloak/keycloak-instance-domain-nginx.yml
+++ b/generic/kubernetes/operator-based/keycloak/keycloak-instance-domain-nginx.yml
@@ -5,7 +5,7 @@ metadata:
     name: keycloak
 spec:
     # renovate: datasource=docker depName=camunda/keycloak versioning=regex:^quay-optimized-(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)$
-    image: docker.io/camunda/keycloak:quay-optimized-26.6.3
+    image: docker.io/camunda/keycloak:quay-optimized-26.6.4
     instances: 1
     db:
         # Use official url parameter instead of individual host/port/database

--- a/generic/kubernetes/operator-based/keycloak/keycloak-instance-domain-openshift.yml
+++ b/generic/kubernetes/operator-based/keycloak/keycloak-instance-domain-openshift.yml
@@ -5,7 +5,7 @@ metadata:
     name: keycloak
 spec:
     # renovate: datasource=docker depName=camunda/keycloak versioning=regex:^quay-optimized-(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)$
-    image: docker.io/camunda/keycloak:quay-optimized-26.6.3
+    image: docker.io/camunda/keycloak:quay-optimized-26.6.4
     instances: 1
     db:
         # Use official url parameter instead of individual host/port/database

--- a/generic/kubernetes/operator-based/keycloak/keycloak-instance-no-domain.yml
+++ b/generic/kubernetes/operator-based/keycloak/keycloak-instance-no-domain.yml
@@ -5,7 +5,7 @@ metadata:
     name: keycloak
 spec:
     # renovate: datasource=docker depName=camunda/keycloak versioning=regex:^quay-optimized-(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)$
-    image: docker.io/camunda/keycloak:quay-optimized-26.6.3
+    image: docker.io/camunda/keycloak:quay-optimized-26.6.4
     instances: 1
     db:
         # Use official url parameter instead of individual host/port/database
@@ -39,18 +39,3 @@ spec:
         requests:
             cpu: 250m
             memory: 512Mi
-    # Workaround for the camunda/keycloak quay-optimized images. The image build copies the AWS
-    # JDBC wrapper's transitive dependencies into /opt/keycloak/providers, adding a second, older
-    # Netty (netty-nio-client) that shadows Keycloak's bundled, Vert.x-aligned Netty. Any client
-    # that negotiates HTTP/2 cleartext (h2c) against this plain-HTTP endpoint (port-forward, no
-    # TLS) then hits a NoSuchMethodError that terminates the Keycloak process; HTTP/1.1 traffic is
-    # unaffected. Disabling HTTP/2 keeps access on HTTP/1.1, which is all port-forward needs.
-    # Remove once the pinned image ships a Netty-aligned build (fixed upstream in camunda/keycloak#596).
-    # See https://github.com/camunda/camunda-deployment-references/issues/2809
-    unsupported:
-        podTemplate:
-            spec:
-                containers:
-                    - env:
-                          - name: QUARKUS_HTTP_HTTP2
-                            value: 'false'

--- a/generic/kubernetes/operator-based/keycloak/keycloak-instance-no-domain.yml
+++ b/generic/kubernetes/operator-based/keycloak/keycloak-instance-no-domain.yml
@@ -39,12 +39,13 @@ spec:
         requests:
             cpu: 250m
             memory: 512Mi
-    # Workaround for the camunda/keycloak quay-optimized images: the AWS JDBC wrapper ships an
-    # older Netty under /opt/keycloak/providers that shadows Keycloak's bundled, Vert.x-aligned
-    # Netty. Over plain HTTP (port-forward, no TLS) a browser sends "Upgrade: h2c", which drives
-    # the HTTP/2 cleartext path and crashes the pod with a NoSuchMethodError. Disabling HTTP/2
-    # forces HTTP/1.1, which is all port-forward access needs. Remove once the pinned image ships
-    # a Netty-aligned build (fixed upstream in camunda/keycloak#596).
+    # Workaround for the camunda/keycloak quay-optimized images. The image build copies the AWS
+    # JDBC wrapper's transitive dependencies into /opt/keycloak/providers, adding a second, older
+    # Netty (netty-nio-client) that shadows Keycloak's bundled, Vert.x-aligned Netty. Any client
+    # that negotiates HTTP/2 cleartext (h2c) against this plain-HTTP endpoint (port-forward, no
+    # TLS) then hits a NoSuchMethodError that terminates the Keycloak process; HTTP/1.1 traffic is
+    # unaffected. Disabling HTTP/2 keeps access on HTTP/1.1, which is all port-forward needs.
+    # Remove once the pinned image ships a Netty-aligned build (fixed upstream in camunda/keycloak#596).
     # See https://github.com/camunda/camunda-deployment-references/issues/2809
     unsupported:
         podTemplate:

--- a/generic/kubernetes/operator-based/keycloak/keycloak-instance-no-domain.yml
+++ b/generic/kubernetes/operator-based/keycloak/keycloak-instance-no-domain.yml
@@ -44,7 +44,7 @@ spec:
     # Netty. Over plain HTTP (port-forward, no TLS) a browser sends "Upgrade: h2c", which drives
     # the HTTP/2 cleartext path and crashes the pod with a NoSuchMethodError. Disabling HTTP/2
     # forces HTTP/1.1, which is all port-forward access needs. Remove once the pinned image ships
-    # a Netty-aligned build (fixed upstream in camunda/keycloak).
+    # a Netty-aligned build (fixed upstream in camunda/keycloak#596).
     # See https://github.com/camunda/camunda-deployment-references/issues/2809
     unsupported:
         podTemplate:

--- a/generic/kubernetes/operator-based/keycloak/keycloak-instance-no-domain.yml
+++ b/generic/kubernetes/operator-based/keycloak/keycloak-instance-no-domain.yml
@@ -39,3 +39,17 @@ spec:
         requests:
             cpu: 250m
             memory: 512Mi
+    # Workaround for the camunda/keycloak quay-optimized images: the AWS JDBC wrapper ships an
+    # older Netty under /opt/keycloak/providers that shadows Keycloak's bundled, Vert.x-aligned
+    # Netty. Over plain HTTP (port-forward, no TLS) a browser sends "Upgrade: h2c", which drives
+    # the HTTP/2 cleartext path and crashes the pod with a NoSuchMethodError. Disabling HTTP/2
+    # forces HTTP/1.1, which is all port-forward access needs. Remove once the pinned image ships
+    # a Netty-aligned build (fixed upstream in camunda/keycloak).
+    # See https://github.com/camunda/camunda-deployment-references/issues/2809
+    unsupported:
+        podTemplate:
+            spec:
+                containers:
+                    - env:
+                          - name: QUARKUS_HTTP_HTTP2
+                            value: 'false'

--- a/generic/kubernetes/operator-based/tests/check-keycloak-h2c.sh
+++ b/generic/kubernetes/operator-based/tests/check-keycloak-h2c.sh
@@ -23,8 +23,17 @@ KEYCLOAK_HTTP_PORT=${KEYCLOAK_HTTP_PORT:-18080}
 LOCAL_PORT=${LOCAL_PORT:-18080}
 PROBE_PATH=${PROBE_PATH:-/auth/realms/master}
 
+# Fail fast (and clearly) if this runner's curl cannot negotiate HTTP/2 — otherwise
+# `curl --http2` would error and be misreported below as an H2C regression.
+if ! curl -V | grep -qiw HTTP2; then
+    echo "❌ curl on this runner was built without HTTP/2 support; cannot run the h2c probe."
+    exit 1
+fi
+
+# Keycloak is already deployed and waited on by keycloak/deploy.sh before this runs,
+# so this is a short defensive re-check rather than a long provisioning wait.
 echo "Waiting for Keycloak to be Ready..."
-kubectl wait --for=condition=Ready --timeout=300s keycloak --all -n "$CAMUNDA_NAMESPACE"
+kubectl wait --for=condition=Ready --timeout=120s keycloak --all -n "$CAMUNDA_NAMESPACE"
 
 echo "Port-forwarding svc/${KEYCLOAK_SERVICE} ${LOCAL_PORT}:${KEYCLOAK_HTTP_PORT} (namespace ${CAMUNDA_NAMESPACE})..."
 kubectl port-forward -n "$CAMUNDA_NAMESPACE" "svc/${KEYCLOAK_SERVICE}" "${LOCAL_PORT}:${KEYCLOAK_HTTP_PORT}" >/dev/null 2>&1 &
@@ -62,10 +71,10 @@ if [ "$curl_rc" -ne 0 ] || [ -z "$http_code" ] || [ "$http_code" = "000" ]; then
 fi
 
 # An h2c crash exits the JVM (pod restart); make sure Keycloak is still up.
-if ! kubectl wait --for=condition=Ready --timeout=90s keycloak --all -n "$CAMUNDA_NAMESPACE"; then
+if ! kubectl wait --for=condition=Ready --timeout=60s keycloak --all -n "$CAMUNDA_NAMESPACE"; then
     echo "❌ Keycloak is not Ready after the H2C probe — it likely crashed on the h2c request."
     kubectl get pods -n "$CAMUNDA_NAMESPACE" -o wide || true
     exit 1
 fi
 
-echo "✅ H2C probe passed: Keycloak answered the h2c upgrade (http_code=${http_code}) and stayed Ready."
+echo "✅ H2C probe passed: Keycloak responded to the h2c request without dropping the connection (http_code=${http_code}) and stayed Ready."

--- a/generic/kubernetes/operator-based/tests/check-keycloak-h2c.sh
+++ b/generic/kubernetes/operator-based/tests/check-keycloak-h2c.sh
@@ -19,7 +19,8 @@ set -euo pipefail
 
 CAMUNDA_NAMESPACE=${CAMUNDA_NAMESPACE:-camunda}
 KEYCLOAK_SERVICE=${KEYCLOAK_SERVICE:-keycloak-service}
-KEYCLOAK_HTTP_PORT=${KEYCLOAK_HTTP_PORT:-18080}
+# Derived from the Service object once Keycloak is up (see below), unless overridden here.
+KEYCLOAK_HTTP_PORT=${KEYCLOAK_HTTP_PORT:-}
 LOCAL_PORT=${LOCAL_PORT:-18080}
 PROBE_PATH=${PROBE_PATH:-/auth/realms/master}
 
@@ -35,6 +36,17 @@ fi
 echo "Waiting for Keycloak to be Ready..."
 kubectl wait --for=condition=Ready --timeout=120s keycloak --all -n "$CAMUNDA_NAMESPACE"
 
+# Derive the Keycloak service HTTP port from the Service object rather than hard-coding it
+# (the no-domain CR configures 18080). Prefer the port named "http", else the first port,
+# else fall back to 18080.
+if [ -z "$KEYCLOAK_HTTP_PORT" ]; then
+    KEYCLOAK_HTTP_PORT=$(kubectl get "svc/${KEYCLOAK_SERVICE}" -n "$CAMUNDA_NAMESPACE" -o jsonpath='{.spec.ports[?(@.name=="http")].port}' 2>/dev/null || true)
+fi
+if [ -z "$KEYCLOAK_HTTP_PORT" ]; then
+    KEYCLOAK_HTTP_PORT=$(kubectl get "svc/${KEYCLOAK_SERVICE}" -n "$CAMUNDA_NAMESPACE" -o jsonpath='{.spec.ports[0].port}' 2>/dev/null || true)
+fi
+KEYCLOAK_HTTP_PORT=${KEYCLOAK_HTTP_PORT:-18080}
+
 echo "Port-forwarding svc/${KEYCLOAK_SERVICE} ${LOCAL_PORT}:${KEYCLOAK_HTTP_PORT} (namespace ${CAMUNDA_NAMESPACE})..."
 kubectl port-forward -n "$CAMUNDA_NAMESPACE" "svc/${KEYCLOAK_SERVICE}" "${LOCAL_PORT}:${KEYCLOAK_HTTP_PORT}" >/dev/null 2>&1 &
 pf_pid=$!
@@ -46,6 +58,10 @@ url="http://localhost:${LOCAL_PORT}${PROBE_PATH}"
 # Wait until the tunnel accepts plain HTTP/1.1 traffic before probing h2c.
 ready=false
 for _ in $(seq 1 30); do
+    if ! kill -0 "$pf_pid" 2>/dev/null; then
+        echo "❌ kubectl port-forward exited early (service missing, or local port ${LOCAL_PORT} already in use); aborting probe."
+        exit 1
+    fi
     if curl -fsS -o /dev/null "$url" 2>/dev/null; then
         ready=true
         break

--- a/generic/kubernetes/operator-based/tests/check-keycloak-h2c.sh
+++ b/generic/kubernetes/operator-based/tests/check-keycloak-h2c.sh
@@ -4,12 +4,11 @@
 # Regression probe for the HTTP/2 cleartext (h2c) crash of the camunda/keycloak
 # quay-optimized images (see issue #2809 and camunda/keycloak#596).
 #
-# The image build copies the AWS JDBC wrapper's transitive dependencies into
-# /opt/keycloak/providers, which includes an older Netty (netty-nio-client) that
-# shadows Keycloak's bundled, Vert.x-aligned Netty. On an affected image an h2c
-# upgrade throws NoSuchMethodError and terminates the Keycloak process (the
-# connection is dropped). The no-domain Keycloak CR disables HTTP/2
-# (QUARKUS_HTTP_HTTP2=false) to avoid this; this probe fails if that protection
+# A previously-affected image copied the AWS JDBC wrapper's transitive dependencies
+# into /opt/keycloak/providers, including an older Netty that shadowed Keycloak's
+# bundled, Vert.x-aligned Netty; an h2c upgrade then threw NoSuchMethodError and
+# terminated the Keycloak process. The fix ships in the image itself (the conflicting
+# Netty is removed from providers, camunda/keycloak#596); this probe fails if that
 # regresses.
 #
 # It port-forwards the Keycloak service, sends an h2c upgrade with `curl --http2`,
@@ -81,7 +80,8 @@ echo "curl exit=${curl_rc} http_code=${http_code}"
 
 if [ "$curl_rc" -ne 0 ] || [ -z "$http_code" ] || [ "$http_code" = "000" ]; then
     echo "❌ H2C regression: Keycloak dropped the HTTP/2 cleartext connection (NoSuchMethodError crash)."
-    echo "   Keep QUARKUS_HTTP_HTTP2=false on the no-domain Keycloak CR, or use a Netty-aligned image (camunda/keycloak#596)."
+    echo "   Fix: use a camunda/keycloak image whose /opt/keycloak/providers has no conflicting Netty (camunda/keycloak#596)."
+    echo "   Or, on an older image without that fix, set QUARKUS_HTTP_HTTP2=false on the Keycloak CR to force HTTP/1.1."
     kubectl get pods -n "$CAMUNDA_NAMESPACE" -o wide || true
     exit 1
 fi

--- a/generic/kubernetes/operator-based/tests/check-keycloak-h2c.sh
+++ b/generic/kubernetes/operator-based/tests/check-keycloak-h2c.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+# check-keycloak-h2c.sh
+#
+# Regression probe for the HTTP/2 cleartext (h2c) crash of the camunda/keycloak
+# quay-optimized images (see issue #2809 and camunda/keycloak#596).
+#
+# The image build copies the AWS JDBC wrapper's transitive dependencies into
+# /opt/keycloak/providers, which includes an older Netty (netty-nio-client) that
+# shadows Keycloak's bundled, Vert.x-aligned Netty. On an affected image an h2c
+# upgrade throws NoSuchMethodError and terminates the Keycloak process (the
+# connection is dropped). The no-domain Keycloak CR disables HTTP/2
+# (QUARKUS_HTTP_HTTP2=false) to avoid this; this probe fails if that protection
+# regresses.
+#
+# It port-forwards the Keycloak service, sends an h2c upgrade with `curl --http2`,
+# and asserts a valid HTTP response comes back (i.e. the process did not crash).
+
+set -euo pipefail
+
+CAMUNDA_NAMESPACE=${CAMUNDA_NAMESPACE:-camunda}
+KEYCLOAK_SERVICE=${KEYCLOAK_SERVICE:-keycloak-service}
+KEYCLOAK_HTTP_PORT=${KEYCLOAK_HTTP_PORT:-18080}
+LOCAL_PORT=${LOCAL_PORT:-18080}
+PROBE_PATH=${PROBE_PATH:-/auth/realms/master}
+
+echo "Waiting for Keycloak to be Ready..."
+kubectl wait --for=condition=Ready --timeout=300s keycloak --all -n "$CAMUNDA_NAMESPACE"
+
+echo "Port-forwarding svc/${KEYCLOAK_SERVICE} ${LOCAL_PORT}:${KEYCLOAK_HTTP_PORT} (namespace ${CAMUNDA_NAMESPACE})..."
+kubectl port-forward -n "$CAMUNDA_NAMESPACE" "svc/${KEYCLOAK_SERVICE}" "${LOCAL_PORT}:${KEYCLOAK_HTTP_PORT}" >/dev/null 2>&1 &
+pf_pid=$!
+cleanup() { kill "$pf_pid" 2>/dev/null || true; }
+trap cleanup EXIT
+
+url="http://localhost:${LOCAL_PORT}${PROBE_PATH}"
+
+# Wait until the tunnel accepts plain HTTP/1.1 traffic before probing h2c.
+ready=false
+for _ in $(seq 1 30); do
+    if curl -fsS -o /dev/null "$url" 2>/dev/null; then
+        ready=true
+        break
+    fi
+    sleep 2
+done
+if [ "$ready" != "true" ]; then
+    echo "❌ Could not reach Keycloak over HTTP/1.1 through the port-forward; aborting probe."
+    kubectl get pods -n "$CAMUNDA_NAMESPACE" -o wide || true
+    exit 1
+fi
+
+echo "Sending an HTTP/2 cleartext (h2c) upgrade request to ${url}..."
+curl_rc=0
+http_code=$(curl -sS -o /dev/null -w '%{http_code}' --http2 --max-time 20 "$url") || curl_rc=$?
+echo "curl exit=${curl_rc} http_code=${http_code}"
+
+if [ "$curl_rc" -ne 0 ] || [ -z "$http_code" ] || [ "$http_code" = "000" ]; then
+    echo "❌ H2C regression: Keycloak dropped the HTTP/2 cleartext connection (NoSuchMethodError crash)."
+    echo "   Keep QUARKUS_HTTP_HTTP2=false on the no-domain Keycloak CR, or use a Netty-aligned image (camunda/keycloak#596)."
+    kubectl get pods -n "$CAMUNDA_NAMESPACE" -o wide || true
+    exit 1
+fi
+
+# An h2c crash exits the JVM (pod restart); make sure Keycloak is still up.
+if ! kubectl wait --for=condition=Ready --timeout=90s keycloak --all -n "$CAMUNDA_NAMESPACE"; then
+    echo "❌ Keycloak is not Ready after the H2C probe — it likely crashed on the h2c request."
+    kubectl get pods -n "$CAMUNDA_NAMESPACE" -o wide || true
+    exit 1
+fi
+
+echo "✅ H2C probe passed: Keycloak answered the h2c upgrade (http_code=${http_code}) and stayed Ready."

--- a/generic/kubernetes/operator-based/tests/check-keycloak-h2c.sh
+++ b/generic/kubernetes/operator-based/tests/check-keycloak-h2c.sh
@@ -61,7 +61,7 @@ for _ in $(seq 1 30); do
         echo "❌ kubectl port-forward exited early (service missing, or local port ${LOCAL_PORT} already in use); aborting probe."
         exit 1
     fi
-    if curl -fsS -o /dev/null "$url" 2>/dev/null; then
+    if curl -sS -o /dev/null --max-time 5 "$url" 2>/dev/null; then
         ready=true
         break
     fi
@@ -75,8 +75,10 @@ fi
 
 echo "Sending an HTTP/2 cleartext (h2c) upgrade request to ${url}..."
 curl_rc=0
-http_code=$(curl -sS -o /dev/null -w '%{http_code}' --http2 --max-time 20 "$url") || curl_rc=$?
-echo "curl exit=${curl_rc} http_code=${http_code}"
+metrics=$(curl -sS -o /dev/null -w '%{http_code} %{http_version}' --http2 --max-time 20 "$url") || curl_rc=$?
+http_code=${metrics%% *}
+http_version=${metrics##* }
+echo "curl exit=${curl_rc} http_code=${http_code:-} http_version=${http_version:-}"
 
 if [ "$curl_rc" -ne 0 ] || [ -z "$http_code" ] || [ "$http_code" = "000" ]; then
     echo "❌ H2C regression: Keycloak dropped the HTTP/2 cleartext connection (NoSuchMethodError crash)."
@@ -85,6 +87,19 @@ if [ "$curl_rc" -ne 0 ] || [ -z "$http_code" ] || [ "$http_code" = "000" ]; then
     kubectl get pods -n "$CAMUNDA_NAMESPACE" -o wide || true
     exit 1
 fi
+
+# The request must actually negotiate HTTP/2, otherwise the h2c upgrade path (the one that
+# used to crash) was never exercised and this probe would pass without guarding anything.
+case "${http_version:-}" in
+    2 | 2.0) : ;;
+    *)
+        echo "❌ H2C probe ineffective: the request negotiated HTTP/${http_version:-unknown}, not HTTP/2."
+        echo "   The h2c upgrade path was not exercised. Ensure HTTP/2 is enabled on Keycloak"
+        echo "   (do not set QUARKUS_HTTP_HTTP2=false on the pinned, Netty-fixed image)."
+        kubectl get pods -n "$CAMUNDA_NAMESPACE" -o wide || true
+        exit 1
+        ;;
+esac
 
 # An h2c crash exits the JVM (pod restart); make sure Keycloak is still up.
 if ! kubectl wait --for=condition=Ready --timeout=60s keycloak --all -n "$CAMUNDA_NAMESPACE"; then


### PR DESCRIPTION
## Problem

Fixes #2809.

On the operator-based **no-domain** setup (port-forward, no ingress, no TLS), Keycloak crashed on an HTTP/2 cleartext (h2c) upgrade with `NoSuchMethodError`, so the management identity page failed to load and the login page hung on a white screen after submitting credentials.

## Root cause

The `camunda/keycloak:quay-optimized-*` image shipped an older Netty under `/opt/keycloak/providers` (dragged in transitively by the AWS JDBC wrapper's `netty-nio-client`) that shadowed Keycloak's bundled, Vert.x-aligned Netty in `/opt/keycloak/lib`. Over plain HTTP a browser sends `Upgrade: h2c`; Vert.x then builds an HTTP/2 handler against the mismatched Netty and the pod crashes.

Full analysis and the upstream image fix: **camunda/keycloak#596**.

## Change

Pin the no-domain Keycloak instance to the Netty-fixed image **`quay-optimized-26.6.4`** and drop the earlier `QUARKUS_HTTP_HTTP2=false` workaround. The fix ships in the image itself — the conflicting Netty is removed from `/opt/keycloak/providers` (camunda/keycloak#596) — so Keycloak serves h2c correctly and no CR-level override is needed.

To prevent a silent regression, this PR also adds a CI **h2c regression probe** (`tests/check-keycloak-h2c.sh`) wired into the operator-based workflow on the no-domain declination. It port-forwards Keycloak, sends a `curl --http2` request, and fails if the connection is dropped (the crash) or if the request does not actually negotiate HTTP/2 — so the guard cannot pass without exercising the h2c path.

The domain variants (contour/nginx/openshift) pinned the same pre-fix image but do not trigger the crash — the ingress terminates TLS and speaks HTTP/1.1 upstream. They are aligned to `quay-optimized-26.6.4` as well, so every operator-based Keycloak instance uses the same Netty-fixed image and the pins no longer drift apart.

## Validation

`quay-optimized-26.6.4` verified: `/opt/keycloak/providers` has no Netty jars, the AWS JDBC wrapper is still present, and `curl --http2` negotiates HTTP/2 (version 2) with no `NoSuchMethodError`. The probe passes on the operator-based no-domain e2e.

## Backports

The same no-domain CR exists on `stable/8.9` (#2817) and `stable/8.8` (#2816); both bump to `quay-optimized-26.6.4` and add the same probe. `stable/8.7` and earlier do not use the operator/quay-optimized Keycloak and are not affected.
