### PR TITLE
chore(azure): modernize Postgres Flexible Server compute to Ddsv5 [ready]

### DIFF
--- a/azure/kubernetes/aks-single-region-rdbms/README.md
+++ b/azure/kubernetes/aks-single-region-rdbms/README.md
@@ -65,7 +65,7 @@ Refer to the [AKS single-region documentation](../aks-single-region/README.md) f
 | <a name="input_pe_subnet_address_prefix"></a> [pe\_subnet\_address\_prefix](#input\_pe\_subnet\_address\_prefix) | Address prefix for the private endpoint subnet | `list(string)` | <pre>[<br/>  "10.1.2.0/24"<br/>]</pre> | no |
 | <a name="input_postgres_backup_retention_days"></a> [postgres\_backup\_retention\_days](#input\_postgres\_backup\_retention\_days) | Backup retention days for PostgreSQL | `number` | `7` | no |
 | <a name="input_postgres_enable_geo_redundant_backup"></a> [postgres\_enable\_geo\_redundant\_backup](#input\_postgres\_enable\_geo\_redundant\_backup) | Enable geo-redundant backup for PostgreSQL | `bool` | `true` | no |
-| <a name="input_postgres_sku_tier"></a> [postgres\_sku\_tier](#input\_postgres\_sku\_tier) | SKU tier for PostgreSQL Flexible Server | `string` | `"GP_Standard_D2s_v3"` | no |
+| <a name="input_postgres_sku_tier"></a> [postgres\_sku\_tier](#input\_postgres\_sku\_tier) | SKU tier for PostgreSQL Flexible Server | `string` | `"GP_Standard_D2ds_v5"` | no |
 | <a name="input_postgres_standby_zone"></a> [postgres\_standby\_zone](#input\_postgres\_standby\_zone) | Standby Availability Zone for PostgreSQL high availability | `string` | `"2"` | no |
 | <a name="input_postgres_storage_mb"></a> [postgres\_storage\_mb](#input\_postgres\_storage\_mb) | Storage size in MB for PostgreSQL | `number` | `32768` | no |
 | <a name="input_postgres_version"></a> [postgres\_version](#input\_postgres\_version) | PostgreSQL version | `string` | `"18"` | no |

--- a/azure/kubernetes/aks-single-region-rdbms/test/golden/tfplan-golden.json
+++ b/azure/kubernetes/aks-single-region-rdbms/test/golden/tfplan-golden.json
@@ -919,7 +919,7 @@
             "public_network_access_enabled": false,
             "replication_role": null,
             "resource_group_name": "camunda-rg",
-            "sku_name": "GP_Standard_D2s_v3",
+            "sku_name": "GP_Standard_D2ds_v5",
             "source_server_id": null,
             "storage_mb": 32768,
             "tags": {

--- a/azure/kubernetes/aks-single-region/README.md
+++ b/azure/kubernetes/aks-single-region/README.md
@@ -33,7 +33,7 @@
 | <a name="input_pe_subnet_address_prefix"></a> [pe\_subnet\_address\_prefix](#input\_pe\_subnet\_address\_prefix) | Address prefix for the private endpoint subnet | `list(string)` | <pre>[<br/>  "10.1.2.0/24"<br/>]</pre> | no |
 | <a name="input_postgres_backup_retention_days"></a> [postgres\_backup\_retention\_days](#input\_postgres\_backup\_retention\_days) | Backup retention days for PostgreSQL | `number` | `7` | no |
 | <a name="input_postgres_enable_geo_redundant_backup"></a> [postgres\_enable\_geo\_redundant\_backup](#input\_postgres\_enable\_geo\_redundant\_backup) | Enable geo-redundant backup for PostgreSQL | `bool` | `true` | no |
-| <a name="input_postgres_sku_tier"></a> [postgres\_sku\_tier](#input\_postgres\_sku\_tier) | SKU tier for PostgreSQL Flexible Server | `string` | `"GP_Standard_D2s_v3"` | no |
+| <a name="input_postgres_sku_tier"></a> [postgres\_sku\_tier](#input\_postgres\_sku\_tier) | SKU tier for PostgreSQL Flexible Server | `string` | `"GP_Standard_D2ds_v5"` | no |
 | <a name="input_postgres_standby_zone"></a> [postgres\_standby\_zone](#input\_postgres\_standby\_zone) | Standby Availability Zone for PostgreSQL high availability | `string` | `"2"` | no |
 | <a name="input_postgres_storage_mb"></a> [postgres\_storage\_mb](#input\_postgres\_storage\_mb) | Storage size in MB for PostgreSQL | `number` | `32768` | no |
 | <a name="input_postgres_version"></a> [postgres\_version](#input\_postgres\_version) | PostgreSQL version | `string` | `"18"` | no |

--- a/azure/kubernetes/aks-single-region/test/golden/tfplan-golden.json
+++ b/azure/kubernetes/aks-single-region/test/golden/tfplan-golden.json
@@ -919,7 +919,7 @@
             "public_network_access_enabled": false,
             "replication_role": null,
             "resource_group_name": "camunda-rg",
-            "sku_name": "GP_Standard_D2s_v3",
+            "sku_name": "GP_Standard_D2ds_v5",
             "source_server_id": null,
             "storage_mb": 32768,
             "tags": {

--- a/azure/kubernetes/aks-single-region/variables.tf
+++ b/azure/kubernetes/aks-single-region/variables.tf
@@ -118,8 +118,9 @@ variable "postgres_version" {
 }
 
 variable "postgres_sku_tier" {
-  # Ddsv5 is the newest GP tier offered for Flexible Server in swedencentral
-  # (v6 is not available for Flexible Server, unlike the AKS node pools).
+  # GP_Standard_D2ds_v5 is the newest General Purpose tier offered for Flexible
+  # Server in swedencentral (v6 is not available for Flexible Server, unlike the
+  # AKS node pools).
   description = "SKU tier for PostgreSQL Flexible Server"
   type        = string
   default     = "GP_Standard_D2ds_v5"

--- a/azure/kubernetes/aks-single-region/variables.tf
+++ b/azure/kubernetes/aks-single-region/variables.tf
@@ -118,9 +118,11 @@ variable "postgres_version" {
 }
 
 variable "postgres_sku_tier" {
+  # Ddsv5 is the newest GP tier offered for Flexible Server in swedencentral
+  # (v6 is not available for Flexible Server, unlike the AKS node pools).
   description = "SKU tier for PostgreSQL Flexible Server"
   type        = string
-  default     = "GP_Standard_D2s_v3"
+  default     = "GP_Standard_D2ds_v5"
 }
 
 variable "postgres_storage_mb" {


### PR DESCRIPTION
## What

Follow-up to #2843 (Dsv6 node pools). Modernize the AKS reference architecture's **PostgreSQL Flexible Server** compute:

- `postgres_sku_tier`: `GP_Standard_D2s_v3` → **`GP_Standard_D2ds_v5`**

Same 2 vCPU / 8 GB, newer generation (better price/perf, local temp disk).

## Why v5 (and not v6)

Unlike the VM node pools, **Flexible Server does not offer a v6 GP tier** in swedencentral — v5 is the newest available. `az postgres flexible-server list-skus --location swedencentral` (GeneralPurpose, 2 vCPU):

| Gen | SKU | |
|---|---|---|
| v3 (current) | `GP_Standard_D2s_v3` | old |
| v4 | `GP_Standard_D2ds_v4` | |
| **v5 (chosen)** | **`GP_Standard_D2ds_v5`** / `GP_Standard_D2ads_v5` (AMD) | newest offered |
| v6 | — | not offered for Flexible Server |

The engine version is out of scope: it is managed separately by the existing `postgres_version` variable (currently **18**). Only the compute tier changes here.

## Scope

- `azure/kubernetes/aks-single-region` root default (`aks-single-region-rdbms` symlinks `variables.tf`)
- regenerated `README.md` (terraform-docs)
- regenerated golden plans — `sku_name` passthrough; the golden-plan CI job verifies byte-equality
- The reusable `azure/modules/postgres-db` default (`B_Standard_B1ms`) is intentionally left as-is — it is a generic module default the reference architecture overrides.

## Notes

- Separate from #2843 on purpose: different resource + separate capacity/quota pool, so it gets its own CI validation (Flexible Server provisioning) rather than resetting the already-validated node-pool fix.
- Heads-up: the AKS integration suite is currently red due to a pre-existing, unrelated Camunda 8.10 pre-release deploy-health flake (tracked in #2844), not this change.

## Backport

Targets `stable/8.7`, `stable/8.8`, `stable/8.9` — all carry the same `GP_Standard_D2s_v3` default.

---
Not merged — merging is a human action.
