### PR TITLE
fix(azure): switch AKS node pools to Dsv6 to fix recurring OverconstrainedZonalAllocationRequest [ready]

### DIFF
--- a/azure/kubernetes/aks-single-region-rdbms/README.md
+++ b/azure/kubernetes/aks-single-region-rdbms/README.md
@@ -73,12 +73,12 @@ Refer to the [AKS single-region documentation](../aks-single-region/README.md) f
 | <a name="input_resource_prefix_placeholder"></a> [resource\_prefix\_placeholder](#input\_resource\_prefix\_placeholder) | Placeholder for the resource prefix | `string` | `""` | no |
 | <a name="input_subscription_id"></a> [subscription\_id](#input\_subscription\_id) | The Azure Subscription ID to deploy into | `string` | n/a | yes |
 | <a name="input_system_node_pool_count"></a> [system\_node\_pool\_count](#input\_system\_node\_pool\_count) | Number of nodes in the system node pool | `number` | `1` | no |
-| <a name="input_system_node_pool_vm_size"></a> [system\_node\_pool\_vm\_size](#input\_system\_node\_pool\_vm\_size) | VM size for the system node pool | `string` | `"Standard_D2ds_v6"` | no |
+| <a name="input_system_node_pool_vm_size"></a> [system\_node\_pool\_vm\_size](#input\_system\_node\_pool\_vm\_size) | VM size for the system node pool | `string` | `"Standard_D2s_v6"` | no |
 | <a name="input_system_node_pool_zones"></a> [system\_node\_pool\_zones](#input\_system\_node\_pool\_zones) | List of AZs for the system node pool | `list(string)` | <pre>[<br/>  "1",<br/>  "2",<br/>  "3"<br/>]</pre> | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | <pre>{<br/>  "Environment": "Testing",<br/>  "Purpose": "Reference Implementation"<br/>}</pre> | no |
 | <a name="input_terraform_sp_app_id"></a> [terraform\_sp\_app\_id](#input\_terraform\_sp\_app\_id) | The Service Principals Application (client) ID that Terraform is using | `string` | n/a | yes |
 | <a name="input_user_node_pool_count"></a> [user\_node\_pool\_count](#input\_user\_node\_pool\_count) | Number of nodes in the user node pool | `number` | `5` | no |
-| <a name="input_user_node_pool_vm_size"></a> [user\_node\_pool\_vm\_size](#input\_user\_node\_pool\_vm\_size) | VM size for the user node pool | `string` | `"Standard_D4ds_v6"` | no |
+| <a name="input_user_node_pool_vm_size"></a> [user\_node\_pool\_vm\_size](#input\_user\_node\_pool\_vm\_size) | VM size for the user node pool | `string` | `"Standard_D4s_v6"` | no |
 | <a name="input_user_node_pool_zones"></a> [user\_node\_pool\_zones](#input\_user\_node\_pool\_zones) | List of AZs for the user node pool | `list(string)` | <pre>[<br/>  "1",<br/>  "2",<br/>  "3"<br/>]</pre> | no |
 | <a name="input_vnet_address_space"></a> [vnet\_address\_space](#input\_vnet\_address\_space) | Address space for the virtual network | `list(string)` | <pre>[<br/>  "10.1.0.0/16"<br/>]</pre> | no |
 ## Outputs

--- a/azure/kubernetes/aks-single-region-rdbms/README.md
+++ b/azure/kubernetes/aks-single-region-rdbms/README.md
@@ -73,12 +73,12 @@ Refer to the [AKS single-region documentation](../aks-single-region/README.md) f
 | <a name="input_resource_prefix_placeholder"></a> [resource\_prefix\_placeholder](#input\_resource\_prefix\_placeholder) | Placeholder for the resource prefix | `string` | `""` | no |
 | <a name="input_subscription_id"></a> [subscription\_id](#input\_subscription\_id) | The Azure Subscription ID to deploy into | `string` | n/a | yes |
 | <a name="input_system_node_pool_count"></a> [system\_node\_pool\_count](#input\_system\_node\_pool\_count) | Number of nodes in the system node pool | `number` | `1` | no |
-| <a name="input_system_node_pool_vm_size"></a> [system\_node\_pool\_vm\_size](#input\_system\_node\_pool\_vm\_size) | VM size for the system node pool | `string` | `"Standard_D2s_v3"` | no |
+| <a name="input_system_node_pool_vm_size"></a> [system\_node\_pool\_vm\_size](#input\_system\_node\_pool\_vm\_size) | VM size for the system node pool | `string` | `"Standard_D2ds_v6"` | no |
 | <a name="input_system_node_pool_zones"></a> [system\_node\_pool\_zones](#input\_system\_node\_pool\_zones) | List of AZs for the system node pool | `list(string)` | <pre>[<br/>  "1",<br/>  "2",<br/>  "3"<br/>]</pre> | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | <pre>{<br/>  "Environment": "Testing",<br/>  "Purpose": "Reference Implementation"<br/>}</pre> | no |
 | <a name="input_terraform_sp_app_id"></a> [terraform\_sp\_app\_id](#input\_terraform\_sp\_app\_id) | The Service Principals Application (client) ID that Terraform is using | `string` | n/a | yes |
 | <a name="input_user_node_pool_count"></a> [user\_node\_pool\_count](#input\_user\_node\_pool\_count) | Number of nodes in the user node pool | `number` | `5` | no |
-| <a name="input_user_node_pool_vm_size"></a> [user\_node\_pool\_vm\_size](#input\_user\_node\_pool\_vm\_size) | VM size for the user node pool | `string` | `"Standard_D4s_v3"` | no |
+| <a name="input_user_node_pool_vm_size"></a> [user\_node\_pool\_vm\_size](#input\_user\_node\_pool\_vm\_size) | VM size for the user node pool | `string` | `"Standard_D4ds_v6"` | no |
 | <a name="input_user_node_pool_zones"></a> [user\_node\_pool\_zones](#input\_user\_node\_pool\_zones) | List of AZs for the user node pool | `list(string)` | <pre>[<br/>  "1",<br/>  "2",<br/>  "3"<br/>]</pre> | no |
 | <a name="input_vnet_address_space"></a> [vnet\_address\_space](#input\_vnet\_address\_space) | Address space for the virtual network | `list(string)` | <pre>[<br/>  "10.1.0.0/16"<br/>]</pre> | no |
 ## Outputs

--- a/azure/kubernetes/aks-single-region-rdbms/test/golden/tfplan-golden.json
+++ b/azure/kubernetes/aks-single-region-rdbms/test/golden/tfplan-golden.json
@@ -147,7 +147,7 @@
                     "undrainable_node_behavior": null
                   }
                 ],
-                "vm_size": "Standard_D2s_v3",
+                "vm_size": "Standard_D2ds_v6",
                 "zones": [
                   "1",
                   "2",
@@ -295,7 +295,7 @@
                 "undrainable_node_behavior": null
               }
             ],
-            "vm_size": "Standard_D4s_v3",
+            "vm_size": "Standard_D4ds_v6",
             "windows_profile": [],
             "workload_runtime": null,
             "zones": [

--- a/azure/kubernetes/aks-single-region-rdbms/test/golden/tfplan-golden.json
+++ b/azure/kubernetes/aks-single-region-rdbms/test/golden/tfplan-golden.json
@@ -147,7 +147,7 @@
                     "undrainable_node_behavior": null
                   }
                 ],
-                "vm_size": "Standard_D2ds_v6",
+                "vm_size": "Standard_D2s_v6",
                 "zones": [
                   "1",
                   "2",
@@ -295,7 +295,7 @@
                 "undrainable_node_behavior": null
               }
             ],
-            "vm_size": "Standard_D4ds_v6",
+            "vm_size": "Standard_D4s_v6",
             "windows_profile": [],
             "workload_runtime": null,
             "zones": [

--- a/azure/kubernetes/aks-single-region/README.md
+++ b/azure/kubernetes/aks-single-region/README.md
@@ -41,12 +41,12 @@
 | <a name="input_resource_prefix_placeholder"></a> [resource\_prefix\_placeholder](#input\_resource\_prefix\_placeholder) | Placeholder for the resource prefix | `string` | `""` | no |
 | <a name="input_subscription_id"></a> [subscription\_id](#input\_subscription\_id) | The Azure Subscription ID to deploy into | `string` | n/a | yes |
 | <a name="input_system_node_pool_count"></a> [system\_node\_pool\_count](#input\_system\_node\_pool\_count) | Number of nodes in the system node pool | `number` | `1` | no |
-| <a name="input_system_node_pool_vm_size"></a> [system\_node\_pool\_vm\_size](#input\_system\_node\_pool\_vm\_size) | VM size for the system node pool | `string` | `"Standard_D2ds_v6"` | no |
+| <a name="input_system_node_pool_vm_size"></a> [system\_node\_pool\_vm\_size](#input\_system\_node\_pool\_vm\_size) | VM size for the system node pool | `string` | `"Standard_D2s_v6"` | no |
 | <a name="input_system_node_pool_zones"></a> [system\_node\_pool\_zones](#input\_system\_node\_pool\_zones) | List of AZs for the system node pool | `list(string)` | <pre>[<br/>  "1",<br/>  "2",<br/>  "3"<br/>]</pre> | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | <pre>{<br/>  "Environment": "Testing",<br/>  "Purpose": "Reference Implementation"<br/>}</pre> | no |
 | <a name="input_terraform_sp_app_id"></a> [terraform\_sp\_app\_id](#input\_terraform\_sp\_app\_id) | The Service Principals Application (client) ID that Terraform is using | `string` | n/a | yes |
 | <a name="input_user_node_pool_count"></a> [user\_node\_pool\_count](#input\_user\_node\_pool\_count) | Number of nodes in the user node pool | `number` | `5` | no |
-| <a name="input_user_node_pool_vm_size"></a> [user\_node\_pool\_vm\_size](#input\_user\_node\_pool\_vm\_size) | VM size for the user node pool | `string` | `"Standard_D4ds_v6"` | no |
+| <a name="input_user_node_pool_vm_size"></a> [user\_node\_pool\_vm\_size](#input\_user\_node\_pool\_vm\_size) | VM size for the user node pool | `string` | `"Standard_D4s_v6"` | no |
 | <a name="input_user_node_pool_zones"></a> [user\_node\_pool\_zones](#input\_user\_node\_pool\_zones) | List of AZs for the user node pool | `list(string)` | <pre>[<br/>  "1",<br/>  "2",<br/>  "3"<br/>]</pre> | no |
 | <a name="input_vnet_address_space"></a> [vnet\_address\_space](#input\_vnet\_address\_space) | Address space for the virtual network | `list(string)` | <pre>[<br/>  "10.1.0.0/16"<br/>]</pre> | no |
 ## Outputs

--- a/azure/kubernetes/aks-single-region/README.md
+++ b/azure/kubernetes/aks-single-region/README.md
@@ -41,12 +41,12 @@
 | <a name="input_resource_prefix_placeholder"></a> [resource\_prefix\_placeholder](#input\_resource\_prefix\_placeholder) | Placeholder for the resource prefix | `string` | `""` | no |
 | <a name="input_subscription_id"></a> [subscription\_id](#input\_subscription\_id) | The Azure Subscription ID to deploy into | `string` | n/a | yes |
 | <a name="input_system_node_pool_count"></a> [system\_node\_pool\_count](#input\_system\_node\_pool\_count) | Number of nodes in the system node pool | `number` | `1` | no |
-| <a name="input_system_node_pool_vm_size"></a> [system\_node\_pool\_vm\_size](#input\_system\_node\_pool\_vm\_size) | VM size for the system node pool | `string` | `"Standard_D2s_v3"` | no |
+| <a name="input_system_node_pool_vm_size"></a> [system\_node\_pool\_vm\_size](#input\_system\_node\_pool\_vm\_size) | VM size for the system node pool | `string` | `"Standard_D2ds_v6"` | no |
 | <a name="input_system_node_pool_zones"></a> [system\_node\_pool\_zones](#input\_system\_node\_pool\_zones) | List of AZs for the system node pool | `list(string)` | <pre>[<br/>  "1",<br/>  "2",<br/>  "3"<br/>]</pre> | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | <pre>{<br/>  "Environment": "Testing",<br/>  "Purpose": "Reference Implementation"<br/>}</pre> | no |
 | <a name="input_terraform_sp_app_id"></a> [terraform\_sp\_app\_id](#input\_terraform\_sp\_app\_id) | The Service Principals Application (client) ID that Terraform is using | `string` | n/a | yes |
 | <a name="input_user_node_pool_count"></a> [user\_node\_pool\_count](#input\_user\_node\_pool\_count) | Number of nodes in the user node pool | `number` | `5` | no |
-| <a name="input_user_node_pool_vm_size"></a> [user\_node\_pool\_vm\_size](#input\_user\_node\_pool\_vm\_size) | VM size for the user node pool | `string` | `"Standard_D4s_v3"` | no |
+| <a name="input_user_node_pool_vm_size"></a> [user\_node\_pool\_vm\_size](#input\_user\_node\_pool\_vm\_size) | VM size for the user node pool | `string` | `"Standard_D4ds_v6"` | no |
 | <a name="input_user_node_pool_zones"></a> [user\_node\_pool\_zones](#input\_user\_node\_pool\_zones) | List of AZs for the user node pool | `list(string)` | <pre>[<br/>  "1",<br/>  "2",<br/>  "3"<br/>]</pre> | no |
 | <a name="input_vnet_address_space"></a> [vnet\_address\_space](#input\_vnet\_address\_space) | Address space for the virtual network | `list(string)` | <pre>[<br/>  "10.1.0.0/16"<br/>]</pre> | no |
 ## Outputs

--- a/azure/kubernetes/aks-single-region/test/golden/tfplan-golden.json
+++ b/azure/kubernetes/aks-single-region/test/golden/tfplan-golden.json
@@ -147,7 +147,7 @@
                     "undrainable_node_behavior": null
                   }
                 ],
-                "vm_size": "Standard_D2s_v3",
+                "vm_size": "Standard_D2ds_v6",
                 "zones": [
                   "1",
                   "2",
@@ -295,7 +295,7 @@
                 "undrainable_node_behavior": null
               }
             ],
-            "vm_size": "Standard_D4s_v3",
+            "vm_size": "Standard_D4ds_v6",
             "windows_profile": [],
             "workload_runtime": null,
             "zones": [

--- a/azure/kubernetes/aks-single-region/test/golden/tfplan-golden.json
+++ b/azure/kubernetes/aks-single-region/test/golden/tfplan-golden.json
@@ -147,7 +147,7 @@
                     "undrainable_node_behavior": null
                   }
                 ],
-                "vm_size": "Standard_D2ds_v6",
+                "vm_size": "Standard_D2s_v6",
                 "zones": [
                   "1",
                   "2",
@@ -295,7 +295,7 @@
                 "undrainable_node_behavior": null
               }
             ],
-            "vm_size": "Standard_D4ds_v6",
+            "vm_size": "Standard_D4s_v6",
             "windows_profile": [],
             "workload_runtime": null,
             "zones": [

--- a/azure/kubernetes/aks-single-region/variables.tf
+++ b/azure/kubernetes/aks-single-region/variables.tf
@@ -79,7 +79,8 @@ variable "system_node_pool_count" {
 variable "system_node_pool_vm_size" {
   description = "VM size for the system node pool"
   type        = string
-  default     = "Standard_D2s_v3"
+  # Ddsv6 is a recent VM generation (as of 2026-07).
+  default = "Standard_D2ds_v6"
 }
 
 variable "user_node_pool_count" {
@@ -91,7 +92,8 @@ variable "user_node_pool_count" {
 variable "user_node_pool_vm_size" {
   description = "VM size for the user node pool"
   type        = string
-  default     = "Standard_D4s_v3"
+  # Ddsv6 is a recent VM generation (as of 2026-07).
+  default = "Standard_D4ds_v6"
 }
 
 variable "system_node_pool_zones" {

--- a/azure/kubernetes/aks-single-region/variables.tf
+++ b/azure/kubernetes/aks-single-region/variables.tf
@@ -77,10 +77,10 @@ variable "system_node_pool_count" {
 }
 
 variable "system_node_pool_vm_size" {
+  # Dsv6 is a recent VM generation (as of 2026-07).
   description = "VM size for the system node pool"
   type        = string
-  # Dsv6 is a recent VM generation (as of 2026-07).
-  default = "Standard_D2s_v6"
+  default     = "Standard_D2s_v6"
 }
 
 variable "user_node_pool_count" {
@@ -90,10 +90,10 @@ variable "user_node_pool_count" {
 }
 
 variable "user_node_pool_vm_size" {
+  # Dsv6 is a recent VM generation (as of 2026-07).
   description = "VM size for the user node pool"
   type        = string
-  # Dsv6 is a recent VM generation (as of 2026-07).
-  default = "Standard_D4s_v6"
+  default     = "Standard_D4s_v6"
 }
 
 variable "system_node_pool_zones" {

--- a/azure/kubernetes/aks-single-region/variables.tf
+++ b/azure/kubernetes/aks-single-region/variables.tf
@@ -79,8 +79,8 @@ variable "system_node_pool_count" {
 variable "system_node_pool_vm_size" {
   description = "VM size for the system node pool"
   type        = string
-  # Ddsv6 is a recent VM generation (as of 2026-07).
-  default = "Standard_D2ds_v6"
+  # Dsv6 is a recent VM generation (as of 2026-07).
+  default = "Standard_D2s_v6"
 }
 
 variable "user_node_pool_count" {
@@ -92,8 +92,8 @@ variable "user_node_pool_count" {
 variable "user_node_pool_vm_size" {
   description = "VM size for the user node pool"
   type        = string
-  # Ddsv6 is a recent VM generation (as of 2026-07).
-  default = "Standard_D4ds_v6"
+  # Dsv6 is a recent VM generation (as of 2026-07).
+  default = "Standard_D4s_v6"
 }
 
 variable "system_node_pool_zones" {

--- a/azure/modules/aks/README.md
+++ b/azure/modules/aks/README.md
@@ -30,7 +30,7 @@ No modules.
 | <a name="input_subnet_id"></a> [subnet\_id](#input\_subnet\_id) | ID of the subnet where the AKS cluster will be deployed | `string` | n/a | yes |
 | <a name="input_system_node_disk_size_gb"></a> [system\_node\_disk\_size\_gb](#input\_system\_node\_disk\_size\_gb) | OS disk size in GB for system nodes | `number` | `30` | no |
 | <a name="input_system_node_pool_count"></a> [system\_node\_pool\_count](#input\_system\_node\_pool\_count) | Number of nodes in the system node pool | `number` | `3` | no |
-| <a name="input_system_node_pool_vm_size"></a> [system\_node\_pool\_vm\_size](#input\_system\_node\_pool\_vm\_size) | VM size for the system node pool | `string` | `"Standard_D2ds_v6"` | no |
+| <a name="input_system_node_pool_vm_size"></a> [system\_node\_pool\_vm\_size](#input\_system\_node\_pool\_vm\_size) | VM size for the system node pool | `string` | `"Standard_D2s_v6"` | no |
 | <a name="input_system_node_pool_zones"></a> [system\_node\_pool\_zones](#input\_system\_node\_pool\_zones) | AZs for system node pool, e.g. ["1","2","3"] | `list(string)` | <pre>[<br/>  "1",<br/>  "2",<br/>  "3"<br/>]</pre> | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to apply to all resources | `map(string)` | `{}` | no |
 | <a name="input_uami_id"></a> [uami\_id](#input\_uami\_id) | User-assigned identity ID to use for KMS | `string` | n/a | yes |
@@ -40,7 +40,7 @@ No modules.
 | <a name="input_user_node_pool_drain_timeout_in_minutes"></a> [user\_node\_pool\_drain\_timeout\_in\_minutes](#input\_user\_node\_pool\_drain\_timeout\_in\_minutes) | The amount of time in minutes to wait on eviction of pods and graceful termination per node | `number` | `0` | no |
 | <a name="input_user_node_pool_max_surge"></a> [user\_node\_pool\_max\_surge](#input\_user\_node\_pool\_max\_surge) | The maximum number or percentage of nodes which will be added to the Node Pool size during an upgrade | `number` | `10` | no |
 | <a name="input_user_node_pool_node_soak_duration_in_minutes"></a> [user\_node\_pool\_node\_soak\_duration\_in\_minutes](#input\_user\_node\_pool\_node\_soak\_duration\_in\_minutes) | The amount of time in minutes to wait after draining a node and before reimaging and moving on to next node | `number` | `0` | no |
-| <a name="input_user_node_pool_vm_size"></a> [user\_node\_pool\_vm\_size](#input\_user\_node\_pool\_vm\_size) | VM size for the user node pool | `string` | `"Standard_D4ds_v6"` | no |
+| <a name="input_user_node_pool_vm_size"></a> [user\_node\_pool\_vm\_size](#input\_user\_node\_pool\_vm\_size) | VM size for the user node pool | `string` | `"Standard_D4s_v6"` | no |
 | <a name="input_user_node_pool_zones"></a> [user\_node\_pool\_zones](#input\_user\_node\_pool\_zones) | AZs for user node pool | `list(string)` | <pre>[<br/>  "1",<br/>  "2",<br/>  "3"<br/>]</pre> | no |
 ## Outputs
 

--- a/azure/modules/aks/README.md
+++ b/azure/modules/aks/README.md
@@ -30,7 +30,7 @@ No modules.
 | <a name="input_subnet_id"></a> [subnet\_id](#input\_subnet\_id) | ID of the subnet where the AKS cluster will be deployed | `string` | n/a | yes |
 | <a name="input_system_node_disk_size_gb"></a> [system\_node\_disk\_size\_gb](#input\_system\_node\_disk\_size\_gb) | OS disk size in GB for system nodes | `number` | `30` | no |
 | <a name="input_system_node_pool_count"></a> [system\_node\_pool\_count](#input\_system\_node\_pool\_count) | Number of nodes in the system node pool | `number` | `3` | no |
-| <a name="input_system_node_pool_vm_size"></a> [system\_node\_pool\_vm\_size](#input\_system\_node\_pool\_vm\_size) | VM size for the system node pool | `string` | `"Standard_D2s_v3"` | no |
+| <a name="input_system_node_pool_vm_size"></a> [system\_node\_pool\_vm\_size](#input\_system\_node\_pool\_vm\_size) | VM size for the system node pool | `string` | `"Standard_D2ds_v6"` | no |
 | <a name="input_system_node_pool_zones"></a> [system\_node\_pool\_zones](#input\_system\_node\_pool\_zones) | AZs for system node pool, e.g. ["1","2","3"] | `list(string)` | <pre>[<br/>  "1",<br/>  "2",<br/>  "3"<br/>]</pre> | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to apply to all resources | `map(string)` | `{}` | no |
 | <a name="input_uami_id"></a> [uami\_id](#input\_uami\_id) | User-assigned identity ID to use for KMS | `string` | n/a | yes |
@@ -40,7 +40,7 @@ No modules.
 | <a name="input_user_node_pool_drain_timeout_in_minutes"></a> [user\_node\_pool\_drain\_timeout\_in\_minutes](#input\_user\_node\_pool\_drain\_timeout\_in\_minutes) | The amount of time in minutes to wait on eviction of pods and graceful termination per node | `number` | `0` | no |
 | <a name="input_user_node_pool_max_surge"></a> [user\_node\_pool\_max\_surge](#input\_user\_node\_pool\_max\_surge) | The maximum number or percentage of nodes which will be added to the Node Pool size during an upgrade | `number` | `10` | no |
 | <a name="input_user_node_pool_node_soak_duration_in_minutes"></a> [user\_node\_pool\_node\_soak\_duration\_in\_minutes](#input\_user\_node\_pool\_node\_soak\_duration\_in\_minutes) | The amount of time in minutes to wait after draining a node and before reimaging and moving on to next node | `number` | `0` | no |
-| <a name="input_user_node_pool_vm_size"></a> [user\_node\_pool\_vm\_size](#input\_user\_node\_pool\_vm\_size) | VM size for the user node pool | `string` | `"Standard_D4s_v3"` | no |
+| <a name="input_user_node_pool_vm_size"></a> [user\_node\_pool\_vm\_size](#input\_user\_node\_pool\_vm\_size) | VM size for the user node pool | `string` | `"Standard_D4ds_v6"` | no |
 | <a name="input_user_node_pool_zones"></a> [user\_node\_pool\_zones](#input\_user\_node\_pool\_zones) | AZs for user node pool | `list(string)` | <pre>[<br/>  "1",<br/>  "2",<br/>  "3"<br/>]</pre> | no |
 ## Outputs
 

--- a/azure/modules/aks/variables.tf
+++ b/azure/modules/aks/variables.tf
@@ -35,8 +35,8 @@ variable "tags" {
 variable "system_node_pool_vm_size" {
   description = "VM size for the system node pool"
   type        = string
-  # Ddsv6 is a recent VM generation (as of 2026-07).
-  default = "Standard_D2ds_v6"
+  # Dsv6 is a recent VM generation (as of 2026-07).
+  default = "Standard_D2s_v6"
 }
 
 variable "system_node_disk_size_gb" {
@@ -55,8 +55,8 @@ variable "system_node_pool_count" {
 variable "user_node_pool_vm_size" {
   description = "VM size for the user node pool"
   type        = string
-  # Ddsv6 is a recent VM generation (as of 2026-07).
-  default = "Standard_D4ds_v6"
+  # Dsv6 is a recent VM generation (as of 2026-07).
+  default = "Standard_D4s_v6"
 }
 
 variable "user_node_disk_size_gb" {

--- a/azure/modules/aks/variables.tf
+++ b/azure/modules/aks/variables.tf
@@ -35,7 +35,8 @@ variable "tags" {
 variable "system_node_pool_vm_size" {
   description = "VM size for the system node pool"
   type        = string
-  default     = "Standard_D2s_v3"
+  # Ddsv6 is a recent VM generation (as of 2026-07).
+  default = "Standard_D2ds_v6"
 }
 
 variable "system_node_disk_size_gb" {
@@ -54,7 +55,8 @@ variable "system_node_pool_count" {
 variable "user_node_pool_vm_size" {
   description = "VM size for the user node pool"
   type        = string
-  default     = "Standard_D4s_v3"
+  # Ddsv6 is a recent VM generation (as of 2026-07).
+  default = "Standard_D4ds_v6"
 }
 
 variable "user_node_disk_size_gb" {

--- a/azure/modules/aks/variables.tf
+++ b/azure/modules/aks/variables.tf
@@ -33,10 +33,10 @@ variable "tags" {
 
 # System node pool configuration
 variable "system_node_pool_vm_size" {
+  # Dsv6 is a recent VM generation (as of 2026-07).
   description = "VM size for the system node pool"
   type        = string
-  # Dsv6 is a recent VM generation (as of 2026-07).
-  default = "Standard_D2s_v6"
+  default     = "Standard_D2s_v6"
 }
 
 variable "system_node_disk_size_gb" {
@@ -53,10 +53,10 @@ variable "system_node_pool_count" {
 
 # User node pool configuration
 variable "user_node_pool_vm_size" {
+  # Dsv6 is a recent VM generation (as of 2026-07).
   description = "VM size for the user node pool"
   type        = string
-  # Dsv6 is a recent VM generation (as of 2026-07).
-  default = "Standard_D4s_v6"
+  default     = "Standard_D4s_v6"
 }
 
 variable "user_node_disk_size_gb" {


### PR DESCRIPTION
## Problem

The AKS reference architecture provisions its node pools on the **Dv3** family
in **swedencentral**:

- user pool: `Standard_D4s_v3` × 5, zones 1/2/3
- system pool: `Standard_D2s_v3`, zones 1/2/3

Creating the **user** VMSS repeatedly fails with
`OverconstrainedZonalAllocationRequest` — Azure cannot allocate the requested
combination of **Availability Zone + Accelerated Networking + VM Size** because
in-region capacity for that Dv3 triple is exhausted.

### This has recurred several times (not a one-off)

`OverconstrainedZonalAllocationRequest` on `aks-user-*-vmss` in
`MC_*_swedencentral`, across branches and days:

| Date (2026) | Run |
|---|---|
| Jul 01 | [28508536984](https://github.com/camunda/camunda-deployment-references/actions/runs/28508536984) |
| Jul 03 | [28655860171](https://github.com/camunda/camunda-deployment-references/actions/runs/28655860171) |
| Jul 03 | [28663984249](https://github.com/camunda/camunda-deployment-references/actions/runs/28663984249) |
| Jul 03 | [28664792081](https://github.com/camunda/camunda-deployment-references/actions/runs/28664792081) |
| Jul 06 | [28796520818](https://github.com/camunda/camunda-deployment-references/actions/runs/28796520818) |
| Jul 06 | [28792719886](https://github.com/camunda/camunda-deployment-references/actions/runs/28792719886) |

## Fix

Move both node pools to the **Dsv6** generation:

- user pool: `Standard_D4s_v3` → `Standard_D4s_v6`
- system pool: `Standard_D2s_v3` → `Standard_D2s_v6`

Same vCPU/RAM, newest generation, drop-in change.

### How this was narrowed down (data-driven)

`az vm list-skus --location swedencentral` — availability/zones/restrictions:

| Gen | user `D4*` | system `D2*` | zones 1/2/3 | subscription restriction |
|---|---|---|---|---|
| v3 (current) | `D4s_v3` | `D2s_v3` | yes | none — but live capacity exhausted (the failure) |
| v5 | `D4s_v5` | `D2s_v5` | yes | none |
| **v6 (chosen)** | `D4s_v6` | `D2s_v6` | yes | none |
| v7 | — | — | — | not offered in swedencentral |

A first attempt with the local-temp-disk `Ddsv6` variant got **past allocation**
(the original error was gone — v6 capacity exists) but then failed with
`ErrCode_InsufficientVCPUQuota`: the new `dd` family has almost no quota in the
subscription. `az vm list-usage --location swedencentral`:

| Family | used/limit | verdict |
|---|---|---|
| `StandardDdsv6Family` (Ddsv6) | 4/**10** | ✗ too little (user pool needs ~20) |
| `standardDDSv5Family` (Ddsv5) | 0/**0** | ✗ no quota |
| `standardDSv3Family` (Dsv3, current) | 44/100 | quota ok, but no capacity (original error) |
| **`StandardDsv6Family` (Dsv6)** | 0/**100** | ✓ quota **and** v6 capacity |

So `Dsv6` (no local temp disk) is the family that satisfies **both** capacity
and quota. AKS uses **managed** OS disks here (`os_disk_size_gb = 30`, no
ephemeral/temp-disk dependency), so dropping the `dd` temp disk has no
functional impact on these node pools.

> Capacity/quota can still shift over time; if `Dsv6` shows pressure, `Dsv5`
> is an equivalent fallback (also 100 quota + all-zone availability here).

## Scope

- `azure/modules/aks` default (reusable module)
- `azure/kubernetes/aks-single-region` + `aks-single-region-rdbms` root defaults
  (`aks-single-region-rdbms` symlinks `variables.tf`)
- regenerated `README.md` (terraform-docs)
- regenerated golden plans — pure `vm_size` passthrough; the golden-plan CI job
  verifies byte-equality

## Not touched / checked

- **PostgreSQL** `GP_Standard_D2s_v3` (Flexible Server tier) left as-is: it is a
  separate capacity pool, its failures in these runs were transient
  `InternalServerError` (not zonal allocation), and Flexible Server does not
  even offer `*_v6` SKUs in swedencentral (tops out at v5).
- **camunda-docs**: the AKS guide embeds procedure scripts + links to
  `stable/8.x`; it hardcodes no VM size, so no docs change is required.
- **infraex-terraform**: org/infra management only, no AKS/VM sizing to align.

## Backport

Targets `stable/8.7`, `stable/8.8`, `stable/8.9` — all carry the same
`Standard_D4s_v3` default and the same swedencentral exposure.

---
Not merged — merging is a human action.
