### PR TITLE
ci(demos): add keep_alive on-demand demo mode across ref-arch workflows

### DIFF
--- a/.github/workflows/aws_compute_ec2_single_region_tests.yml
+++ b/.github/workflows/aws_compute_ec2_single_region_tests.yml
@@ -22,6 +22,19 @@ on:
                 description: Whether to enable the tests.
                 type: boolean
                 default: true
+
+            keep_alive:
+                description: |
+                    Spawn a long-lived on-demand DEMO instead of an ephemeral test run.
+                    When true the clusters deploy to the AWS weekly-work region(s)
+                    (us-east-1, plus us-east-2 for dual-region) instead of the
+                    nightly-wiped CI regions, their Terraform state uses a dedicated
+                    "-keep-alive" prefix that the daily-cleanup workflow never scans,
+                    and the in-run teardown is skipped. The demo therefore lives the
+                    whole work week and is removed by the InfraEx weekly cleanup on
+                    Saturday ~05:00 UTC. Re-run with the SAME cluster_name to rebuild it.
+                type: boolean
+                default: false
             ref-arch:
                 description: |
                     Valid values are `ec2-single-region`.
@@ -55,15 +68,15 @@ env:
     IS_RENOVATE_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.user.login == 'renovate[bot]' }}
 
     AWS_PROFILE: infraex
-    AWS_REGION: eu-west-2
+    AWS_REGION: ${{ github.event.inputs.keep_alive == 'true' && 'us-east-1' || 'eu-west-2' }}
     S3_BACKEND_BUCKET: tests-ra-aws-rosa-hcp-tf-state-eu-central-1
     S3_BUCKET_REGION: eu-central-1
-    S3_BACKEND_BUCKET_PREFIX: aws/compute/ec2-single-region/ # keep it synced with the name of the module for simplicity
+    # keep it synced with the name of the module for simplicity
+    S3_BACKEND_BUCKET_PREFIX: aws/compute/ec2-single-region${{ github.event.inputs.keep_alive == 'true' && '-keep-alive/' || '/' }}
     TF_MODULES_PATH: ./.action-tf-modules/aws-compute-ec2-single-region-create
 
     CI_MATRIX_FILE: .github/workflows-config/aws-compute-ec2-single-region/test_matrix.yml
-    CLEANUP_CLUSTERS: ${{ github.event.inputs.delete_clusters || 'true' }}
-
+    CLEANUP_CLUSTERS: ${{ github.event.inputs.keep_alive == 'true' && 'false' || github.event.inputs.delete_clusters || 'true' }}
     TESTS_ENABLED: ${{ github.event.inputs.enable_tests || 'true' }}
 
     # renovate: datasource=github-releases depName=camunda/camunda versioning=regex:^8\.9?(\.(?<patch>\d+))?$

--- a/.github/workflows/aws_ecs_single_region_fargate_tests.yml
+++ b/.github/workflows/aws_ecs_single_region_fargate_tests.yml
@@ -21,6 +21,19 @@ on:
                 description: Whether to enable the tests.
                 type: boolean
                 default: true
+
+            keep_alive:
+                description: |
+                    Spawn a long-lived on-demand DEMO instead of an ephemeral test run.
+                    When true the clusters deploy to the AWS weekly-work region(s)
+                    (us-east-1, plus us-east-2 for dual-region) instead of the
+                    nightly-wiped CI regions, their Terraform state uses a dedicated
+                    "-keep-alive" prefix that the daily-cleanup workflow never scans,
+                    and the in-run teardown is skipped. The demo therefore lives the
+                    whole work week and is removed by the InfraEx weekly cleanup on
+                    Saturday ~05:00 UTC. Re-run with the SAME cluster_name to rebuild it.
+                type: boolean
+                default: false
             ref-arch:
                 description: |
                     Valid values are `ecs-single-region-fargate`.
@@ -53,15 +66,15 @@ env:
     IS_RENOVATE_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.user.login == 'renovate[bot]' }}
 
     AWS_PROFILE: infraex
-    AWS_REGION: eu-west-2
+    AWS_REGION: ${{ github.event.inputs.keep_alive == 'true' && 'us-east-1' || 'eu-west-2' }}
     S3_BACKEND_BUCKET: tests-ra-aws-rosa-hcp-tf-state-eu-central-1
     S3_BUCKET_REGION: eu-central-1
-    S3_BACKEND_BUCKET_PREFIX: aws/containers/ecs-single-region-fargate/ # keep it synced with the name of the module for simplicity
+    # keep it synced with the name of the module for simplicity
+    S3_BACKEND_BUCKET_PREFIX: aws/containers/ecs-single-region-fargate${{ github.event.inputs.keep_alive == 'true' && '-keep-alive/' || '/' }}
     TF_MODULES_PATH: ./.action-tf-modules/aws-containers-ecs-single-region-fargate-create
 
     CI_MATRIX_FILE: .github/workflows-config/aws-containers-ecs-single-region-fargate/test_matrix.yml
-    CLEANUP_CLUSTERS: ${{ github.event.inputs.delete_clusters || 'true' }}
-
+    CLEANUP_CLUSTERS: ${{ github.event.inputs.keep_alive == 'true' && 'false' || github.event.inputs.delete_clusters || 'true' }}
     TESTS_ENABLED: ${{ github.event.inputs.enable_tests || 'true' }}
 
 jobs:

--- a/.github/workflows/aws_kubernetes_eks_dual_region_tests.yml
+++ b/.github/workflows/aws_kubernetes_eks_dual_region_tests.yml
@@ -22,6 +22,19 @@ on:
                 description: Whether to enable the tests.
                 type: boolean
                 default: true
+
+            keep_alive:
+                description: |
+                    Spawn a long-lived on-demand DEMO instead of an ephemeral test run.
+                    When true the clusters deploy to the AWS weekly-work region(s)
+                    (us-east-1, plus us-east-2 for dual-region) instead of the
+                    nightly-wiped CI regions, their Terraform state uses a dedicated
+                    "-keep-alive" prefix that the daily-cleanup workflow never scans,
+                    and the in-run teardown is skipped. The demo therefore lives the
+                    whole work week and is removed by the InfraEx weekly cleanup on
+                    Saturday ~05:00 UTC. Re-run with the SAME cluster_name to rebuild it.
+                type: boolean
+                default: false
             ref-arch:
                 description: |
                     Reference architecture to use, can only deploy one at a time.
@@ -58,15 +71,15 @@ env:
     IS_RENOVATE_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.user.login == 'renovate[bot]' }}
 
     AWS_PROFILE: infraex
-    AWS_REGION: eu-west-2
-    CLUSTER_0_AWS_REGION: eu-west-2
-    CLUSTER_1_AWS_REGION: eu-west-3
+    AWS_REGION: ${{ github.event.inputs.keep_alive == 'true' && 'us-east-1' || 'eu-west-2' }}
+    CLUSTER_0_AWS_REGION: ${{ github.event.inputs.keep_alive == 'true' && 'us-east-1' || 'eu-west-2' }}
+    CLUSTER_1_AWS_REGION: ${{ github.event.inputs.keep_alive == 'true' && 'us-east-2' || 'eu-west-3' }}
     TESTS_TF_BINARY_NAME: terraform
     S3_BACKEND_BUCKET: tests-ra-aws-rosa-hcp-tf-state-eu-central-1
     S3_BUCKET_REGION: eu-central-1
 
-    CLEANUP_CLUSTERS: ${{ github.event.inputs.delete_clusters || 'true' }}
-
+    KEEP_ALIVE_STATE_SUFFIX: ${{ github.event.inputs.keep_alive == 'true' && '-keep-alive' || '' }}
+    CLEANUP_CLUSTERS: ${{ github.event.inputs.keep_alive == 'true' && 'false' || github.event.inputs.delete_clusters || 'true' }}
     # TEST VARIABLES
 
     # Vars with "CI_" prefix are used in the CI workflow only.
@@ -170,7 +183,7 @@ jobs:
               id: s3_prefix
               run: |
                   set -euo pipefail
-                  echo "S3_BACKEND_BUCKET_PREFIX=aws/kubernetes/${{ matrix.scenario.name }}/" | tee -a "$GITHUB_OUTPUT"
+                  echo "S3_BACKEND_BUCKET_PREFIX=aws/kubernetes/${{ matrix.scenario.name }}${KEEP_ALIVE_STATE_SUFFIX}/" | tee -a "$GITHUB_OUTPUT"
 
             - name: Create K8S dual-region clusters and login
               uses: ./.github/actions/aws-kubernetes-eks-dual-region-create
@@ -530,7 +543,7 @@ jobs:
               id: s3_prefix
               run: |
                   set -euo pipefail
-                  echo "S3_BACKEND_BUCKET_PREFIX=aws/kubernetes/${{ matrix.scenario.name }}/" | tee -a "$GITHUB_OUTPUT"
+                  echo "S3_BACKEND_BUCKET_PREFIX=aws/kubernetes/${{ matrix.scenario.name }}${KEEP_ALIVE_STATE_SUFFIX}/" | tee -a "$GITHUB_OUTPUT"
             ########### KubeConfig Generation ############
             - name: Export Cluster Name
               run: |

--- a/.github/workflows/aws_kubernetes_eks_single_region_tests.yml
+++ b/.github/workflows/aws_kubernetes_eks_single_region_tests.yml
@@ -48,6 +48,19 @@ on:
                 description: Whether to enable the tests.
                 type: boolean
                 default: true
+
+            keep_alive:
+                description: |
+                    Spawn a long-lived on-demand DEMO instead of an ephemeral test run.
+                    When true the clusters deploy to the AWS weekly-work region(s)
+                    (us-east-1, plus us-east-2 for dual-region) instead of the
+                    nightly-wiped CI regions, their Terraform state uses a dedicated
+                    "-keep-alive" prefix that the daily-cleanup workflow never scans,
+                    and the in-run teardown is skipped. The demo therefore lives the
+                    whole work week and is removed by the InfraEx weekly cleanup on
+                    Saturday ~05:00 UTC. Re-run with the SAME cluster_name to rebuild it.
+                type: boolean
+                default: false
             ref-arch:
                 description: |
                     Reference architecture to use, can only deploy one at a time.
@@ -73,14 +86,14 @@ env:
     IS_RENOVATE_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.user.login == 'renovate[bot]' }}
 
     AWS_PROFILE: infraex
-    AWS_REGION: eu-west-2
+    AWS_REGION: ${{ github.event.inputs.keep_alive == 'true' && 'us-east-1' || 'eu-west-2' }}
     S3_BACKEND_BUCKET: tests-ra-aws-rosa-hcp-tf-state-eu-central-1
     S3_BUCKET_REGION: eu-central-1
     TLD: camunda.ie
     MAIL_OVERWRITE: admin@camunda.ie
 
-    CLEANUP_CLUSTERS: ${{ github.event.inputs.delete_clusters || 'true' }}
-
+    KEEP_ALIVE_STATE_SUFFIX: ${{ github.event.inputs.keep_alive == 'true' && '-keep-alive' || '' }}
+    CLEANUP_CLUSTERS: ${{ github.event.inputs.keep_alive == 'true' && 'false' || github.event.inputs.delete_clusters || 'true' }}
     # TEST VARIABLES
 
     # Vars with "CI_" prefix are used in the CI workflow only.
@@ -187,7 +200,7 @@ jobs:
               id: s3_prefix
               run: |
                   set -euo pipefail
-                  echo "S3_BACKEND_BUCKET_PREFIX=aws/kubernetes/${{ matrix.scenario.name }}/" | tee -a "$GITHUB_OUTPUT"
+                  echo "S3_BACKEND_BUCKET_PREFIX=aws/kubernetes/${{ matrix.scenario.name }}${KEEP_ALIVE_STATE_SUFFIX}/" | tee -a "$GITHUB_OUTPUT"
 
             - name: Create K8S cluster and login
               uses: ./.github/actions/aws-kubernetes-eks-single-region-create
@@ -1072,7 +1085,7 @@ jobs:
               id: s3_prefix
               run: |
                   set -euo pipefail
-                  echo "S3_BACKEND_BUCKET_PREFIX=aws/kubernetes/${{ matrix.scenario.name }}/" | tee -a "$GITHUB_OUTPUT"
+                  echo "S3_BACKEND_BUCKET_PREFIX=aws/kubernetes/${{ matrix.scenario.name }}${KEEP_ALIVE_STATE_SUFFIX}/" | tee -a "$GITHUB_OUTPUT"
 
             - name: Delete on-demand EKS Cluster
               uses: ./.github/actions/aws-generic-terraform-cleanup

--- a/.github/workflows/aws_openshift_rosa_hcp_dual_region_tests.yml
+++ b/.github/workflows/aws_openshift_rosa_hcp_dual_region_tests.yml
@@ -47,6 +47,19 @@ on:
                 type: boolean
                 default: true
 
+
+            keep_alive:
+                description: |
+                    Spawn a long-lived on-demand DEMO instead of an ephemeral test run.
+                    When true the clusters deploy to the AWS weekly-work region(s)
+                    (us-east-1, plus us-east-2 for dual-region) instead of the
+                    nightly-wiped CI regions, their Terraform state uses a dedicated
+                    "-keep-alive" prefix that the daily-cleanup workflow never scans,
+                    and the in-run teardown is skipped. The demo therefore lives the
+                    whole work week and is removed by the InfraEx weekly cleanup on
+                    Saturday ~05:00 UTC. Re-run with the SAME cluster_name to rebuild it.
+                type: boolean
+                default: false
             ref-arch:
                 description: |
                     Reference architecture to use, can only deploy one at a time.
@@ -71,14 +84,13 @@ env:
 
     S3_BACKEND_BUCKET: tests-ra-aws-rosa-hcp-tf-state-eu-central-1
     S3_BUCKET_REGION: eu-central-1
-    S3_BACKEND_BUCKET_PREFIX: aws/openshift/rosa-hcp-dual-region/ # keep it synced with the name of the module for simplicity
+    # keep it synced with the name of the module for simplicity
+    S3_BACKEND_BUCKET_PREFIX: aws/openshift/rosa-hcp-dual-region${{ github.event.inputs.keep_alive == 'true' && '-keep-alive/' || '/' }}
     TF_MODULES_DIRECTORY: ./.tf-modules-workflow/   # where the tf repo will be clone
 
-    CLUSTER_0_AWS_REGION: eu-west-2
-    CLUSTER_1_AWS_REGION: eu-west-3
-
-    CLEANUP_CLUSTERS: ${{ github.event.inputs.delete_clusters || 'true' }}
-
+    CLUSTER_0_AWS_REGION: ${{ github.event.inputs.keep_alive == 'true' && 'us-east-1' || 'eu-west-2' }}
+    CLUSTER_1_AWS_REGION: ${{ github.event.inputs.keep_alive == 'true' && 'us-east-2' || 'eu-west-3' }}
+    CLEANUP_CLUSTERS: ${{ github.event.inputs.keep_alive == 'true' && 'false' || github.event.inputs.delete_clusters || 'true' }}
     # TEST VARIABLES
 
     # Vars with "CI_" prefix are used in the CI workflow only.

--- a/.github/workflows/aws_openshift_rosa_hcp_single_region_tests.yml
+++ b/.github/workflows/aws_openshift_rosa_hcp_single_region_tests.yml
@@ -48,6 +48,19 @@ on:
                 type: boolean
                 default: true
 
+
+            keep_alive:
+                description: |
+                    Spawn a long-lived on-demand DEMO instead of an ephemeral test run.
+                    When true the clusters deploy to the AWS weekly-work region(s)
+                    (us-east-1, plus us-east-2 for dual-region) instead of the
+                    nightly-wiped CI regions, their Terraform state uses a dedicated
+                    "-keep-alive" prefix that the daily-cleanup workflow never scans,
+                    and the in-run teardown is skipped. The demo therefore lives the
+                    whole work week and is removed by the InfraEx weekly cleanup on
+                    Saturday ~05:00 UTC. Re-run with the SAME cluster_name to rebuild it.
+                type: boolean
+                default: false
             ref-arch:
                 description: |
                     Reference architecture to use, can only deploy one at a time.
@@ -70,14 +83,14 @@ env:
     IS_RENOVATE_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.user.login == 'renovate[bot]' }}
 
     AWS_PROFILE: infex
-    AWS_REGION: eu-west-2
+    AWS_REGION: ${{ github.event.inputs.keep_alive == 'true' && 'us-east-1' || 'eu-west-2' }}
     S3_BACKEND_BUCKET: tests-ra-aws-rosa-hcp-tf-state-eu-central-1
     S3_BUCKET_REGION: eu-central-1
     TF_MODULES_DIRECTORY: ./.tf-modules-workflow/   # where the tf repo will be clone
-    S3_BACKEND_BUCKET_PREFIX: aws/openshift/rosa-hcp-single-region/ # keep it synced with the name of the module for simplicity
+    # keep it synced with the name of the module for simplicity
+    S3_BACKEND_BUCKET_PREFIX: aws/openshift/rosa-hcp-single-region${{ github.event.inputs.keep_alive == 'true' && '-keep-alive/' || '/' }}
 
-    CLEANUP_CLUSTERS: ${{ github.event.inputs.delete_clusters || 'true' }}
-
+    CLEANUP_CLUSTERS: ${{ github.event.inputs.keep_alive == 'true' && 'false' || github.event.inputs.delete_clusters || 'true' }}
     # TEST VARIABLES
 
     # Vars with "CI_" prefix are used in the CI workflow only.

--- a/.github/workflows/azure_kubernetes_aks_single_region_tests.yml
+++ b/.github/workflows/azure_kubernetes_aks_single_region_tests.yml
@@ -46,6 +46,18 @@ on:
                 description: Whether to enable the tests.
                 type: boolean
                 default: true
+
+            keep_alive:
+                description: |
+                    Spawn a long-lived on-demand DEMO instead of an ephemeral test run.
+                    When true the Terraform state uses a dedicated "-keep-alive" prefix
+                    that the daily-cleanup workflow never scans and the in-run teardown is
+                    skipped, so the AKS cluster survives the run. NOTE: Azure has no
+                    weekly-work region, so this demo does NOT auto-expire - destroy it
+                    manually when you are done (dispatch the daily-cleanup workflow or
+                    `az group delete`). Re-run with the SAME resource group to rebuild it.
+                type: boolean
+                default: false
             cluster_name:
                 description: Name of the cluster to deploy.
                 type: string
@@ -96,8 +108,8 @@ env:
     # Test environment for cloud provider, please keep it synced between the workflows
     AZURE_REGION: swedencentral
 
-    CLEANUP_CLUSTERS: ${{ github.event.inputs.delete_clusters || 'true' }}
-
+    KEEP_ALIVE_STATE_SUFFIX: ${{ github.event.inputs.keep_alive == 'true' && '-keep-alive' || '' }}
+    CLEANUP_CLUSTERS: ${{ github.event.inputs.keep_alive == 'true' && 'false' || github.event.inputs.delete_clusters || 'true' }}
     # TEST VARIABLES
 
     CI_MATRIX_FILE: .github/workflows-config/azure-kubernetes-aks-single-region/test_matrix.yml
@@ -204,7 +216,7 @@ jobs:
               id: s3_prefix
               run: |
                   set -euo pipefail
-                  echo "S3_BACKEND_BUCKET_PREFIX=azure/kubernetes/${{ matrix.scenario.name }}/" | tee -a "$GITHUB_OUTPUT"
+                  echo "S3_BACKEND_BUCKET_PREFIX=azure/kubernetes/${{ matrix.scenario.name }}${KEEP_ALIVE_STATE_SUFFIX}/" | tee -a "$GITHUB_OUTPUT"
 
             - name: Create terraform.tfvars file
               id: create-tfvars
@@ -914,7 +926,7 @@ jobs:
               id: s3_prefix
               run: |
                   set -euo pipefail
-                  echo "S3_BACKEND_BUCKET_PREFIX=azure/kubernetes/${{ matrix.scenario.name }}/" | tee -a "$GITHUB_OUTPUT"
+                  echo "S3_BACKEND_BUCKET_PREFIX=azure/kubernetes/${{ matrix.scenario.name }}${KEEP_ALIVE_STATE_SUFFIX}/" | tee -a "$GITHUB_OUTPUT"
 
             - name: Delete on-demand AKS Cluster
               uses: ./.github/actions/azure-kubernetes-aks-single-region-cleanup

--- a/.github/workflows/generic_kubernetes_operator_based_test.yml
+++ b/.github/workflows/generic_kubernetes_operator_based_test.yml
@@ -51,6 +51,19 @@ on:
                 type: boolean
                 default: true
 
+
+            keep_alive:
+                description: |
+                    Spawn a long-lived on-demand DEMO instead of an ephemeral test run.
+                    When true the clusters deploy to the AWS weekly-work region(s)
+                    (us-east-1, plus us-east-2 for dual-region) instead of the
+                    nightly-wiped CI regions, their Terraform state uses a dedicated
+                    "-keep-alive" prefix that the daily-cleanup workflow never scans,
+                    and the in-run teardown is skipped. The demo therefore lives the
+                    whole work week and is removed by the InfraEx weekly cleanup on
+                    Saturday ~05:00 UTC. Re-run with the SAME cluster_name to rebuild it.
+                type: boolean
+                default: false
             ref-arch:
                 description: |
                     Reference architecture to use, can only deploy one at a time.
@@ -78,18 +91,18 @@ env:
     IS_RENOVATE_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.user.login == 'renovate[bot]' }}
 
     AWS_PROFILE: infex
-    AWS_REGION: eu-west-2
+    AWS_REGION: ${{ github.event.inputs.keep_alive == 'true' && 'us-east-1' || 'eu-west-2' }}
     S3_BACKEND_BUCKET: tests-ra-aws-rosa-hcp-tf-state-eu-central-1
     S3_BUCKET_REGION: eu-central-1
     TF_MODULES_DIRECTORY: ./.tf-modules-workflow/   # where the tf repo will be clone
 
     # keep it synced with ROSA single region so we have the cleanup
     # maybe later we could extract this in a common file
-    S3_BACKEND_BUCKET_PREFIX_ROSA_HCP_SINGLE_REGION: aws/openshift/rosa-hcp-single-region/
-    S3_BACKEND_BUCKET_PREFIX_EKS_SINGLE_REGION: aws/kubernetes/eks-single-region/
+    S3_BACKEND_BUCKET_PREFIX_ROSA_HCP_SINGLE_REGION: aws/openshift/rosa-hcp-single-region${{ github.event.inputs.keep_alive == 'true' && '-keep-alive/'
+        || '/' }}
+    S3_BACKEND_BUCKET_PREFIX_EKS_SINGLE_REGION: aws/kubernetes/eks-single-region${{ github.event.inputs.keep_alive == 'true' && '-keep-alive/' || '/' }}
 
-    CLEANUP_CLUSTERS: ${{ github.event.inputs.delete_clusters || 'true' }}
-
+    CLEANUP_CLUSTERS: ${{ github.event.inputs.keep_alive == 'true' && 'false' || github.event.inputs.delete_clusters || 'true' }}
     # TEST VARIABLES
 
     # Vars with "CI_" prefix are used in the CI workflow only.


### PR DESCRIPTION
## Motivation

Enable **on-demand demos** on `stable/8.9`: spin up a long-lived Camunda 8 environment from a ref-arch integration workflow without it being destroyed by the nightly/daily cleanups. Backport of the `main` change (#2859); same pattern as ROSA dual-region #2857.

## What changed

A `keep_alive` `workflow_dispatch` input on each ref-arch workflow. When `keep_alive=true`:

| Concern | Normal CI run | `keep_alive=true` |
|---|---|---|
| AWS cluster region(s) | eu-west-2 (+ eu-west-3) | **us-east-1** (+ **us-east-2** dual) |
| Terraform state prefix | `…/<arch>/` | **`…/<arch>-keep-alive/`** (daily cleanup never scans it) |
| In-run teardown | honors `delete_clusters` | **forced off** |

AWS demos live the whole work week, removed by the InfraEx weekly cleanup **Saturday ~05:00 UTC**; rebuild by re-running with the same `cluster_name`. Scheduled/PR/normal-dispatch runs are unaffected (conditionals fall back to CI values).

**Workflows (8.9):** ec2-single, ecs-single, eks-single, eks-dual, rosa-single, rosa-dual, generic operator-based, azure-aks.

**Azure caveat:** no Azure weekly-work region exists, so the AKS demo keeps `swedencentral` and does **NOT auto-expire** — destroy it manually (documented in the input).

**Excluded:** eks-dual teleport (separate multi-region framework), local kind (can't persist), `aws_modules_*` (not ref-archs).

## Validation
`actionlint`, `yamllint`, `yamlfmt` pass on all 8 files. Not run end-to-end; **not** tagged `[ready]`.

Part of the per-branch rollout: main #2859, and stable/8.8 + stable/8.7 companion PRs.
