### PR TITLE
feat(ci): source-build the dual-region pre-release chart instead of the private OCI registry

### DIFF
--- a/.github/actions/internal-multi-region-tests/action.yml
+++ b/.github/actions/internal-multi-region-tests/action.yml
@@ -133,8 +133,23 @@ runs:
               set -euo pipefail
 
               if [[ "${{ inputs.helm-version }}" =~ dev-latest ]]; then
+                # The pre-release dev chart is not published to the public Helm repo,
+                # so build it from source instead of pulling the private OCI registry:
+                # clone the pinned tag, resolve its in-repo (file://) dependency, and
+                # point the test at the local chart directory. InstallUpgradeC8Helm
+                # skips `helm repo add` and `--version` for a local chart path.
+                # TODO: [release-duty] at GA, drop this source-build and pull the
+                # published chart from the public Helm repo (camunda/camunda-platform).
+                # Keep CHART_GIT_REF in sync with the renovate-tracked pin in the
+                # generic/kind build-camunda-chart.sh helpers as the 15.x line advances.
+                CHART_GIT_REF="camunda-platform-8.10-15.0.0-alpha2"
+                CAMUNDA_VERSION="$(cat "${{ github.workspace }}/.camunda-version")"
+                CHART_CHECKOUT="$(mktemp -d)/camunda-platform-helm"
+                git clone --depth 1 --branch "$CHART_GIT_REF" \
+                  https://github.com/camunda/camunda-platform-helm.git "$CHART_CHECKOUT"
+                helm dependency update "$CHART_CHECKOUT/charts/camunda-platform-$CAMUNDA_VERSION"
                 {
-                  echo "HELM_CHART_NAME=oci://registry.camunda.cloud/team-distribution/camunda-platform"
+                  echo "HELM_CHART_NAME=$CHART_CHECKOUT/charts/camunda-platform-$CAMUNDA_VERSION"
                 } >> "$GITHUB_ENV"
               else
                 {

--- a/.github/actions/internal-multi-region-tests/action.yml
+++ b/.github/actions/internal-multi-region-tests/action.yml
@@ -140,8 +140,7 @@ runs:
                 # skips `helm repo add` and `--version` for a local chart path.
                 # TODO: [release-duty] at GA, drop this source-build and pull the
                 # published chart from the public Helm repo (camunda/camunda-platform).
-                # Keep CHART_GIT_REF in sync with the renovate-tracked pin in the
-                # generic/kind build-camunda-chart.sh helpers as the 15.x line advances.
+                # renovate: datasource=github-tags depName=camunda/camunda-platform-helm extractVersion=^camunda-platform-8\.10-(?<version>.+)$
                 CHART_GIT_REF="camunda-platform-8.10-15.0.0-alpha2"
                 CAMUNDA_VERSION="$(cat "${{ github.workspace }}/.camunda-version")"
                 CHART_CHECKOUT="$(mktemp -d)/camunda-platform-helm"

--- a/.github/actions/internal-multi-region-tests/action.yml
+++ b/.github/actions/internal-multi-region-tests/action.yml
@@ -138,8 +138,12 @@ runs:
                 # clone the pinned tag, resolve its in-repo (file://) dependency, and
                 # point the test at the local chart directory. InstallUpgradeC8Helm
                 # skips `helm repo add` and `--version` for a local chart path.
-                # TODO: [release-duty] at GA, drop this source-build and pull the
-                # published chart from the public Helm repo (camunda/camunda-platform).
+                # The pre-release (dev-latest) chart isn't on the public Helm repo, so
+                # build it from source; released versions use the public repo via the
+                # `else` branch, so GA needs no manual switch here (the workflow's
+                # helm-version flips to a released value and this block is bypassed).
+                # TODO: [release-duty] when the pre-release line moves to the next major,
+                # bump CHART_GIT_REF and the hardcoded 8.10 in the renovate regex below.
                 # renovate: datasource=github-tags depName=camunda/camunda-platform-helm extractVersion=^camunda-platform-8\.10-(?<version>.+)$
                 CHART_GIT_REF="camunda-platform-8.10-15.0.0-alpha2"
                 CAMUNDA_VERSION="$(cat "${{ github.workspace }}/.camunda-version")"

--- a/aws/kubernetes/eks-dual-region/test/internal/helpers/kubectl/helpers.go
+++ b/aws/kubernetes/eks-dual-region/test/internal/helpers/kubectl/helpers.go
@@ -689,10 +689,23 @@ func InstallUpgradeC8Helm(t *testing.T, kubectlOptions *k8s.KubectlOptions, remo
 	// oci:// ref. Only add the Helm repo for the repo-ref case, and never pass
 	// --version for a local path (Helm resolves the version from the chart's
 	// Chart.yaml and errors if --version is given alongside a local chart).
+	// A source-built (pre-release) chart is passed as a local filesystem path; a
+	// released chart is a "camunda/camunda-platform" repo ref; a dev chart may be an
+	// oci:// ref. Only add the Helm repo for the repo-ref case, and never pass
+	// --version for a local path (Helm resolves the version from the chart's
+	// Chart.yaml and errors if --version is given alongside a local chart).
 	isOCIChart := strings.HasPrefix(remoteChartName, "oci://")
+	// Detect an explicit path prefix, then fall back to an on-disk check so a plain
+	// relative path (e.g. "charts/camunda-platform-8.10") is also treated as local and
+	// not confused with a "repo/chart" Helm repo reference (e.g. "camunda/camunda-platform").
 	isLocalChart := strings.HasPrefix(remoteChartName, "/") ||
 		strings.HasPrefix(remoteChartName, "./") ||
 		strings.HasPrefix(remoteChartName, "../")
+	if !isOCIChart && !isLocalChart {
+		if info, statErr := os.Stat(remoteChartName); statErr == nil && info.IsDir() {
+			isLocalChart = true
+		}
+	}
 
 	if !isOCIChart && !isLocalChart {
 		helm.AddRepo(t, helmOptions, "camunda", remoteChartSource)

--- a/aws/kubernetes/eks-dual-region/test/internal/helpers/kubectl/helpers.go
+++ b/aws/kubernetes/eks-dual-region/test/internal/helpers/kubectl/helpers.go
@@ -689,11 +689,6 @@ func InstallUpgradeC8Helm(t *testing.T, kubectlOptions *k8s.KubectlOptions, remo
 	// oci:// ref. Only add the Helm repo for the repo-ref case, and never pass
 	// --version for a local path (Helm resolves the version from the chart's
 	// Chart.yaml and errors if --version is given alongside a local chart).
-	// A source-built (pre-release) chart is passed as a local filesystem path; a
-	// released chart is a "camunda/camunda-platform" repo ref; a dev chart may be an
-	// oci:// ref. Only add the Helm repo for the repo-ref case, and never pass
-	// --version for a local path (Helm resolves the version from the chart's
-	// Chart.yaml and errors if --version is given alongside a local chart).
 	isOCIChart := strings.HasPrefix(remoteChartName, "oci://")
 	// Detect an explicit path prefix, then fall back to an on-disk check so a plain
 	// relative path (e.g. "charts/camunda-platform-8.10") is also treated as local and
@@ -713,7 +708,12 @@ func InstallUpgradeC8Helm(t *testing.T, kubectlOptions *k8s.KubectlOptions, remo
 
 	// Terratest is actively ignoring the version in an upgrade
 	upgradeArgs := []string{"--install"}
-	if !isLocalChart {
+	if isLocalChart {
+		// Helm resolves the version from the local chart's Chart.yaml; clear any
+		// requested version so neither the extra args nor Options.Version can
+		// re-introduce --version for a local path, which Helm rejects.
+		helmOptions.Version = ""
+	} else {
 		upgradeArgs = append([]string{"--version", remoteChartVersion}, upgradeArgs...)
 	}
 	helmOptions.ExtraArgs = map[string][]string{

--- a/aws/kubernetes/eks-dual-region/test/internal/helpers/kubectl/helpers.go
+++ b/aws/kubernetes/eks-dual-region/test/internal/helpers/kubectl/helpers.go
@@ -684,13 +684,27 @@ func InstallUpgradeC8Helm(t *testing.T, kubectlOptions *k8s.KubectlOptions, remo
 		SetStrValues:   setStringValues,
 	}
 
-	if !strings.HasPrefix(remoteChartName, "oci://") {
+	// A source-built (pre-release) chart is passed as a local filesystem path; a
+	// released chart is a "camunda/camunda-platform" repo ref; a dev chart may be an
+	// oci:// ref. Only add the Helm repo for the repo-ref case, and never pass
+	// --version for a local path (Helm resolves the version from the chart's
+	// Chart.yaml and errors if --version is given alongside a local chart).
+	isOCIChart := strings.HasPrefix(remoteChartName, "oci://")
+	isLocalChart := strings.HasPrefix(remoteChartName, "/") ||
+		strings.HasPrefix(remoteChartName, "./") ||
+		strings.HasPrefix(remoteChartName, "../")
+
+	if !isOCIChart && !isLocalChart {
 		helm.AddRepo(t, helmOptions, "camunda", remoteChartSource)
 	}
 
 	// Terratest is actively ignoring the version in an upgrade
+	upgradeArgs := []string{"--install"}
+	if !isLocalChart {
+		upgradeArgs = append([]string{"--version", remoteChartVersion}, upgradeArgs...)
+	}
 	helmOptions.ExtraArgs = map[string][]string{
-		"upgrade": {"--version", remoteChartVersion, "--install"},
+		"upgrade": upgradeArgs,
 	}
 
 	// Write the final merged values to a debug file for troubleshooting

--- a/aws/kubernetes/eks-dual-region/test/multi_region_aws_camunda_test.go
+++ b/aws/kubernetes/eks-dual-region/test/multi_region_aws_camunda_test.go
@@ -33,8 +33,10 @@ var (
 	// TODO: [release-duty] adjust renovate comment to bump the major version
 	// renovate: datasource=helm depName=camunda-platform registryUrl=https://helm.camunda.io versioning=regex:^14(\.(?<minor>\d+))?(\.(?<patch>\d+))?$
 	remoteChartVersion = helpers.GetEnv("HELM_CHART_VERSION", "14.6.0")
-	// TODO: [release-duty] before the release, switch back to "camunda/camunda-platform" (non-OCI)
-	remoteChartName = helpers.GetEnv("HELM_CHART_NAME", "oci://registry.camunda.cloud/team-distribution/camunda-platform")  // OCI registry
+	// The default targets the public Helm repo (no private registry auth). CI overrides
+	// HELM_CHART_NAME to a local, source-built chart directory for the pre-release
+	// (dev-latest) line, since that chart is not published to the public repo.
+	remoteChartName = helpers.GetEnv("HELM_CHART_NAME", "camunda/camunda-platform")
 	globalImageTag  = helpers.GetEnv("GLOBAL_IMAGE_TAG", "")                                                                // allows overwriting the image tag via GHA of every Camunda image
 	clusterName     = helpers.GetEnv("CLUSTER_NAME", "nightly")                                                             // allows supplying random cluster name via GHA
 	cluster0Name    = helpers.GetEnv("CLUSTER_0_NAME", fmt.Sprintf("%s-london", helpers.GetEnv("CLUSTER_NAME", "nightly"))) // kubectl context name for cluster 0


### PR DESCRIPTION
> [!WARNING]
> **Draft — CI-validated only.** The dual-region suites (EKS + ROSA + teleport) are the sole way to truly validate this, and they're expensive + Submariner-flaky. Locally verified: `gofmt`, `go build`, `shellcheck`, `yamllint`, pre-commit — but **not** an actual dual-region run.

Removes the private OCI registry (`registry.camunda.cloud/team-distribution`) from the **dual-region integration tests'** chart install, mirroring the source-build approach used for the shell-based guides in #2841 / kind #2856.

## Change
- **Shared action `internal-multi-region-tests`** (used by eks-dual, rosa-dual, eks-dual-teleport): for the pre-release `dev-latest` line, `git clone` the pinned `camunda-platform-8.10-15.0.0-alpha2` tag, `helm dependency update` (only in-repo `file://` deps — no auth), and point the test at the **local chart directory** instead of `oci://registry.camunda.cloud/…`. Released versions still use the public `camunda/camunda-platform` repo.
- **`helpers.go` (`InstallUpgradeC8Helm`)**: handle a local chart path — skip `helm repo add` and drop `--version` (Helm resolves the version from the local chart's `Chart.yaml` and errors if `--version` is passed with a path).
- **Go default `remoteChartName`** → `camunda/camunda-platform` (public), resolving the existing `[release-duty]` TODO; the private-OCI default is gone.

## Scope / caveats
- **Blast radius:** the shared action means this also changes **rosa-dual** and **eks-dual-teleport** (all now source-build the dev chart). Intended for consistency.
- **Not fully OCI-free:** the `internal-helm-deprecation-check` step still `helm pull`s the chart schema via `oci://…` (it derives the chart from the deployed release, independent of the install). Out of scope here.
- **Manual guide** (`export_environment_prerequisites.sh` `HELM_CHART_REF`) is unchanged — that's the doc procedure, not the Go test; separate follow-up.
- `CHART_GIT_REF` is pinned; keep it in sync with the renovate-tracked pins in the `generic`/`kind` `build-camunda-chart.sh` helpers as the 15.x line advances (`[release-duty]`).

Follow-up to #2841. Not merging — human action.
