### PR TITLE
feat(helm): source-build the generic ref-arch charts (no OCI auth) and warn on pre-release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,6 +135,9 @@ debug/**
 debug
 camunda-platform-helm
 camunda-platform-helm/**
+# Local chart checkout created by the shared build-camunda-chart.sh helper.
+.camunda-platform-helm
+.camunda-platform-helm/**
 
 # Exclude actionlint binary
 actionlint

--- a/aws/kubernetes/eks-dual-region/procedure/export_environment_prerequisites.sh
+++ b/aws/kubernetes/eks-dual-region/procedure/export_environment_prerequisites.sh
@@ -14,7 +14,7 @@ cat >&2 <<'PRERELEASE_WARNING'
   ############################################################################
   #  ⚠  PRE-RELEASE — NOT A STABLE CAMUNDA RELEASE                           #
   #                                                                          #
-  #  This deploys an unreleased, in-development Camunda 8 chart.             #
+  #  This targets an unreleased, in-development Camunda 8 chart.             #
   #  It may be unstable or fail to start — that is expected here.            #
   #                                                                          #
   #  Need a stable, supported setup? Follow the Administrator quickstart:    #

--- a/aws/kubernetes/eks-dual-region/procedure/export_environment_prerequisites.sh
+++ b/aws/kubernetes/eks-dual-region/procedure/export_environment_prerequisites.sh
@@ -8,6 +8,21 @@
 # . ./export_environment_prerequisites.sh
 # to export the environment variables to the current shell
 
+# Warn that this targets an unreleased, in-development chart (to stderr).
+cat >&2 <<'PRERELEASE_WARNING'
+
+  ############################################################################
+  #  ⚠  PRE-RELEASE — NOT A STABLE CAMUNDA RELEASE                           #
+  #                                                                          #
+  #  This deploys an unreleased, in-development Camunda 8 chart.             #
+  #  It may be unstable or fail to start — that is expected here.            #
+  #                                                                          #
+  #  Need a stable, supported setup? Follow the Administrator quickstart:    #
+  #  https://docs.camunda.io/docs/self-managed/quickstart/administrator-quickstart/
+  ############################################################################
+
+PRERELEASE_WARNING
+
 # The AWS regions of your Kubernetes cluster 0 and 1
 export REGION_0=${REGION_0:-eu-west-2}
 export REGION_1=${REGION_1:-eu-west-3}

--- a/aws/kubernetes/eks-dual-region/procedure/export_environment_prerequisites.sh
+++ b/aws/kubernetes/eks-dual-region/procedure/export_environment_prerequisites.sh
@@ -9,6 +9,7 @@
 # to export the environment variables to the current shell
 
 # Warn that this targets an unreleased, in-development chart (to stderr).
+# TODO: [release-duty] remove this pre-release warning at release.
 cat >&2 <<'PRERELEASE_WARNING'
 
   ############################################################################

--- a/generic/kubernetes/single-region/procedure/build-camunda-chart.sh
+++ b/generic/kubernetes/single-region/procedure/build-camunda-chart.sh
@@ -17,7 +17,9 @@ set -euo pipefail
 #   CAMUNDA_HELM_CHART_CHECKOUT_DIR  clone location; must be an absolute path
 
 _chart_src_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-_repo_root="$(git -C "$_chart_src_dir" rev-parse --show-toplevel)"
+# Repo root computed relative to this script (generic/kubernetes/single-region/
+# procedure), so the helper works even without a .git dir (e.g. a source archive).
+_repo_root="$(cd "$_chart_src_dir/../../../.." && pwd)"
 _camunda_version="$(cat "$_repo_root/.camunda-version")"
 
 _chart_git_url="${CAMUNDA_HELM_CHART_GIT_URL:-https://github.com/camunda/camunda-platform-helm.git}"

--- a/generic/kubernetes/single-region/procedure/build-camunda-chart.sh
+++ b/generic/kubernetes/single-region/procedure/build-camunda-chart.sh
@@ -33,9 +33,15 @@ _camunda_version="$(cat "$_repo_root/.camunda-version")"
 _chart_git_url="${CAMUNDA_HELM_CHART_GIT_URL:-https://github.com/camunda/camunda-platform-helm.git}"
 # Pin to the released chart tag the guides target (the pre-release 15.x line), not a
 # moving 'main': 'main' can be mid-migration and drop components (e.g. console when
-# values move under camundaHub), which breaks the deployment tests.
-# TODO: [release-duty] bump this tag alongside CAMUNDA_HELM_CHART_VERSION and the helm-values.
-_chart_git_ref="${CAMUNDA_HELM_CHART_GIT_REF:-camunda-platform-8.10-15.0.0-alpha2}"
+# values move under camundaHub) or ship an inconsistent set of component images,
+# which breaks the deployment tests. Renovate bumps the pin below only once a newer
+# 8.10 chart tag is *published* (not the moving 'main' tip); the default is split out
+# on its own line so the '# renovate:' inline manager can parse it (the ${VAR:-...}
+# override wrapper is not cleanly matchable).
+# renovate: datasource=github-tags depName=camunda/camunda-platform-helm versioning=regex:^camunda-platform-8\.10-(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)(?:-(?<prerelease>.+))?$
+_chart_default_git_ref="camunda-platform-8.10-15.0.0-alpha2"
+# TODO: [release-duty] bump the 8.10 pin above as the 15.x line advances (keep in sync with CAMUNDA_HELM_CHART_VERSION and the helm-values).
+_chart_git_ref="${CAMUNDA_HELM_CHART_GIT_REF:-$_chart_default_git_ref}"
 _default_checkout_dir="$_repo_root/.camunda-platform-helm"
 _chart_checkout_dir="${CAMUNDA_HELM_CHART_CHECKOUT_DIR:-$_default_checkout_dir}"
 

--- a/generic/kubernetes/single-region/procedure/build-camunda-chart.sh
+++ b/generic/kubernetes/single-region/procedure/build-camunda-chart.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+set -euo pipefail
+
+# Build the Camunda Helm chart from source (camunda/camunda-platform-helm) so the
+# reference architectures need no registry authentication during the pre-release
+# phase. Prints the built chart directory on stdout; capture it with:
+#   LOCAL_CHART="$(.../procedure/build-camunda-chart.sh)"
+#
+# Shared by the generic install scripts (kubernetes/openshift, single/dual region).
+#
+# TODO: [release-duty] delete this helper at release time — the guides then install
+# the published chart from https://helm.camunda.io.
+#
+# Optional overrides (env vars):
+#   CAMUNDA_HELM_CHART_GIT_URL       source repo URL
+#   CAMUNDA_HELM_CHART_GIT_REF       branch or tag to build (passed to git clone --branch)
+#   CAMUNDA_HELM_CHART_CHECKOUT_DIR  clone location; must be an absolute path
+
+_chart_src_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_repo_root="$(git -C "$_chart_src_dir" rev-parse --show-toplevel)"
+_camunda_version="$(cat "$_repo_root/.camunda-version")"
+
+_chart_git_url="${CAMUNDA_HELM_CHART_GIT_URL:-https://github.com/camunda/camunda-platform-helm.git}"
+# Pin to the released chart tag the guides target (the pre-release 15.x line), not a
+# moving 'main': 'main' can be mid-migration and drop components (e.g. console when
+# values move under camundaHub), which breaks the deployment tests.
+# TODO: [release-duty] bump this tag alongside CAMUNDA_HELM_CHART_VERSION and the helm-values.
+_chart_git_ref="${CAMUNDA_HELM_CHART_GIT_REF:-camunda-platform-8.10-15.0.0-alpha2}"
+_default_checkout_dir="$_repo_root/.camunda-platform-helm"
+_chart_checkout_dir="${CAMUNDA_HELM_CHART_CHECKOUT_DIR:-$_default_checkout_dir}"
+
+# The checkout dir is overridable and is deleted+recreated below, so validate it
+# before the rm -rf: it must be an absolute path, contain no '.'/'..' segments, and
+# not be the filesystem root; and a pre-existing dir must carry our marker file, so
+# we only ever delete a checkout this script created. '--' below also keeps a value
+# starting with '-' from being read as a flag.
+_clone_marker=".built-by-build-camunda-chart"
+if [[ "$_chart_checkout_dir" != /* ]]; then
+    echo "ERROR: CAMUNDA_HELM_CHART_CHECKOUT_DIR must be an absolute path, got: '$_chart_checkout_dir'" >&2
+    exit 1
+fi
+case "/$_chart_checkout_dir/" in
+    */../* | */./*)
+        echo "ERROR: CAMUNDA_HELM_CHART_CHECKOUT_DIR must not contain '.' or '..' path segments: '$_chart_checkout_dir'" >&2
+        exit 1
+        ;;
+esac
+# Reject the filesystem root outright (any number of trailing slashes), so rm -rf
+# can never target '/' even if a stray marker file were present there.
+_root_probe="$_chart_checkout_dir"
+while [[ "$_root_probe" == */ ]]; do _root_probe="${_root_probe%/}"; done
+if [[ -z "$_root_probe" ]]; then
+    echo "ERROR: refusing to use the filesystem root as the checkout directory." >&2
+    exit 1
+fi
+# Use the trailing-slash-stripped form for every use below, so 'rm -rf' can never
+# follow a symlink via a path that ends in '/'.
+_chart_checkout_dir="$_root_probe"
+if [[ -e "$_chart_checkout_dir" && ! -f "$_chart_checkout_dir/$_clone_marker" ]]; then
+    echo "ERROR: '$_chart_checkout_dir' already exists and was not created by this script; refusing to delete it." >&2
+    exit 1
+fi
+
+# Progress goes to stderr so stdout carries only the chart path.
+echo "Building Camunda Helm chart 'camunda-platform-$_camunda_version' from source (ref: $_chart_git_ref)..." >&2
+rm -rf -- "$_chart_checkout_dir"
+if ! git clone --depth 1 --branch "$_chart_git_ref" -- "$_chart_git_url" "$_chart_checkout_dir" >&2; then
+    # Remove the partial checkout so the marker guard does not block a rerun.
+    rm -rf -- "$_chart_checkout_dir"
+    echo "ERROR: failed to clone '$_chart_git_url' (ref '$_chart_git_ref')." >&2
+    exit 1
+fi
+if ! touch "$_chart_checkout_dir/$_clone_marker"; then
+    # Remove the partial checkout so the marker guard does not block a rerun.
+    rm -rf -- "$_chart_checkout_dir"
+    echo "ERROR: failed to write the marker file in '$_chart_checkout_dir'." >&2
+    exit 1
+fi
+
+_local_chart="$_chart_checkout_dir/charts/camunda-platform-$_camunda_version"
+if [[ ! -d "$_local_chart" ]]; then
+    echo "ERROR: chart 'camunda-platform-$_camunda_version' not found on ref '$_chart_git_ref'." >&2
+    echo "       Expected directory: $_local_chart" >&2
+    exit 1
+fi
+
+# Resolve the file:// "common" dependency locally (no registry auth); logs to stderr.
+helm dependency update "$_local_chart" >&2
+
+echo "$_local_chart"

--- a/generic/kubernetes/single-region/procedure/build-camunda-chart.sh
+++ b/generic/kubernetes/single-region/procedure/build-camunda-chart.sh
@@ -71,6 +71,11 @@ if [[ -e "$_chart_checkout_dir" && ! -f "$_chart_checkout_dir/$_clone_marker" ]]
     exit 1
 fi
 
+# On any exit or interrupt, remove a checkout that never got its marker (e.g. an
+# interrupted clone), so a rerun is not blocked by the guard above. A completed
+# build keeps its marker, so this never deletes a successful checkout.
+trap 'if [[ -e "$_chart_checkout_dir" && ! -f "$_chart_checkout_dir/$_clone_marker" ]]; then rm -rf -- "$_chart_checkout_dir"; fi' EXIT
+
 # Progress goes to stderr so stdout carries only the chart path.
 echo "Building Camunda Helm chart 'camunda-platform-$_camunda_version' from source (ref: $_chart_git_ref)..." >&2
 rm -rf -- "$_chart_checkout_dir"

--- a/generic/kubernetes/single-region/procedure/build-camunda-chart.sh
+++ b/generic/kubernetes/single-region/procedure/build-camunda-chart.sh
@@ -16,6 +16,14 @@ set -euo pipefail
 #   CAMUNDA_HELM_CHART_GIT_REF       branch or tag to build (passed to git clone --branch)
 #   CAMUNDA_HELM_CHART_CHECKOUT_DIR  clone location; must be an absolute path
 
+# Fail fast with a clear message if a required tool is missing.
+for _tool in git helm; do
+    if ! command -v "$_tool" >/dev/null 2>&1; then
+        echo "ERROR: '$_tool' is required to build the Camunda chart from source but was not found in PATH." >&2
+        exit 1
+    fi
+done
+
 _chart_src_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Repo root computed relative to this script (generic/kubernetes/single-region/
 # procedure), so the helper works even without a .git dir (e.g. a source archive).

--- a/generic/kubernetes/single-region/procedure/install-chart.sh
+++ b/generic/kubernetes/single-region/procedure/install-chart.sh
@@ -1,5 +1,20 @@
 #!/bin/bash
 
+# Warn that this deploys an unreleased, in-development chart (to stderr).
+cat >&2 <<'PRERELEASE_WARNING'
+
+  ############################################################################
+  #  ⚠  PRE-RELEASE — NOT A STABLE CAMUNDA RELEASE                           #
+  #                                                                          #
+  #  This deploys an unreleased, in-development Camunda 8 chart.             #
+  #  It may be unstable or fail to start — that is expected here.            #
+  #                                                                          #
+  #  Need a stable, supported setup? Follow the Administrator quickstart:    #
+  #  https://docs.camunda.io/docs/self-managed/quickstart/administrator-quickstart/
+  ############################################################################
+
+PRERELEASE_WARNING
+
 helm upgrade --install \
     "$CAMUNDA_RELEASE_NAME" oci://registry.camunda.cloud/team-distribution/camunda-platform \
     --version "$CAMUNDA_HELM_CHART_VERSION" --namespace "$CAMUNDA_NAMESPACE" \

--- a/generic/kubernetes/single-region/procedure/install-chart.sh
+++ b/generic/kubernetes/single-region/procedure/install-chart.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
+set -euo pipefail
 
 # Warn that this deploys an unreleased, in-development chart (to stderr).
+# TODO: [release-duty] remove this pre-release warning at release.
 cat >&2 <<'PRERELEASE_WARNING'
 
   ############################################################################

--- a/generic/kubernetes/single-region/procedure/install-chart.sh
+++ b/generic/kubernetes/single-region/procedure/install-chart.sh
@@ -17,13 +17,18 @@ cat >&2 <<'PRERELEASE_WARNING'
 
 PRERELEASE_WARNING
 
+# Build the chart from source so no registry authentication is required; prints the
+# local chart directory.
+_script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LOCAL_CHART="$("$_script_dir/build-camunda-chart.sh")"
+
 helm upgrade --install \
-    "$CAMUNDA_RELEASE_NAME" oci://registry.camunda.cloud/team-distribution/camunda-platform \
-    --version "$CAMUNDA_HELM_CHART_VERSION" --namespace "$CAMUNDA_NAMESPACE" \
+    "$CAMUNDA_RELEASE_NAME" "$LOCAL_CHART" \
+    --namespace "$CAMUNDA_NAMESPACE" \
     -f generated-values.yml
 
-# TODO: [release-duty] before the release, update this by removing the oci pull above
-# and uncomment the installation instruction below
+# TODO: [release-duty] before the release, remove the source-build above and
+# uncomment the standard Helm install below.
 
 # helm upgrade --install \
 #   "$CAMUNDA_RELEASE_NAME" camunda-platform \

--- a/generic/openshift/dual-region/procedure/install-chart.sh
+++ b/generic/openshift/dual-region/procedure/install-chart.sh
@@ -23,7 +23,8 @@ helm repo update
 
 # Build the chart from source so no registry authentication is required; prints the
 # local chart directory. The build helper is shared with the generic k8s guide.
-LOCAL_CHART="$("$(git rev-parse --show-toplevel)/generic/kubernetes/single-region/procedure/build-camunda-chart.sh")"
+_repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+LOCAL_CHART="$("$_repo_root/generic/kubernetes/single-region/procedure/build-camunda-chart.sh")"
 
 # Resolve the broker image of the chart being installed so the cross-region
 # DNS-gate initContainer (see helm-values/values-base.yml) reuses the exact

--- a/generic/openshift/dual-region/procedure/install-chart.sh
+++ b/generic/openshift/dual-region/procedure/install-chart.sh
@@ -21,6 +21,10 @@ PRERELEASE_WARNING
 helm repo add camunda https://helm.camunda.io --force-update
 helm repo update
 
+# Build the chart from source so no registry authentication is required; prints the
+# local chart directory. The build helper is shared with the generic k8s guide.
+LOCAL_CHART="$("$(git rev-parse --show-toplevel)/generic/kubernetes/single-region/procedure/build-camunda-chart.sh")"
+
 # Resolve the broker image of the chart being installed so the cross-region
 # DNS-gate initContainer (see helm-values/values-base.yml) reuses the exact
 # same image as the broker — already pulled on the node, no extra pull, and no
@@ -32,13 +36,10 @@ if ! command -v yq >/dev/null 2>&1; then
   echo "ERROR: 'yq' is required to resolve the broker image for the cross-region DNS gate but was not found in PATH." >&2
   exit 1
 fi
-# TODO: [release-duty] before the release, switch the chart reference below from the
-# dev OCI registry (oci://registry.camunda.cloud/team-distribution/camunda-platform)
-# to the public chart `camunda/camunda-platform`, consistent with the install commands
-# at the bottom of this file.
-BROKER_IMAGE="$(helm show values \
-  oci://registry.camunda.cloud/team-distribution/camunda-platform \
-  --version "$HELM_CHART_VERSION" \
+# TODO: [release-duty] before the release, resolve the broker image from the public
+# chart `camunda/camunda-platform` instead of the source-built chart, consistent with
+# the install commands at the bottom of this file.
+BROKER_IMAGE="$(helm show values "$LOCAL_CHART" \
   | yq -r '(.orchestration.image // .zeebe.image) | ([.registry, .repository] | map(. // "") | map(select(. != "")) | join("/")) + ":" + .tag')"
 # Guard against a malformed result (e.g. unexpected chart values shape) so we never
 # substitute an invalid image into the generated values and fail later with a confusing
@@ -64,23 +65,19 @@ for region_values in generated-values-region-0.yml generated-values-region-1.yml
 done
 
 helm upgrade --install \
-  "$CAMUNDA_RELEASE_NAME" \
-   oci://registry.camunda.cloud/team-distribution/camunda-platform \
-  --version "$HELM_CHART_VERSION" \
+  "$CAMUNDA_RELEASE_NAME" "$LOCAL_CHART" \
   --kube-context "$CLUSTER_0" \
   --namespace "$CAMUNDA_NAMESPACE_0" \
   -f generated-values-region-0.yml
 
 helm upgrade --install \
-  "$CAMUNDA_RELEASE_NAME" \
-   oci://registry.camunda.cloud/team-distribution/camunda-platform \
-  --version "$HELM_CHART_VERSION" \
+  "$CAMUNDA_RELEASE_NAME" "$LOCAL_CHART" \
   --kube-context "$CLUSTER_1" \
   --namespace "$CAMUNDA_NAMESPACE_1" \
   -f generated-values-region-1.yml
 
-# TODO: [release-duty] before the release, update this by removing the oci pull above
-# and uncomment the installation instruction below
+# TODO: [release-duty] before the release, remove the source-build above and
+# uncomment the installation instruction below
 
 # helm upgrade --install \
 #    "$CAMUNDA_RELEASE_NAME" camunda/camunda-platform \

--- a/generic/openshift/dual-region/procedure/install-chart.sh
+++ b/generic/openshift/dual-region/procedure/install-chart.sh
@@ -17,10 +17,6 @@ cat >&2 <<'PRERELEASE_WARNING'
 
 PRERELEASE_WARNING
 
-# --force-update keeps this idempotent under `set -e` if the repo already exists.
-helm repo add camunda https://helm.camunda.io --force-update
-helm repo update
-
 # Build the chart from source so no registry authentication is required; prints the
 # local chart directory. The build helper is shared with the generic k8s guide.
 _repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
@@ -79,6 +75,10 @@ helm upgrade --install \
 
 # TODO: [release-duty] before the release, remove the source-build above and
 # uncomment the installation instruction below
+
+# # --force-update keeps this idempotent under `set -e` if the repo already exists.
+# helm repo add camunda https://helm.camunda.io --force-update
+# helm repo update
 
 # helm upgrade --install \
 #    "$CAMUNDA_RELEASE_NAME" camunda/camunda-platform \

--- a/generic/openshift/dual-region/procedure/install-chart.sh
+++ b/generic/openshift/dual-region/procedure/install-chart.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 # Warn that this deploys an unreleased, in-development chart (to stderr).
+# TODO: [release-duty] remove this pre-release warning at release.
 cat >&2 <<'PRERELEASE_WARNING'
 
   ############################################################################

--- a/generic/openshift/dual-region/procedure/install-chart.sh
+++ b/generic/openshift/dual-region/procedure/install-chart.sh
@@ -1,6 +1,21 @@
 #!/bin/bash
 set -euo pipefail
 
+# Warn that this deploys an unreleased, in-development chart (to stderr).
+cat >&2 <<'PRERELEASE_WARNING'
+
+  ############################################################################
+  #  ⚠  PRE-RELEASE — NOT A STABLE CAMUNDA RELEASE                           #
+  #                                                                          #
+  #  This deploys an unreleased, in-development Camunda 8 chart.             #
+  #  It may be unstable or fail to start — that is expected here.            #
+  #                                                                          #
+  #  Need a stable, supported setup? Follow the Administrator quickstart:    #
+  #  https://docs.camunda.io/docs/self-managed/quickstart/administrator-quickstart/
+  ############################################################################
+
+PRERELEASE_WARNING
+
 # --force-update keeps this idempotent under `set -e` if the repo already exists.
 helm repo add camunda https://helm.camunda.io --force-update
 helm repo update

--- a/generic/openshift/dual-region/procedure/install-chart.sh
+++ b/generic/openshift/dual-region/procedure/install-chart.sh
@@ -17,6 +17,14 @@ cat >&2 <<'PRERELEASE_WARNING'
 
 PRERELEASE_WARNING
 
+# yq is required below to resolve the broker image for the cross-region DNS gate.
+# Check it up front so we fail fast with a clear message before the network-heavy
+# chart source-build, instead of a generic "command not found" mid-install.
+if ! command -v yq >/dev/null 2>&1; then
+  echo "ERROR: 'yq' is required to resolve the broker image for the cross-region DNS gate but was not found in PATH." >&2
+  exit 1
+fi
+
 # Build the chart from source so no registry authentication is required; prints the
 # local chart directory. The build helper is shared with the generic k8s guide.
 _repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
@@ -27,12 +35,6 @@ LOCAL_CHART="$("$_repo_root/generic/kubernetes/single-region/procedure/build-cam
 # same image as the broker — already pulled on the node, no extra pull, and no
 # hardcoded tag to maintain. The generated values carry a literal ${BROKER_IMAGE}
 # placeholder (passed through the first envsubst via ${DOLLAR}); resolve it here.
-# yq is required for this; fail fast with a clear message instead of a generic
-# "command not found" in the middle of the install flow.
-if ! command -v yq >/dev/null 2>&1; then
-  echo "ERROR: 'yq' is required to resolve the broker image for the cross-region DNS gate but was not found in PATH." >&2
-  exit 1
-fi
 # TODO: [release-duty] before the release, resolve the broker image from the public
 # chart `camunda/camunda-platform` instead of the source-built chart, consistent with
 # the install commands at the bottom of this file.

--- a/generic/openshift/single-region/procedure/install-chart.sh
+++ b/generic/openshift/single-region/procedure/install-chart.sh
@@ -1,6 +1,21 @@
 #!/bin/bash
 set -euo pipefail
 
+# Warn that this deploys an unreleased, in-development chart (to stderr).
+cat >&2 <<'PRERELEASE_WARNING'
+
+  ############################################################################
+  #  ⚠  PRE-RELEASE — NOT A STABLE CAMUNDA RELEASE                           #
+  #                                                                          #
+  #  This deploys an unreleased, in-development Camunda 8 chart.             #
+  #  It may be unstable or fail to start — that is expected here.            #
+  #                                                                          #
+  #  Need a stable, supported setup? Follow the Administrator quickstart:    #
+  #  https://docs.camunda.io/docs/self-managed/quickstart/administrator-quickstart/
+  ############################################################################
+
+PRERELEASE_WARNING
+
 helm upgrade --install \
     "$CAMUNDA_RELEASE_NAME" oci://registry.camunda.cloud/team-distribution/camunda-platform \
     --version "$CAMUNDA_HELM_CHART_VERSION" --namespace "$CAMUNDA_NAMESPACE" \

--- a/generic/openshift/single-region/procedure/install-chart.sh
+++ b/generic/openshift/single-region/procedure/install-chart.sh
@@ -19,7 +19,8 @@ PRERELEASE_WARNING
 
 # Build the chart from source so no registry authentication is required; prints the
 # local chart directory. The build helper is shared with the generic k8s guide.
-LOCAL_CHART="$("$(git rev-parse --show-toplevel)/generic/kubernetes/single-region/procedure/build-camunda-chart.sh")"
+_repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+LOCAL_CHART="$("$_repo_root/generic/kubernetes/single-region/procedure/build-camunda-chart.sh")"
 
 helm upgrade --install \
     "$CAMUNDA_RELEASE_NAME" "$LOCAL_CHART" \

--- a/generic/openshift/single-region/procedure/install-chart.sh
+++ b/generic/openshift/single-region/procedure/install-chart.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 # Warn that this deploys an unreleased, in-development chart (to stderr).
+# TODO: [release-duty] remove this pre-release warning at release.
 cat >&2 <<'PRERELEASE_WARNING'
 
   ############################################################################

--- a/generic/openshift/single-region/procedure/install-chart.sh
+++ b/generic/openshift/single-region/procedure/install-chart.sh
@@ -17,13 +17,17 @@ cat >&2 <<'PRERELEASE_WARNING'
 
 PRERELEASE_WARNING
 
+# Build the chart from source so no registry authentication is required; prints the
+# local chart directory. The build helper is shared with the generic k8s guide.
+LOCAL_CHART="$("$(git rev-parse --show-toplevel)/generic/kubernetes/single-region/procedure/build-camunda-chart.sh")"
+
 helm upgrade --install \
-    "$CAMUNDA_RELEASE_NAME" oci://registry.camunda.cloud/team-distribution/camunda-platform \
-    --version "$CAMUNDA_HELM_CHART_VERSION" --namespace "$CAMUNDA_NAMESPACE" \
+    "$CAMUNDA_RELEASE_NAME" "$LOCAL_CHART" \
+    --namespace "$CAMUNDA_NAMESPACE" \
     -f generated-values.yml
 
-# TODO: [release-duty] before the release, update this by removing the oci pull above
-# and uncomment the installation instruction below
+# TODO: [release-duty] before the release, remove the source-build above and
+# uncomment the standard Helm install below.
 
 # helm upgrade --install \
 #   "$CAMUNDA_RELEASE_NAME" camunda-platform \


### PR DESCRIPTION
Removes the private OCI registry dependency for the generic (shell-based) reference architectures **and** adds a pre-release warning at each install point. Combines the pre-release warnings (originally #2828, folded in here) with the source-build switch, mirroring the kind guide (#2823 / #2827).

## Source-build (remove the OCI dependency)

- **New shared helper** `generic/kubernetes/single-region/procedure/build-camunda-chart.sh` — `git clone`s `camunda/camunda-platform-helm` at the pinned `camunda-platform-8.10-15.0.0-alpha2` tag (the pre-release 15.x line the guides target; overridable via `CAMUNDA_HELM_CHART_GIT_REF`), runs `helm dependency update`, prints the local chart path. Safety-guarded (absolute path, no `.`/`..` segments, not root, marker-based deletion, EXIT-trap cleanup, upfront `git`/`helm` check). No registry auth (the chart's only dependency is the in-repo `common` library via `file://`). Repo root is resolved via `${BASH_SOURCE[0]}` (works without a `.git` dir).
- **Switch to source-build:** `generic/kubernetes/single-region` + `generic/openshift/single-region` + `generic/openshift/dual-region` `install-chart.sh` — both region installs **and** the broker-image `helm show values` now use the local chart.
- gitignore the `.camunda-platform-helm` checkout.

## Pre-release warning

- Prominent PRE-RELEASE warning (to stderr) at each install touchpoint + the EKS dual-region prereq script, pointing to the [Administrator quickstart](https://docs.camunda.io/docs/self-managed/quickstart/administrator-quickstart/). Flagged `[release-duty]` for removal at GA. These scripts are embedded verbatim into the unreleased docs, so the warning surfaces there too.

## Notes

- **Supersedes #2828** (its warnings are folded in here).
- **Pinned to the published dev tag, not `main`.** `main` can be mid-migration: it currently pins `identity:8.10.0-alpha3`, whose Keycloak client-init (`assignPermissions` → `findResourceServerByAudience`) 404s at startup and CrashLoops, taking the whole deployment down. The `…-alpha2` tag is the last known-good, self-consistent image set (passed EKS + ROSA single-region). Matches the repo's current (pre-`camundaHub`) console values. `[release-duty]`: bump the tag as the 15.x line advances.
- The **EKS dual-region** install is a Go test (`helpers.go`) still using the OCI registry — a **separate follow-up**.
- Not merged — merging is a human action.
