### PR TITLE
fix(ecs-dual-region): use single shared backup bucket across both regions

### DIFF
--- a/aws/containers/ecs-dual-region-fargate/terraform/app/camunda.tf
+++ b/aws/containers/ecs-dual-region-fargate/terraform/app/camunda.tf
@@ -54,6 +54,10 @@ module "orchestration_cluster_region_0" {
         name  = "CAMUNDA_DATA_BACKUP_REPOSITORYNAME"
         value = local.infra.backup_bucket_region_0_name
       },
+      {
+        name  = "CAMUNDA_DATA_BACKUP_S3_REGION"
+        value = data.aws_region.region_0.id
+      },
     ]
   )
 
@@ -148,11 +152,18 @@ module "orchestration_cluster_region_1" {
     [
       {
         name  = "CAMUNDA_DATA_BACKUP_S3_BUCKETNAME"
-        value = local.infra.backup_bucket_region_1_name
+        value = local.infra.backup_bucket_region_0_name
       },
       {
         name  = "CAMUNDA_DATA_BACKUP_REPOSITORYNAME"
-        value = local.infra.backup_bucket_region_1_name
+        value = local.infra.backup_bucket_region_0_name
+      },
+      {
+        # Explicit bucket region: region 1 brokers write cross-region to the
+        # shared bucket in region 0; the S3 client must know where the bucket
+        # lives for correct endpoint resolution.
+        name  = "CAMUNDA_DATA_BACKUP_S3_REGION"
+        value = data.aws_region.region_0.id
       },
     ]
   )
@@ -177,7 +188,7 @@ module "orchestration_cluster_region_1" {
 
   extra_task_role_attachments = concat(
     local.infra.rds_db_connect_policy_region_1_arn != null ? [local.infra.rds_db_connect_policy_region_1_arn] : [],
-    [local.infra.s3_backup_access_policy_region_1_arn],
+    [local.infra.s3_backup_access_policy_region_0_arn],
   )
 
   # See region 0 comments above.

--- a/aws/containers/ecs-dual-region-fargate/terraform/infra/README.md
+++ b/aws/containers/ecs-dual-region-fargate/terraform/infra/README.md
@@ -21,7 +21,6 @@
 | [aws_iam_policy.rds_db_connect_region_0](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.rds_db_connect_region_1](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.s3_backup_access_region_0](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
-| [aws_iam_policy.s3_backup_access_region_1](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.ecs_task_execution_region_0](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.ecs_task_execution_region_1](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.ecs_task_execution_region_0](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
@@ -29,11 +28,9 @@
 | [aws_iam_role_policy_attachment.ecs_task_secrets_region_0](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.ecs_task_secrets_region_1](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_kms_alias.s3_region_0](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
-| [aws_kms_alias.s3_region_1](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
 | [aws_kms_alias.secrets_region_0](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
 | [aws_kms_alias.secrets_region_1](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
 | [aws_kms_key.s3_region_0](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
-| [aws_kms_key.s3_region_1](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 | [aws_kms_key.secrets_region_0](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 | [aws_kms_key.secrets_region_1](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 | [aws_lb.alb_region_0](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb) | resource |
@@ -47,13 +44,9 @@
 | [aws_lb_listener.http_webapp_region_0](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
 | [aws_lb_listener.http_webapp_region_1](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
 | [aws_s3_bucket.backup_region_0](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
-| [aws_s3_bucket.backup_region_1](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket_public_access_block.backup_region_0](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
-| [aws_s3_bucket_public_access_block.backup_region_1](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
 | [aws_s3_bucket_server_side_encryption_configuration.backup_region_0](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
-| [aws_s3_bucket_server_side_encryption_configuration.backup_region_1](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
 | [aws_s3_bucket_versioning.backup_region_0](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
-| [aws_s3_bucket_versioning.backup_region_1](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
 | [aws_secretsmanager_secret.admin_user_password_region_0](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
 | [aws_secretsmanager_secret.admin_user_password_region_1](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
 | [aws_secretsmanager_secret.connectors_password_region_0](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
@@ -129,7 +122,6 @@
 | <a name="output_aurora_secondary_cluster_identifier"></a> [aurora\_secondary\_cluster\_identifier](#output\_aurora\_secondary\_cluster\_identifier) | n/a |
 | <a name="output_aurora_secondary_endpoint"></a> [aurora\_secondary\_endpoint](#output\_aurora\_secondary\_endpoint) | n/a |
 | <a name="output_backup_bucket_region_0_name"></a> [backup\_bucket\_region\_0\_name](#output\_backup\_bucket\_region\_0\_name) | n/a |
-| <a name="output_backup_bucket_region_1_name"></a> [backup\_bucket\_region\_1\_name](#output\_backup\_bucket\_region\_1\_name) | n/a |
 | <a name="output_cluster_name"></a> [cluster\_name](#output\_cluster\_name) | n/a |
 | <a name="output_connectors_password_secret_region_0_arn"></a> [connectors\_password\_secret\_region\_0\_arn](#output\_connectors\_password\_secret\_region\_0\_arn) | n/a |
 | <a name="output_connectors_password_secret_region_1_arn"></a> [connectors\_password\_secret\_region\_1\_arn](#output\_connectors\_password\_secret\_region\_1\_arn) | n/a |
@@ -158,7 +150,6 @@
 | <a name="output_registry_credentials_region_0_arn"></a> [registry\_credentials\_region\_0\_arn](#output\_registry\_credentials\_region\_0\_arn) | n/a |
 | <a name="output_registry_credentials_region_1_arn"></a> [registry\_credentials\_region\_1\_arn](#output\_registry\_credentials\_region\_1\_arn) | n/a |
 | <a name="output_s3_backup_access_policy_region_0_arn"></a> [s3\_backup\_access\_policy\_region\_0\_arn](#output\_s3\_backup\_access\_policy\_region\_0\_arn) | n/a |
-| <a name="output_s3_backup_access_policy_region_1_arn"></a> [s3\_backup\_access\_policy\_region\_1\_arn](#output\_s3\_backup\_access\_policy\_region\_1\_arn) | n/a |
 | <a name="output_s3_force_destroy"></a> [s3\_force\_destroy](#output\_s3\_force\_destroy) | n/a |
 | <a name="output_secondary_storage_type"></a> [secondary\_storage\_type](#output\_secondary\_storage\_type) | n/a |
 | <a name="output_sg_camunda_ports_region_0_id"></a> [sg\_camunda\_ports\_region\_0\_id](#output\_sg\_camunda\_ports\_region\_0\_id) | n/a |

--- a/aws/containers/ecs-dual-region-fargate/terraform/infra/kms.tf
+++ b/aws/containers/ecs-dual-region-fargate/terraform/infra/kms.tf
@@ -94,22 +94,3 @@ resource "aws_kms_alias" "s3_region_0" {
   name          = "alias/${local.prefix_region_0}-s3-key"
   target_key_id = aws_kms_key.s3_region_0.key_id
 }
-
-resource "aws_kms_key" "s3_region_1" {
-  provider = aws.accepter
-
-  description             = "KMS key for ${local.prefix_region_1} S3 bucket encryption"
-  deletion_window_in_days = 7
-  enable_key_rotation     = true
-
-  tags = {
-    Name = "${local.prefix_region_1}-s3-kms-key"
-  }
-}
-
-resource "aws_kms_alias" "s3_region_1" {
-  provider = aws.accepter
-
-  name          = "alias/${local.prefix_region_1}-s3-key"
-  target_key_id = aws_kms_key.s3_region_1.key_id
-}

--- a/aws/containers/ecs-dual-region-fargate/terraform/infra/outputs.tf
+++ b/aws/containers/ecs-dual-region-fargate/terraform/infra/outputs.tf
@@ -171,9 +171,6 @@ output "s3_backup_access_policy_region_0_arn" {
   value = aws_iam_policy.s3_backup_access_region_0.arn
 }
 
-output "s3_backup_access_policy_region_1_arn" {
-  value = aws_iam_policy.s3_backup_access_region_1.arn
-}
 
 ################################################################
 #                        Secrets Outputs                       #
@@ -257,9 +254,6 @@ output "backup_bucket_region_0_name" {
   value = aws_s3_bucket.backup_region_0.bucket
 }
 
-output "backup_bucket_region_1_name" {
-  value = aws_s3_bucket.backup_region_1.bucket
-}
 
 output "s3_force_destroy" {
   value = var.s3_force_destroy

--- a/aws/containers/ecs-dual-region-fargate/terraform/infra/s3.tf
+++ b/aws/containers/ecs-dual-region-fargate/terraform/infra/s3.tf
@@ -80,4 +80,3 @@ resource "aws_iam_policy" "s3_backup_access_region_0" {
     ]
   })
 }
-

--- a/aws/containers/ecs-dual-region-fargate/terraform/infra/s3.tf
+++ b/aws/containers/ecs-dual-region-fargate/terraform/infra/s3.tf
@@ -1,5 +1,11 @@
 ################################################################
-#               Backup S3 Buckets (per region)                 #
+#               Backup S3 Bucket (shared, region 0)            #
+#                                                              #
+# Single bucket shared by both regions. All backup data lands  #
+# wherever the Zeebe partition leader runs; with per-region    #
+# buckets the restore-side bucket is always empty. Region 1    #
+# brokers write cross-region — S3 is globally accessible with  #
+# the right IAM permissions, and the AWS SDK handles routing.  #
 ################################################################
 
 # Region 0 backup bucket
@@ -32,46 +38,6 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "backup_region_0" 
 
 resource "aws_s3_bucket_versioning" "backup_region_0" {
   bucket = aws_s3_bucket.backup_region_0.id
-
-  versioning_configuration {
-    status = "Enabled"
-  }
-}
-
-# Region 1 backup bucket
-#trivy:ignore:AVD-AWS-0089 Bucket logging disabled to simplify setup
-resource "aws_s3_bucket" "backup_region_1" {
-  provider      = aws.accepter
-  bucket        = "${local.prefix_region_1}-backup-${local.bucket_suffix}"
-  force_destroy = var.s3_force_destroy
-}
-
-resource "aws_s3_bucket_public_access_block" "backup_region_1" {
-  provider = aws.accepter
-  bucket   = aws_s3_bucket.backup_region_1.id
-
-  block_public_acls       = true
-  block_public_policy     = true
-  ignore_public_acls      = true
-  restrict_public_buckets = true
-}
-
-resource "aws_s3_bucket_server_side_encryption_configuration" "backup_region_1" {
-  provider = aws.accepter
-  bucket   = aws_s3_bucket.backup_region_1.id
-
-  rule {
-    apply_server_side_encryption_by_default {
-      kms_master_key_id = aws_kms_key.s3_region_1.arn
-      sse_algorithm     = "aws:kms"
-    }
-    bucket_key_enabled = true
-  }
-}
-
-resource "aws_s3_bucket_versioning" "backup_region_1" {
-  provider = aws.accepter
-  bucket   = aws_s3_bucket.backup_region_1.id
 
   versioning_configuration {
     status = "Enabled"
@@ -117,39 +83,3 @@ resource "aws_iam_policy" "s3_backup_access_region_0" {
   })
 }
 
-resource "aws_iam_policy" "s3_backup_access_region_1" {
-  provider = aws.accepter
-
-  name        = "${local.prefix_region_1}-s3-backup-access"
-  description = "S3 backup bucket access for region 1"
-
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Action = [
-          "s3:GetObject",
-          "s3:PutObject",
-          "s3:DeleteObject",
-          "s3:ListBucket",
-          "s3:GetBucketLocation"
-        ]
-        Resource = [
-          aws_s3_bucket.backup_region_1.arn,
-          "${aws_s3_bucket.backup_region_1.arn}/*"
-        ]
-      },
-      {
-        Effect = "Allow"
-        Action = [
-          "kms:Decrypt",
-          "kms:Encrypt",
-          "kms:GenerateDataKey",
-          "kms:DescribeKey"
-        ]
-        Resource = [aws_kms_key.s3_region_1.arn]
-      }
-    ]
-  })
-}

--- a/aws/containers/ecs-dual-region-fargate/terraform/infra/s3.tf
+++ b/aws/containers/ecs-dual-region-fargate/terraform/infra/s3.tf
@@ -1,11 +1,9 @@
 ################################################################
-#               Backup S3 Bucket (shared, region 0)            #
+#            Backup S3 Bucket (single, shared by both regions) #
 #                                                              #
-# Single bucket shared by both regions. All backup data lands  #
-# wherever the Zeebe partition leader runs; with per-region    #
-# buckets the restore-side bucket is always empty. Region 1    #
-# brokers write cross-region — S3 is globally accessible with  #
-# the right IAM permissions, and the AWS SDK handles routing.  #
+# Both regions write backups to this bucket and restore from   #
+# it. A single shared bucket ensures all backup data is in     #
+# one place, regardless of which region is active.             #
 ################################################################
 
 # Region 0 backup bucket


### PR DESCRIPTION
## Summary

- Remove region 1 backup bucket and its IAM policy from `infra/s3.tf` — both regions now share region 0's bucket
- Remove orphaned `aws_kms_key.s3_region_1` and `aws_kms_alias.s3_region_1` from `infra/kms.tf` (sole consumer was the deleted bucket)
- Remove stale `backup_bucket_region_1_name` and `s3_backup_access_policy_region_1_arn` outputs from `infra/outputs.tf`
- Update region 1 module in `app/camunda.tf` to reference region 0's bucket name and IAM policy
- Add explicit `CAMUNDA_DATA_BACKUP_S3_REGION` env var on both modules (set to region 0, the bucket's home region)

## Why

Confirmed finding by Andreas Hauser (tested and passing), confirmed by Carlo Sana (2026-07-03): with per-region buckets, restore fails because Zeebe partition leaders can be in either region, so all backup data lands in one bucket while the other stays empty. A single shared bucket ensures all backup data is in one place regardless of which region is active.

## Migration note for existing deployments

Removing the region 1 backup bucket resource will cause `terraform apply` to destroy it. If the bucket contains existing backup data, either empty it manually first or set `s3_force_destroy = true` in `terraform/infra/terraform.tfvars` before applying.

## Test plan

- [ ] `terraform plan` on `infra/` shows destruction of region 1 backup bucket, its IAM policy, and its KMS key/alias only — no other unexpected changes
- [ ] `terraform plan` on `app/` shows updated env vars on region 1 module (`CAMUNDA_DATA_BACKUP_S3_BUCKETNAME`, `CAMUNDA_DATA_BACKUP_REPOSITORYNAME`, `CAMUNDA_DATA_BACKUP_S3_REGION`) and updated `extra_task_role_attachments`
- [ ] CI integration test passes