### PR TITLE
feat(helm): warn on pre-release chart deploy in the reference architectures

### DIFF
--- a/aws/kubernetes/eks-dual-region/procedure/export_environment_prerequisites.sh
+++ b/aws/kubernetes/eks-dual-region/procedure/export_environment_prerequisites.sh
@@ -14,7 +14,7 @@ cat >&2 <<'PRERELEASE_WARNING'
   ############################################################################
   #  ⚠  PRE-RELEASE — NOT A STABLE CAMUNDA RELEASE                           #
   #                                                                          #
-  #  This deploys an unreleased, in-development Camunda 8 chart.             #
+  #  This targets an unreleased, in-development Camunda 8 chart.             #
   #  It may be unstable or fail to start — that is expected here.            #
   #                                                                          #
   #  Need a stable, supported setup? Follow the Administrator quickstart:    #

--- a/aws/kubernetes/eks-dual-region/procedure/export_environment_prerequisites.sh
+++ b/aws/kubernetes/eks-dual-region/procedure/export_environment_prerequisites.sh
@@ -8,6 +8,21 @@
 # . ./export_environment_prerequisites.sh
 # to export the environment variables to the current shell
 
+# Warn that this targets an unreleased, in-development chart (to stderr).
+cat >&2 <<'PRERELEASE_WARNING'
+
+  ############################################################################
+  #  ⚠  PRE-RELEASE — NOT A STABLE CAMUNDA RELEASE                           #
+  #                                                                          #
+  #  This deploys an unreleased, in-development Camunda 8 chart.             #
+  #  It may be unstable or fail to start — that is expected here.            #
+  #                                                                          #
+  #  Need a stable, supported setup? Follow the Administrator quickstart:    #
+  #  https://docs.camunda.io/docs/self-managed/quickstart/administrator-quickstart/
+  ############################################################################
+
+PRERELEASE_WARNING
+
 # The AWS regions of your Kubernetes cluster 0 and 1
 export REGION_0=${REGION_0:-eu-west-2}
 export REGION_1=${REGION_1:-eu-west-3}

--- a/aws/kubernetes/eks-dual-region/procedure/export_environment_prerequisites.sh
+++ b/aws/kubernetes/eks-dual-region/procedure/export_environment_prerequisites.sh
@@ -9,6 +9,7 @@
 # to export the environment variables to the current shell
 
 # Warn that this targets an unreleased, in-development chart (to stderr).
+# TODO: [release-duty] remove this pre-release warning at release.
 cat >&2 <<'PRERELEASE_WARNING'
 
   ############################################################################

--- a/generic/kubernetes/single-region/procedure/install-chart.sh
+++ b/generic/kubernetes/single-region/procedure/install-chart.sh
@@ -1,5 +1,20 @@
 #!/bin/bash
 
+# Warn that this deploys an unreleased, in-development chart (to stderr).
+cat >&2 <<'PRERELEASE_WARNING'
+
+  ############################################################################
+  #  ⚠  PRE-RELEASE — NOT A STABLE CAMUNDA RELEASE                           #
+  #                                                                          #
+  #  This deploys an unreleased, in-development Camunda 8 chart.             #
+  #  It may be unstable or fail to start — that is expected here.            #
+  #                                                                          #
+  #  Need a stable, supported setup? Follow the Administrator quickstart:    #
+  #  https://docs.camunda.io/docs/self-managed/quickstart/administrator-quickstart/
+  ############################################################################
+
+PRERELEASE_WARNING
+
 helm upgrade --install \
     "$CAMUNDA_RELEASE_NAME" oci://registry.camunda.cloud/team-distribution/camunda-platform \
     --version "$CAMUNDA_HELM_CHART_VERSION" --namespace "$CAMUNDA_NAMESPACE" \

--- a/generic/kubernetes/single-region/procedure/install-chart.sh
+++ b/generic/kubernetes/single-region/procedure/install-chart.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
+set -euo pipefail
 
 # Warn that this deploys an unreleased, in-development chart (to stderr).
+# TODO: [release-duty] remove this pre-release warning at release.
 cat >&2 <<'PRERELEASE_WARNING'
 
   ############################################################################

--- a/generic/openshift/dual-region/procedure/install-chart.sh
+++ b/generic/openshift/dual-region/procedure/install-chart.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 # Warn that this deploys an unreleased, in-development chart (to stderr).
+# TODO: [release-duty] remove this pre-release warning at release.
 cat >&2 <<'PRERELEASE_WARNING'
 
   ############################################################################

--- a/generic/openshift/dual-region/procedure/install-chart.sh
+++ b/generic/openshift/dual-region/procedure/install-chart.sh
@@ -1,6 +1,21 @@
 #!/bin/bash
 set -euo pipefail
 
+# Warn that this deploys an unreleased, in-development chart (to stderr).
+cat >&2 <<'PRERELEASE_WARNING'
+
+  ############################################################################
+  #  ⚠  PRE-RELEASE — NOT A STABLE CAMUNDA RELEASE                           #
+  #                                                                          #
+  #  This deploys an unreleased, in-development Camunda 8 chart.             #
+  #  It may be unstable or fail to start — that is expected here.            #
+  #                                                                          #
+  #  Need a stable, supported setup? Follow the Administrator quickstart:    #
+  #  https://docs.camunda.io/docs/self-managed/quickstart/administrator-quickstart/
+  ############################################################################
+
+PRERELEASE_WARNING
+
 # --force-update keeps this idempotent under `set -e` if the repo already exists.
 helm repo add camunda https://helm.camunda.io --force-update
 helm repo update

--- a/generic/openshift/single-region/procedure/install-chart.sh
+++ b/generic/openshift/single-region/procedure/install-chart.sh
@@ -1,6 +1,21 @@
 #!/bin/bash
 set -euo pipefail
 
+# Warn that this deploys an unreleased, in-development chart (to stderr).
+cat >&2 <<'PRERELEASE_WARNING'
+
+  ############################################################################
+  #  ⚠  PRE-RELEASE — NOT A STABLE CAMUNDA RELEASE                           #
+  #                                                                          #
+  #  This deploys an unreleased, in-development Camunda 8 chart.             #
+  #  It may be unstable or fail to start — that is expected here.            #
+  #                                                                          #
+  #  Need a stable, supported setup? Follow the Administrator quickstart:    #
+  #  https://docs.camunda.io/docs/self-managed/quickstart/administrator-quickstart/
+  ############################################################################
+
+PRERELEASE_WARNING
+
 helm upgrade --install \
     "$CAMUNDA_RELEASE_NAME" oci://registry.camunda.cloud/team-distribution/camunda-platform \
     --version "$CAMUNDA_HELM_CHART_VERSION" --namespace "$CAMUNDA_NAMESPACE" \

--- a/generic/openshift/single-region/procedure/install-chart.sh
+++ b/generic/openshift/single-region/procedure/install-chart.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 # Warn that this deploys an unreleased, in-development chart (to stderr).
+# TODO: [release-duty] remove this pre-release warning at release.
 cat >&2 <<'PRERELEASE_WARNING'
 
   ############################################################################


### PR DESCRIPTION
The reference architectures deploy the unreleased `15-dev-latest` chart (via the private OCI registry). This adds a consistent pre-release warning at the shared install touchpoints, complementing the kind guide (#2823 / #2827).

## Changes

Print a prominent PRE-RELEASE warning (to stderr) at each shared chart-install touchpoint:

- `generic/kubernetes/single-region/procedure/install-chart.sh` — used by EKS/AKS single-region + operator-based
- `generic/openshift/single-region/procedure/install-chart.sh` — used by ROSA single-region
- `generic/openshift/dual-region/procedure/install-chart.sh` — used by ROSA dual-region
- `aws/kubernetes/eks-dual-region/procedure/export_environment_prerequisites.sh` — EKS dual-region (Go-test based)

The message points users who need a stable setup to the [Administrator quickstart](https://docs.camunda.io/docs/self-managed/quickstart/administrator-quickstart/).

## Notes

- These scripts are embedded verbatim into the **unreleased/"next" docs** (via the github-codeblock plugin), so the warning surfaces in the published install docs too. The stable versioned docs pin `blob/stable/8.x`, so they are unaffected unless backported.
- **No acknowledgement gate here** (unlike the kind guide): these pull from the private registry (internal audience) and are docs-embedded, where an interactive prompt would be inappropriate. Just an informational warning.
- Not merged — merging is a human action.
