### PR TITLE
fix(ci): don't require a standalone `console` container on Camunda 8.10+

### DIFF
--- a/.github/actions/internal-camunda-chart-tests/action.yml
+++ b/.github/actions/internal-camunda-chart-tests/action.yml
@@ -451,7 +451,16 @@ runs:
               fi
 
               if [[ "${{ inputs.console-enabled }}" == "true" ]]; then
-                REQUIRED_CONTAINERS="${REQUIRED_CONTAINERS},console"
+                # Console was consolidated into Camunda Hub in Camunda 8.10
+                # (chart 15.x): it is no longer a standalone deployment but a
+                # feature of Web Modeler (CAMUNDA_MODELER_FEATURE_CONSOLE_ENABLED),
+                # so there is no dedicated `console` container to check for.
+                # Only require it on versions before 8.10.
+                CONSOLE_VERSION="${{ inputs.camunda-version }}"
+                CONSOLE_LOWEST=$(printf '%s\n%s\n' "$CONSOLE_VERSION" "8.10" | sort -V | head -n1)
+                if [[ "$CONSOLE_VERSION" != "8.10" && "$CONSOLE_LOWEST" == "$CONSOLE_VERSION" ]]; then
+                  REQUIRED_CONTAINERS="${REQUIRED_CONTAINERS},console"
+                fi
               fi
 
               echo "Required containers for Camunda ${{ inputs.camunda-version }}: $REQUIRED_CONTAINERS"


### PR DESCRIPTION
## Problem

The `c8-sm-checks` deployment check fails on Camunda 8.10 with:

```
[FAIL] The following required container is missing in the pods in namespace camunda: console
```

## Root cause

Console was **consolidated into Camunda Hub** in Camunda 8.10 (chart 15.x). It is no longer a standalone Deployment/container — it is a **feature of Web Modeler**, wired via `CAMUNDA_MODELER_FEATURE_CONSOLE_ENABLED = camundaHub.consoleEnabled` on the `web-modeler` restapi. Chart 15.0.0-alpha3 ships Deployments only for `connectors, identity, optimize, web-modeler` — there is no `console` deployment.

But `internal-camunda-chart-tests` still appended `console` to the required-container name list whenever `console-enabled=true`, so the name-based check looked for a `console` container that no longer exists on 8.10.

## Fix

Gate the standalone `console` required-container on versions **before 8.10**. From 8.10 on, Console is covered by the `web-modeler` container (checked via `webmodeler-enabled`). Verified the version gate for 8.7/8.8/8.9 (adds `console`) and 8.10/8.11 (does not).

This only affects the deployment-check container list; no deployment behaviour changes.

## Notes

- Separate from the Helm deprecation-drift work (#2812); this is the console→Camunda-Hub consolidation surfacing in the smoke-test tooling.
- A follow-up in the `c8-sm-checks` tool itself (validate the Console *feature* rather than a named container) would be the more complete fix.