### PR TITLE
feat(kind): gate the pre-release chart build and drop the redundant registry login [ready]

### DIFF
--- a/.github/workflows/local_kubernetes_kind_single_region_tests.yml
+++ b/.github/workflows/local_kubernetes_kind_single_region_tests.yml
@@ -90,6 +90,9 @@ jobs:
             CAMUNDA_NAMESPACE: camunda
             CAMUNDA_RELEASE_NAME: camunda
             TEST_CLUSTER_TYPE: kubernetes
+            # Non-interactive acknowledgement of the pre-release chart build.
+            # TODO: [release-duty] remove this together with the source-build (procedure/build-camunda-chart.sh).
+            CAMUNDA_PRERELEASE_ACK: 'true'
         steps:
             - name: Checkout repository
               uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -185,22 +188,6 @@ jobs:
             - name: Create identity secrets
               working-directory: ${{ env.REF_ARCH_PATH }}
               run: ./procedure/create-identity-secrets.sh
-
-            - name: Extract Helm chart version
-              id: chart-version
-              working-directory: ${{ env.REF_ARCH_PATH }}
-              run: |
-                  SCRIPT=${{ matrix.declination.use_tls && 'procedure/camunda-deploy-domain.sh' || 'procedure/camunda-deploy-no-domain.sh' }}
-                  VERSION=$(grep -oP 'CAMUNDA_HELM_CHART_VERSION="\K[^"]+' "$SCRIPT")
-                  echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-
-            - name: Helm registry login
-              uses: ./.github/actions/internal-helm-registry-login
-              with:
-                  helm-chart-version: ${{ steps.chart-version.outputs.version }}
-                  vault-addr: ${{ secrets.VAULT_ADDR }}
-                  vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
-                  vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
 
             # Deploy Camunda
             - name: Deploy Camunda (domain mode)

--- a/local/kubernetes/kind-single-region/procedure/build-camunda-chart.sh
+++ b/local/kubernetes/kind-single-region/procedure/build-camunda-chart.sh
@@ -13,6 +13,44 @@ set -euo pipefail
 #   CAMUNDA_HELM_CHART_GIT_URL       source repo URL
 #   CAMUNDA_HELM_CHART_GIT_REF       branch or tag to build (passed to git clone --branch)
 #   CAMUNDA_HELM_CHART_CHECKOUT_DIR  clone location; must be an absolute path
+#   CAMUNDA_PRERELEASE_ACK           set to 'true' (or pass --yes) to skip the prompt
+
+# Loudly warn that this deploys an unreleased, in-development build (to stderr so
+# it never pollutes the chart path printed on stdout).
+cat >&2 <<'PRERELEASE_WARNING'
+
+  ############################################################################
+  #  ⚠  PRE-RELEASE — NOT A STABLE CAMUNDA RELEASE                           #
+  #                                                                          #
+  #  This builds and deploys an unreleased, in-development Camunda 8 chart.  #
+  #  It may be unstable or fail to start — that is expected here.            #
+  #                                                                          #
+  #  Need a stable, supported setup? Follow the Administrator quickstart:    #
+  #  https://docs.camunda.io/docs/self-managed/quickstart/administrator-quickstart/
+  ############################################################################
+
+PRERELEASE_WARNING
+
+# Require acknowledging the pre-release warning above. Bypass with
+# CAMUNDA_PRERELEASE_ACK=true or the --yes/-y flag; run interactively without
+# either and it prompts for confirmation.
+_prerelease_ack="${CAMUNDA_PRERELEASE_ACK:-}"
+for _arg in "$@"; do
+    case "$_arg" in --yes | -y) _prerelease_ack="true" ;; esac
+done
+if [[ "$_prerelease_ack" != "true" ]]; then
+    if [[ -t 0 ]]; then
+        printf 'Continue with this pre-release build? [y/N] ' >&2
+        read -r _reply || _reply=""
+        case "$_reply" in
+            [yY] | [yY][eE][sS]) ;;
+            *) echo "Aborted: pre-release build not acknowledged." >&2; exit 1 ;;
+        esac
+    else
+        echo "Non-interactive: set CAMUNDA_PRERELEASE_ACK=true (or pass --yes) to acknowledge the pre-release build." >&2
+        exit 1
+    fi
+fi
 
 _chart_src_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 _repo_root="$_chart_src_dir/../../../.."


### PR DESCRIPTION
Follow-up to #2823 (now merged), which switched the kind guide to build the chart from source (git clone).

## Changes

1. **Drop the redundant private Helm registry login** from the kind test workflow. Since the kind deploy builds the chart from source, it no longer pulls from `registry.camunda.cloud`, so the `Extract Helm chart version` + `Helm registry login` steps are dead weight. (The shared `internal-helm-registry-login` action + Vault creds stay — the other reference architectures still pull from the private OCI.)

2. **Warn + gate the pre-release chart build.** `build-camunda-chart.sh` now prints a prominent PRE-RELEASE warning and requires acknowledgement before building: bypass non-interactively with `CAMUNDA_PRERELEASE_ACK=true` or `--yes`/`-y`, otherwise it prompts when a TTY is available. It points users who need a stable setup to the [Administrator quickstart](https://docs.camunda.io/docs/self-managed/quickstart/administrator-quickstart/). CI acknowledges via the job env, flagged `[release-duty]` for removal alongside the source-build helper.

## Notes

- A consistent pre-release warning for the **other** reference architectures (which still use the private OCI, internal audience) will come as a **separate** PR.
- Not merged — merging is a human action.
