### PR TITLE
ci(openshift-dual-region): add keep_alive demo mode (long-lived ROSA dual-region for Yahia)

### DIFF
--- a/.github/workflows/aws_openshift_rosa_hcp_dual_region_tests.yml
+++ b/.github/workflows/aws_openshift_rosa_hcp_dual_region_tests.yml
@@ -43,6 +43,22 @@ on:
                 type: boolean
                 default: true
 
+            keep_alive:
+                description: |
+                    Spawn a long-lived DEMO instead of an ephemeral test run.
+                    When enabled:
+                      * the two clusters are deployed to the AWS "weekly-work" regions
+                        (us-east-1 + us-east-2) instead of the CI regions (eu-west-2/3),
+                        so they are NOT wiped by the nightly InfraEx cleanup;
+                      * their Terraform state is stored under a dedicated prefix that the
+                        daily-cleanup workflow never scans, so it is NOT destroyed after 12h;
+                      * the in-run teardown is skipped (implies delete_clusters=false).
+                    The clusters therefore live for the whole work week and are removed by
+                    the InfraEx weekly cleanup on Saturday ~05:00 UTC. To rebuild them after
+                    that, just re-run this workflow with the SAME cluster_name.
+                type: boolean
+                default: false
+
             ref-arch:
                 description: |
                     Reference architecture to use, can only deploy one at a time.
@@ -67,13 +83,20 @@ env:
 
     S3_BACKEND_BUCKET: tests-ra-aws-rosa-hcp-tf-state-eu-central-1
     S3_BUCKET_REGION: eu-central-1
-    S3_BACKEND_BUCKET_PREFIX: aws/openshift/rosa-hcp-dual-region/ # keep it synced with the name of the module for simplicity
+    # keep it synced with the name of the module for simplicity.
+    # keep_alive demos use a dedicated prefix so the daily-cleanup workflow (which only
+    # scans aws/openshift/rosa-hcp-dual-region/) never destroys them.
+    S3_BACKEND_BUCKET_PREFIX: ${{ github.event.inputs.keep_alive == 'true' && 'aws/openshift/rosa-hcp-dual-region-keep-alive/' || 'aws/openshift/rosa-hcp-dual-region/'
+        }}
     TF_MODULES_DIRECTORY: ./.tf-modules-workflow/   # where the tf repo will be clone
 
-    CLUSTER_1_AWS_REGION: eu-west-2
-    CLUSTER_2_AWS_REGION: eu-west-3
+    # CI runs in eu-west-2/eu-west-3 (wiped nightly). keep_alive demos run in the
+    # weekly-work regions us-east-1/us-east-2 (kept until the Saturday ~05:00 UTC weekly cleanup).
+    CLUSTER_1_AWS_REGION: ${{ github.event.inputs.keep_alive == 'true' && 'us-east-1' || 'eu-west-2' }}
+    CLUSTER_2_AWS_REGION: ${{ github.event.inputs.keep_alive == 'true' && 'us-east-2' || 'eu-west-3' }}
 
-    CLEANUP_CLUSTERS: ${{ github.event.inputs.delete_clusters || 'true' }}
+    # keep_alive forces the teardown off so the demo survives the run.
+    CLEANUP_CLUSTERS: ${{ github.event.inputs.keep_alive == 'true' && 'false' || github.event.inputs.delete_clusters || 'true' }}
 
     # TEST VARIABLES
 

--- a/.github/workflows/aws_openshift_rosa_hcp_dual_region_tests.yml
+++ b/.github/workflows/aws_openshift_rosa_hcp_dual_region_tests.yml
@@ -47,15 +47,22 @@ on:
                 description: |
                     Spawn a long-lived DEMO instead of an ephemeral test run.
                     When enabled:
-                      * the two clusters are deployed to the AWS "weekly-work" regions
-                        (us-east-1 + us-east-2) instead of the CI regions (eu-west-2/3),
-                        so they are NOT wiped by the nightly InfraEx cleanup;
+                      * the two clusters are deployed to the AWS PERMANENT regions
+                        (eu-west-1 + eu-central-1) instead of the CI regions (eu-west-2/3),
+                        so they are out of scope of every region-based InfraEx cloud-nuke
+                        (neither the nightly CI sweep nor the Saturday weekly-work sweep);
+                      * every created AWS resource is tagged `infraex-permanent=true` so the
+                        InfraEx weekly GLOBAL cleanup (infraex-common-config
+                        aws_global_cleanup.sh) skips the account-wide resources it would
+                        otherwise delete on Saturday (OIDC provider, IAM roles, backup S3);
                       * their Terraform state is stored under a dedicated prefix that the
                         daily-cleanup workflow never scans, so it is NOT destroyed after 12h;
                       * the in-run teardown is skipped (implies delete_clusters=false).
-                    The clusters therefore live for the whole work week and are removed by
-                    the InfraEx weekly cleanup on Saturday ~05:00 UTC. To rebuild them after
-                    that, just re-run this workflow with the SAME cluster_name.
+                    The clusters therefore live until torn down manually. To rebuild or
+                    reconcile them, just re-run this workflow with the SAME cluster_name.
+                    NOTE: permanent survival requires the matching infraex-common-config
+                    change that honors the `infraex-permanent` tag; without it the Saturday
+                    global cleanup still deletes the cluster's OIDC provider.
                 type: boolean
                 default: false
 
@@ -91,9 +98,12 @@ env:
     TF_MODULES_DIRECTORY: ./.tf-modules-workflow/   # where the tf repo will be clone
 
     # CI runs in eu-west-2/eu-west-3 (wiped nightly). keep_alive demos run in the
-    # weekly-work regions us-east-1/us-east-2 (kept until the Saturday ~05:00 UTC weekly cleanup).
-    CLUSTER_1_AWS_REGION: ${{ github.event.inputs.keep_alive == 'true' && 'us-east-1' || 'eu-west-2' }}
-    CLUSTER_2_AWS_REGION: ${{ github.event.inputs.keep_alive == 'true' && 'us-east-2' || 'eu-west-3' }}
+    # PERMANENT regions eu-west-1/eu-central-1, which no region-based InfraEx cloud-nuke
+    # touches (see infraex-common-config aws_nightly_cleanup.yml matrix). Surviving the
+    # Saturday account-wide global cleanup additionally relies on the `infraex-permanent`
+    # tag set in the create step below (honored by aws_global_cleanup.sh).
+    CLUSTER_1_AWS_REGION: ${{ github.event.inputs.keep_alive == 'true' && 'eu-west-1' || 'eu-west-2' }}
+    CLUSTER_2_AWS_REGION: ${{ github.event.inputs.keep_alive == 'true' && 'eu-central-1' || 'eu-west-3' }}
 
     # keep_alive forces the teardown off so the demo survives the run.
     CLEANUP_CLUSTERS: ${{ github.event.inputs.keep_alive == 'true' && 'false' || github.event.inputs.delete_clusters || 'true' }}
@@ -235,7 +245,7 @@ jobs:
                         "ci-commit": "${{ github.sha }}",
                         "ci-repo": "${{ github.repository }}",
                         "ci-event": "${{ github.event_name }}",
-                        "map-migrated": "migARUADZHVWZ"
+                        "map-migrated": "migARUADZHVWZ"${{ github.event.inputs.keep_alive == 'true' && ', "infraex-permanent": "true"' || '' }}
                       }
 
             - name: Dump kubeconfig before encryption


### PR DESCRIPTION
## Motivation

Spawn a **long-lived demo** of the AWS OpenShift ROSA HCP dual-region reference
architecture (full Camunda 8.8) for **Yahia**, surviving the InfraEx cleanups
**indefinitely** (not just for one work week).

## Approach

The demo must dodge three independent InfraEx deletion paths:

1. **This repo's daily cleanup** (`aws_rosa_hcp_dual_region_daily_cleanup.yml`) —
   scans the base Terraform-state prefix, `terraform destroy`s after 12h.
2. **InfraEx region-based `cloud-nuke`** (`infraex-common-config/aws_nightly_cleanup.yml`)
   — wipes CI regions nightly and "weekly-work" regions (incl. `us-east-1/2`)
   every Saturday.
3. **InfraEx account-wide global cleanup** (`infraex-common-config/aws_global_cleanup.sh`)
   — every Saturday deletes OIDC providers, IAM roles, Route53 hypershift/rosa
   zones and buckets *regardless of region*.

`keep_alive=true` flips a few env conditionals (deploy path otherwise unchanged):

| Concern | Normal CI run | `keep_alive=true` |
|---|---|---|
| Cluster regions | `eu-west-2` / `eu-west-3` | **`eu-west-1` / `eu-central-1`** (permanent regions) |
| Terraform state prefix | `aws/openshift/rosa-hcp-dual-region/` | **`…-keep-alive/`** |
| In-run teardown (`CLEANUP_CLUSTERS`) | honors `delete_clusters` | **forced `false`** |
| Resource tags | ci metadata | ci metadata **+ `infraex-permanent=true`** |

How each deletion path is dodged:

1. **Dedicated state prefix** → the daily cleanup only scans `rosa-hcp-dual-region/`, so it never sees the demo.
2. **Permanent regions** `eu-west-1`/`eu-central-1` are in **no** `cloud-nuke` matrix — neither the nightly nor the Saturday sweep.
3. **`infraex-permanent=true` tag** (applied via the AWS provider `default_tags`, so it lands on the OIDC provider, IAM roles and backup buckets) makes the account-wide global cleanup **skip** them.
4. **Teardown skipped** so the run itself leaves the clusters up.

Result: the demo lives **indefinitely** until it is torn down manually.
Scheduled / PR / normal-dispatch runs are **unaffected** — every conditional
falls back to the previous CI values when `keep_alive` is unset.

> ⚠️ **Depends on camunda/infraex-common-config#522.** Until that merges, the
> Saturday account-wide cleanup still deletes the demo's OIDC provider (which
> breaks the cluster). The tag is inert/harmless before then.

## Instructions for Yahia

1. **Actions** → **Tests - Integration - AWS OpenShift ROSA HCP Dual Region** → **Run workflow**.
2. **Use workflow from branch `stable/8.8`**.
3. Inputs:
   - `cluster_name`: a short, stable name, e.g. **`yahia-demo`** (reuse the *same* name every time so rebuilds reuse the same state).
   - `keep_alive`: **✅ true**
   - `enable_tests`: **false** (recommended — skips the venom/Playwright suite; **Camunda is still fully deployed**).
   - `ref-arch`: leave `rosa-hcp-dual-region`.
   - `delete_clusters`: ignored when `keep_alive=true`.
4. **Run**. You get two peered ROSA HCP clusters in **`eu-west-1` + `eu-central-1`** with Camunda 8.8 (Submariner + ACM). Access details are in the run logs / cluster-info step.

### Tearing it down

Nothing auto-deletes it anymore (that's the point). Teardown is **manual**:
`terraform destroy` against the keep-alive state, then wipe the state folder:

```bash
aws s3 rm --recursive \
  "s3://tests-ra-aws-rosa-hcp-tf-state-eu-central-1/aws/openshift/rosa-hcp-dual-region-keep-alive/stable/8.8/"
```
(profile `infex`, region `eu-central-1`). Note: simply removing the tag / regions
does **not** delete anything, because permanent regions are never `cloud-nuke`d.

## Notes / residual risks

- **Cost**: two ROSA HCP clusters run **indefinitely** — please tear down when done.
- **Route53**: ROSA/HyperShift may create in-account zones out-of-band that don't carry the tag → tracked in #522.
- **Weekly audit noise**: permanent regions are audited (dry-run, Slack) on Sunday; the demo will surface until allowlisted or the audit is made tag-aware (see #522).
- **Region placement**: `eu-central-1` also hosts shared permanent infra + the TF-state buckets — pending InfraEx confirmation in #522.

## Validation

- `actionlint`, `yamllint`, `yamlfmt`, `check-yaml` pre-commit hooks pass.
- Both `keep_alive` JSON tag renderings validated as valid JSON.
- Expression fall-back checked for all trigger types (dispatch/schedule/PR) — CI paths unchanged.
- Not run end-to-end (real ROSA dual-region deploy); intentionally **not** tagged `[ready]`.
