### PR TITLE
ci(demos): add keep_alive on-demand demo mode across ref-arch workflows

### DIFF
--- a/.github/workflows/aws_kubernetes_eks_single_region_tests.yml
+++ b/.github/workflows/aws_kubernetes_eks_single_region_tests.yml
@@ -34,6 +34,19 @@ on:
                 description: Whether to enable the tests.
                 type: boolean
                 default: true
+
+            keep_alive:
+                description: |
+                    Spawn a long-lived on-demand DEMO instead of an ephemeral test run.
+                    When true the clusters deploy to the AWS weekly-work region(s)
+                    (us-east-1, plus us-east-2 for dual-region) instead of the
+                    nightly-wiped CI regions, their Terraform state uses a dedicated
+                    "-keep-alive" prefix that the daily-cleanup workflow never scans,
+                    and the in-run teardown is skipped. The demo therefore lives the
+                    whole work week and is removed by the InfraEx weekly cleanup on
+                    Saturday ~05:00 UTC. Re-run with the SAME cluster_name to rebuild it.
+                type: boolean
+                default: false
             ref-arch:
                 description: |
                     Reference architecture to use, can only deploy one at a time.
@@ -59,15 +72,15 @@ env:
     IS_RENOVATE_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.user.login == 'renovate[bot]' }}
 
     AWS_PROFILE: infraex
-    AWS_REGION: eu-west-2
+    AWS_REGION: ${{ github.event.inputs.keep_alive == 'true' && 'us-east-1' || 'eu-west-2' }}
     S3_BACKEND_BUCKET: tests-ra-aws-rosa-hcp-tf-state-eu-central-1
     S3_BUCKET_REGION: eu-central-1
     TLD: camunda.ie
     MAIL_OVERWRITE: admin@camunda.ie
     WILDCARD_TLS_SECRET_NAME: camunda-tls
 
-    CLEANUP_CLUSTERS: ${{ github.event.inputs.delete_clusters || 'true' }}
-
+    KEEP_ALIVE_STATE_SUFFIX: ${{ github.event.inputs.keep_alive == 'true' && '-keep-alive' || '' }}
+    CLEANUP_CLUSTERS: ${{ github.event.inputs.keep_alive == 'true' && 'false' || github.event.inputs.delete_clusters || 'true' }}
     # TEST VARIABLES
 
     # Vars with "CI_" prefix are used in the CI workflow only.
@@ -176,7 +189,7 @@ jobs:
               id: s3_prefix
               run: |
                   set -euo pipefail
-                  echo "S3_BACKEND_BUCKET_PREFIX=aws/kubernetes/${{ matrix.scenario.name }}/" | tee -a "$GITHUB_OUTPUT"
+                  echo "S3_BACKEND_BUCKET_PREFIX=aws/kubernetes/${{ matrix.scenario.name }}${KEEP_ALIVE_STATE_SUFFIX}/" | tee -a "$GITHUB_OUTPUT"
 
             - name: Create K8S cluster and login
               uses: ./.github/actions/aws-kubernetes-eks-single-region-create
@@ -820,7 +833,7 @@ jobs:
               id: s3_prefix
               run: |
                   set -euo pipefail
-                  echo "S3_BACKEND_BUCKET_PREFIX=aws/kubernetes/${{ matrix.scenario.name }}/" | tee -a "$GITHUB_OUTPUT"
+                  echo "S3_BACKEND_BUCKET_PREFIX=aws/kubernetes/${{ matrix.scenario.name }}${KEEP_ALIVE_STATE_SUFFIX}/" | tee -a "$GITHUB_OUTPUT"
 
             - name: Delete on-demand EKS Cluster
               uses: ./.github/actions/aws-kubernetes-eks-single-region-cleanup

--- a/.github/workflows/aws_openshift_rosa_hcp_dual_region_tests.yml
+++ b/.github/workflows/aws_openshift_rosa_hcp_dual_region_tests.yml
@@ -37,6 +37,19 @@ on:
                 type: boolean
                 default: true
 
+
+            keep_alive:
+                description: |
+                    Spawn a long-lived on-demand DEMO instead of an ephemeral test run.
+                    When true the clusters deploy to the AWS weekly-work region(s)
+                    (us-east-1, plus us-east-2 for dual-region) instead of the
+                    nightly-wiped CI regions, their Terraform state uses a dedicated
+                    "-keep-alive" prefix that the daily-cleanup workflow never scans,
+                    and the in-run teardown is skipped. The demo therefore lives the
+                    whole work week and is removed by the InfraEx weekly cleanup on
+                    Saturday ~05:00 UTC. Re-run with the SAME cluster_name to rebuild it.
+                type: boolean
+                default: false
             ref-arch:
                 description: |
                     Reference architecture to use, can only deploy one at a time.
@@ -61,14 +74,13 @@ env:
 
     S3_BACKEND_BUCKET: tests-ra-aws-rosa-hcp-tf-state-eu-central-1
     S3_BUCKET_REGION: eu-central-1
-    S3_BACKEND_BUCKET_PREFIX: aws/openshift/rosa-hcp-dual-region/ # keep it synced with the name of the module for simplicity
+    # keep it synced with the name of the module for simplicity
+    S3_BACKEND_BUCKET_PREFIX: aws/openshift/rosa-hcp-dual-region${{ github.event.inputs.keep_alive == 'true' && '-keep-alive/' || '/' }}
     TF_MODULES_DIRECTORY: ./.tf-modules-workflow/   # where the tf repo will be clone
 
-    CLUSTER_1_AWS_REGION: eu-west-2
-    CLUSTER_2_AWS_REGION: eu-west-3
-
-    CLEANUP_CLUSTERS: ${{ github.event.inputs.delete_clusters || 'true' }}
-
+    CLUSTER_1_AWS_REGION: ${{ github.event.inputs.keep_alive == 'true' && 'us-east-1' || 'eu-west-2' }}
+    CLUSTER_2_AWS_REGION: ${{ github.event.inputs.keep_alive == 'true' && 'us-east-2' || 'eu-west-3' }}
+    CLEANUP_CLUSTERS: ${{ github.event.inputs.keep_alive == 'true' && 'false' || github.event.inputs.delete_clusters || 'true' }}
     # TEST VARIABLES
 
     # Vars with "CI_" prefix are used in the CI workflow only.

--- a/.github/workflows/aws_openshift_rosa_hcp_single_region_tests.yml
+++ b/.github/workflows/aws_openshift_rosa_hcp_single_region_tests.yml
@@ -37,6 +37,19 @@ on:
                 type: boolean
                 default: true
 
+
+            keep_alive:
+                description: |
+                    Spawn a long-lived on-demand DEMO instead of an ephemeral test run.
+                    When true the clusters deploy to the AWS weekly-work region(s)
+                    (us-east-1, plus us-east-2 for dual-region) instead of the
+                    nightly-wiped CI regions, their Terraform state uses a dedicated
+                    "-keep-alive" prefix that the daily-cleanup workflow never scans,
+                    and the in-run teardown is skipped. The demo therefore lives the
+                    whole work week and is removed by the InfraEx weekly cleanup on
+                    Saturday ~05:00 UTC. Re-run with the SAME cluster_name to rebuild it.
+                type: boolean
+                default: false
             ref-arch:
                 description: |
                     Reference architecture to use, can only deploy one at a time.
@@ -59,14 +72,14 @@ env:
     IS_RENOVATE_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.user.login == 'renovate[bot]' }}
 
     AWS_PROFILE: infex
-    AWS_REGION: eu-west-2
+    AWS_REGION: ${{ github.event.inputs.keep_alive == 'true' && 'us-east-1' || 'eu-west-2' }}
     S3_BACKEND_BUCKET: tests-ra-aws-rosa-hcp-tf-state-eu-central-1
     S3_BUCKET_REGION: eu-central-1
     TF_MODULES_DIRECTORY: ./.tf-modules-workflow/   # where the tf repo will be clone
-    S3_BACKEND_BUCKET_PREFIX: aws/openshift/rosa-hcp-single-region/ # keep it synced with the name of the module for simplicity
+    # keep it synced with the name of the module for simplicity
+    S3_BACKEND_BUCKET_PREFIX: aws/openshift/rosa-hcp-single-region${{ github.event.inputs.keep_alive == 'true' && '-keep-alive/' || '/' }}
 
-    CLEANUP_CLUSTERS: ${{ github.event.inputs.delete_clusters || 'true' }}
-
+    CLEANUP_CLUSTERS: ${{ github.event.inputs.keep_alive == 'true' && 'false' || github.event.inputs.delete_clusters || 'true' }}
     # TEST VARIABLES
 
     # Vars with "CI_" prefix are used in the CI workflow only.

--- a/.github/workflows/azure_kubernetes_aks_single_region_tests.yml
+++ b/.github/workflows/azure_kubernetes_aks_single_region_tests.yml
@@ -31,6 +31,18 @@ on:
                 description: Whether to enable the tests.
                 type: boolean
                 default: true
+
+            keep_alive:
+                description: |
+                    Spawn a long-lived on-demand DEMO instead of an ephemeral test run.
+                    When true the Terraform state uses a dedicated "-keep-alive" prefix
+                    that the daily-cleanup workflow never scans and the in-run teardown is
+                    skipped, so the AKS cluster survives the run. NOTE: Azure has no
+                    weekly-work region, so this demo does NOT auto-expire - destroy it
+                    manually when you are done (dispatch the daily-cleanup workflow or
+                    `az group delete`). Re-run with the SAME resource group to rebuild it.
+                type: boolean
+                default: false
             cluster_name:
                 description: Name of the cluster to deploy.
                 type: string
@@ -82,8 +94,8 @@ env:
     # Test environment for cloud provider, please keep it synced between the workflows
     AZURE_REGION: swedencentral
 
-    CLEANUP_CLUSTERS: ${{ github.event.inputs.delete_clusters || 'true' }}
-
+    KEEP_ALIVE_STATE_SUFFIX: ${{ github.event.inputs.keep_alive == 'true' && '-keep-alive' || '' }}
+    CLEANUP_CLUSTERS: ${{ github.event.inputs.keep_alive == 'true' && 'false' || github.event.inputs.delete_clusters || 'true' }}
     # TEST VARIABLES
 
     CI_MATRIX_FILE: .github/workflows-config/azure-kubernetes-aks-single-region/test_matrix.yml
@@ -196,7 +208,7 @@ jobs:
               id: s3_prefix
               run: |
                   set -euo pipefail
-                  echo "S3_BACKEND_BUCKET_PREFIX=azure/kubernetes/${{ matrix.scenario.name }}/" | tee -a "$GITHUB_OUTPUT"
+                  echo "S3_BACKEND_BUCKET_PREFIX=azure/kubernetes/${{ matrix.scenario.name }}${KEEP_ALIVE_STATE_SUFFIX}/" | tee -a "$GITHUB_OUTPUT"
 
             - name: Create terraform.tfvars file
               id: create-tfvars
@@ -776,7 +788,7 @@ jobs:
               id: s3_prefix
               run: |
                   set -euo pipefail
-                  echo "S3_BACKEND_BUCKET_PREFIX=azure/kubernetes/${{ matrix.scenario.name }}/" | tee -a "$GITHUB_OUTPUT"
+                  echo "S3_BACKEND_BUCKET_PREFIX=azure/kubernetes/${{ matrix.scenario.name }}${KEEP_ALIVE_STATE_SUFFIX}/" | tee -a "$GITHUB_OUTPUT"
 
             - name: Delete on-demand AKS Cluster
               uses: ./.github/actions/azure-kubernetes-aks-single-region-cleanup


### PR DESCRIPTION
## Motivation

Enable **on-demand demos** on `stable/8.7`. Backport of `main` #2859.

## What changed

A `keep_alive` `workflow_dispatch` input. When `keep_alive=true`: AWS clusters deploy to the weekly-work regions (**us-east-1**, + **us-east-2** for dual), Terraform state moves to a dedicated **`…-keep-alive/`** prefix the daily cleanup never scans, and the in-run teardown is skipped. AWS demos live the work week and are removed by the InfraEx weekly cleanup **Saturday ~05:00 UTC**; rebuild by re-running with the same `cluster_name`. Scheduled/PR/normal-dispatch runs are unaffected.

**Workflows (8.7):** eks-single, rosa-single, rosa-dual, azure-aks.
**Azure caveat:** no Azure weekly-work region, so the AKS demo keeps `swedencentral` and does **NOT auto-expire** — destroy it manually (documented in the input).
**Excluded:** local kind (can't persist), `aws_modules_*` (not ref-archs).

## Validation
`actionlint`, `yamllint`, `yamlfmt` pass on all 4 files. Not run end-to-end; **not** tagged `[ready]`.

Per-branch rollout: main #2859, stable/8.9 #2860, stable/8.8 #2861 (+ ROSA dual #2857).
