### PR TITLE
ci(debug): surface likely crash root-cause for failed pods

### DIFF
--- a/.github/actions/internal-debug-failed-pods/README.md
+++ b/.github/actions/internal-debug-failed-pods/README.md
@@ -11,7 +11,7 @@ Collect debug info from failed pods (CrashLoopBackOff, Error, not ready) and upl
 | `namespace` | <p>The Kubernetes namespace to inspect</p> | `true` | `""` |
 | `context` | <p>The kubectl context to use (for multi-cluster setups). If empty, the current context is used.</p> | `false` | `""` |
 | `log-tail-lines` | <p>Number of log tail lines to display in the CI output (full logs are always uploaded as artifact)</p> | `false` | `200` |
-| `artifact-log-tail-lines` | <p>Max log lines captured per container in the uploaded artifact; bounds runaway/noisy logs while staying effectively complete</p> | `false` | `100000` |
+| `artifact-log-tail-lines` | <p>Max log lines per container for the artifact dump and the root-cause log scan; bounds runaway/noisy logs while staying effectively complete</p> | `false` | `100000` |
 | `artifact-suffix` | <p>Suffix appended to the artifact name (e.g. scenario/declination identifier)</p> | `false` | `""` |
 
 
@@ -43,7 +43,7 @@ This action is a `composite` action.
     # Default: 200
 
     artifact-log-tail-lines:
-    # Max log lines captured per container in the uploaded artifact; bounds runaway/noisy logs while staying effectively complete
+    # Max log lines per container for the artifact dump and the root-cause log scan; bounds runaway/noisy logs while staying effectively complete
     #
     # Required: false
     # Default: 100000

--- a/.github/actions/internal-debug-failed-pods/README.md
+++ b/.github/actions/internal-debug-failed-pods/README.md
@@ -11,6 +11,7 @@ Collect debug info from failed pods (CrashLoopBackOff, Error, not ready) and upl
 | `namespace` | <p>The Kubernetes namespace to inspect</p> | `true` | `""` |
 | `context` | <p>The kubectl context to use (for multi-cluster setups). If empty, the current context is used.</p> | `false` | `""` |
 | `log-tail-lines` | <p>Number of log tail lines to display in the CI output (full logs are always uploaded as artifact)</p> | `false` | `200` |
+| `artifact-log-tail-lines` | <p>Max log lines captured per container in the uploaded artifact; bounds runaway/noisy logs while staying effectively complete</p> | `false` | `100000` |
 | `artifact-suffix` | <p>Suffix appended to the artifact name (e.g. scenario/declination identifier)</p> | `false` | `""` |
 
 
@@ -40,6 +41,12 @@ This action is a `composite` action.
     #
     # Required: false
     # Default: 200
+
+    artifact-log-tail-lines:
+    # Max log lines captured per container in the uploaded artifact; bounds runaway/noisy logs while staying effectively complete
+    #
+    # Required: false
+    # Default: 100000
 
     artifact-suffix:
     # Suffix appended to the artifact name (e.g. scenario/declination identifier)

--- a/.github/actions/internal-debug-failed-pods/action.yml
+++ b/.github/actions/internal-debug-failed-pods/action.yml
@@ -154,8 +154,9 @@ runs:
               # Stderr of the -o yaml dumps is routed here so the .yaml files stay valid YAML.
               DUMP_ERR="${DUMP_DIR}/_dump-stderr.log"
               # yq redaction: blank out common secret-bearing keys (+ the license key)
-              # so credentials from `helm get values` never reach the artifact.
-              REDACT_KEYS='(.. | select(key | test("(?i)(password|passphrase|secret|token|credential|apikey|accesskey|privatekey|clientsecret)"))) = "***REDACTED***"'
+              # so credentials from `helm get values` never reach the artifact. The key is
+              # filtered to strings first so array indices (int keys) don't break `test`.
+              REDACT_KEYS='(.. | select((key | tag) == "!!str") | select(key | test("(?i)(pass|secret|token|credential|apikey|accesskey|privatekey)"))) = "***REDACTED***"'
               REDACT_LICENSE='(.. | select(tag == "!!map" and has("license")).license | select(tag == "!!map" and has("key")).key) = "***REDACTED***"'
               REDACT="${REDACT_KEYS} | ${REDACT_LICENSE}"
               CTX_ARGS=()
@@ -181,8 +182,8 @@ runs:
               # Rendered chart manifest, with Secret documents stripped so no
               # credential data ends up in the uploaded artifact.
               if command -v yq >/dev/null 2>&1; then
-                helm get manifest camunda -n "$NAMESPACE" "${CTX_ARGS[@]/#--context=/--kube-context=}" 2>/dev/null \
-                  | yq 'select(.kind != "Secret")' > "${DUMP_DIR}/helm-manifest-camunda.yaml" 2>/dev/null || true
+                helm get manifest camunda -n "$NAMESPACE" "${CTX_ARGS[@]/#--context=/--kube-context=}" 2>>"$DUMP_ERR" \
+                  | yq 'select(.kind != "Secret")' > "${DUMP_DIR}/helm-manifest-camunda.yaml" 2>>"$DUMP_ERR" || true
               else
                 echo "yq not found; skipping helm manifest dump to avoid leaking Secret data" \
                   > "${DUMP_DIR}/helm-manifest-camunda.yaml"

--- a/.github/actions/internal-debug-failed-pods/action.yml
+++ b/.github/actions/internal-debug-failed-pods/action.yml
@@ -158,10 +158,25 @@ runs:
               kubectl "${CTX_ARGS[@]}" -n "$NAMESPACE" get configmaps,secrets > "${DUMP_DIR}/configmaps-secrets.txt" 2>&1 || true
               helm list -n "$NAMESPACE" -o yaml "${CTX_ARGS[@]/#--context=/--kube-context=}" > "${DUMP_DIR}/helm-releases.yaml" 2>&1 || true
               helm get values camunda -n "$NAMESPACE" -o yaml "${CTX_ARGS[@]/#--context=/--kube-context=}" > "${DUMP_DIR}/helm-values-camunda.yaml" 2>&1 || true
+              helm get manifest camunda -n "$NAMESPACE" "${CTX_ARGS[@]/#--context=/--kube-context=}" > "${DUMP_DIR}/helm-manifest-camunda.yaml" 2>&1 || true
 
-              # Dump info for all non-Completed pods (per container)
+              # Full workload + networking resources (yaml) for the complete picture
+              kubectl "${CTX_ARGS[@]}" -n "$NAMESPACE" get deploy,sts,ds,rs,job,cronjob -o yaml > "${DUMP_DIR}/workloads.yaml" 2>&1 || true
+              kubectl "${CTX_ARGS[@]}" -n "$NAMESPACE" get ingress,httproute,gateway,networkpolicy,sa -o yaml > "${DUMP_DIR}/networking-resources.yaml" 2>&1 || true
+              kubectl "${CTX_ARGS[@]}" -n "$NAMESPACE" get events -o yaml > "${DUMP_DIR}/namespace-events.yaml" 2>&1 || true
+
+              # Node capacity/conditions (scheduling, OOM, disk/memory pressure)
+              kubectl "${CTX_ARGS[@]}" get nodes -o wide > "${DUMP_DIR}/nodes-overview.txt" 2>&1 || true
+              kubectl "${CTX_ARGS[@]}" describe nodes > "${DUMP_DIR}/nodes-describe.txt" 2>&1 || true
+
+              # In-cluster DNS (CoreDNS) config + logs — decisive for OIDC-issuer /
+              # ingress-domain resolution failures (UnknownHostException at startup).
+              kubectl "${CTX_ARGS[@]}" -n kube-system get configmap coredns -o yaml > "${DUMP_DIR}/coredns-configmap.yaml" 2>&1 || true
+              kubectl "${CTX_ARGS[@]}" -n kube-system logs -l k8s-app=kube-dns --prefix --tail=-1 > "${DUMP_DIR}/coredns-logs.txt" 2>&1 || true
+
+              # Dump info for ALL pods (incl. Completed init/setup jobs) — per container
               kubectl "${CTX_ARGS[@]}" -n "$NAMESPACE" get po --no-headers \
-                | awk '!/Completed/{print $1}' | while read -r pod_name; do
+                | awk '{print $1}' | while read -r pod_name; do
                 echo "Dumping info for pod: ${pod_name}"
                 kubectl "${CTX_ARGS[@]}" -n "$NAMESPACE" describe po "$pod_name" > "${DUMP_DIR}/${pod_name}-describe.txt" 2>&1 || true
                 kubectl "${CTX_ARGS[@]}" -n "$NAMESPACE" get po "$pod_name" -o yaml > "${DUMP_DIR}/${pod_name}-manifest.yaml" 2>&1 || true

--- a/.github/actions/internal-debug-failed-pods/action.yml
+++ b/.github/actions/internal-debug-failed-pods/action.yml
@@ -13,6 +13,10 @@ inputs:
         description: Number of log tail lines to display in the CI output (full logs are always uploaded as artifact)
         required: false
         default: '200'
+    artifact-log-tail-lines:
+        description: Max log lines captured per container in the uploaded artifact; bounds runaway/noisy logs while staying effectively complete
+        required: false
+        default: '100000'
     artifact-suffix:
         description: Suffix appended to the artifact name (e.g. scenario/declination identifier)
         required: false
@@ -145,6 +149,9 @@ runs:
               NAMESPACE="${{ inputs.namespace }}"
               DUMP_DIR="/tmp/pod-debug-dump-${NAMESPACE}"
               mkdir -p "$DUMP_DIR"
+              ARTIFACT_TAIL="${{ inputs.artifact-log-tail-lines }}"
+              # Stderr of the -o yaml dumps is routed here so the .yaml files stay valid YAML.
+              DUMP_ERR="${DUMP_DIR}/_dump-stderr.log"
               CTX_ARGS=()
               if [[ -n "${{ inputs.context }}" ]]; then
                 CTX_ARGS=(--context="${{ inputs.context }}")
@@ -156,8 +163,8 @@ runs:
               kubectl "${CTX_ARGS[@]}" -n "$NAMESPACE" get svc,endpoints > "${DUMP_DIR}/services-endpoints.txt" 2>&1 || true
               kubectl "${CTX_ARGS[@]}" -n "$NAMESPACE" get pvc > "${DUMP_DIR}/pvcs.txt" 2>&1 || true
               kubectl "${CTX_ARGS[@]}" -n "$NAMESPACE" get configmaps,secrets > "${DUMP_DIR}/configmaps-secrets.txt" 2>&1 || true
-              helm list -n "$NAMESPACE" -o yaml "${CTX_ARGS[@]/#--context=/--kube-context=}" > "${DUMP_DIR}/helm-releases.yaml" 2>&1 || true
-              helm get values camunda -n "$NAMESPACE" -o yaml "${CTX_ARGS[@]/#--context=/--kube-context=}" > "${DUMP_DIR}/helm-values-camunda.yaml" 2>&1 || true
+              helm list -n "$NAMESPACE" -o yaml "${CTX_ARGS[@]/#--context=/--kube-context=}" > "${DUMP_DIR}/helm-releases.yaml" 2>>"$DUMP_ERR" || true
+              helm get values camunda -n "$NAMESPACE" -o yaml "${CTX_ARGS[@]/#--context=/--kube-context=}" > "${DUMP_DIR}/helm-values-camunda.yaml" 2>>"$DUMP_ERR" || true
               # Rendered chart manifest, with Secret documents stripped so no
               # credential data ends up in the uploaded artifact.
               if command -v yq >/dev/null 2>&1; then
@@ -169,9 +176,9 @@ runs:
               fi
 
               # Full workload + networking resources (yaml) for the complete picture
-              kubectl "${CTX_ARGS[@]}" -n "$NAMESPACE" get deploy,sts,ds,rs,job,cronjob -o yaml > "${DUMP_DIR}/workloads.yaml" 2>&1 || true
-              kubectl "${CTX_ARGS[@]}" -n "$NAMESPACE" get ingress,httproute,gateway,networkpolicy,sa -o yaml > "${DUMP_DIR}/networking-resources.yaml" 2>&1 || true
-              kubectl "${CTX_ARGS[@]}" -n "$NAMESPACE" get events -o yaml > "${DUMP_DIR}/namespace-events.yaml" 2>&1 || true
+              kubectl "${CTX_ARGS[@]}" -n "$NAMESPACE" get deploy,sts,ds,rs,job,cronjob -o yaml > "${DUMP_DIR}/workloads.yaml" 2>>"$DUMP_ERR" || true
+              kubectl "${CTX_ARGS[@]}" -n "$NAMESPACE" get ingress,httproute,gateway,networkpolicy,sa -o yaml > "${DUMP_DIR}/networking-resources.yaml" 2>>"$DUMP_ERR" || true
+              kubectl "${CTX_ARGS[@]}" -n "$NAMESPACE" get events -o yaml > "${DUMP_DIR}/namespace-events.yaml" 2>>"$DUMP_ERR" || true
 
               # Node capacity/conditions (scheduling, OOM, disk/memory pressure)
               kubectl "${CTX_ARGS[@]}" get nodes -o wide > "${DUMP_DIR}/nodes-overview.txt" 2>&1 || true
@@ -179,22 +186,24 @@ runs:
 
               # In-cluster DNS (CoreDNS) config + logs — decisive for OIDC-issuer /
               # ingress-domain resolution failures (UnknownHostException at startup).
-              kubectl "${CTX_ARGS[@]}" -n kube-system get configmap coredns -o yaml > "${DUMP_DIR}/coredns-configmap.yaml" 2>&1 || true
-              kubectl "${CTX_ARGS[@]}" -n kube-system logs -l k8s-app=kube-dns --prefix --tail=-1 > "${DUMP_DIR}/coredns-logs.txt" 2>&1 || true
+              kubectl "${CTX_ARGS[@]}" -n kube-system get configmap coredns -o yaml > "${DUMP_DIR}/coredns-configmap.yaml" 2>>"$DUMP_ERR" || true
+              kubectl "${CTX_ARGS[@]}" -n kube-system logs -l k8s-app=kube-dns --prefix --tail="$ARTIFACT_TAIL" > "${DUMP_DIR}/coredns-logs.txt" 2>&1 || true
 
               # Dump info for ALL pods (incl. Completed init/setup jobs) — per container
               kubectl "${CTX_ARGS[@]}" -n "$NAMESPACE" get po --no-headers \
                 | awk '{print $1}' | while read -r pod_name; do
                 echo "Dumping info for pod: ${pod_name}"
                 kubectl "${CTX_ARGS[@]}" -n "$NAMESPACE" describe po "$pod_name" > "${DUMP_DIR}/${pod_name}-describe.txt" 2>&1 || true
-                kubectl "${CTX_ARGS[@]}" -n "$NAMESPACE" get po "$pod_name" -o yaml > "${DUMP_DIR}/${pod_name}-manifest.yaml" 2>&1 || true
+                kubectl "${CTX_ARGS[@]}" -n "$NAMESPACE" get po "$pod_name" -o yaml > "${DUMP_DIR}/${pod_name}-manifest.yaml" 2>>"$DUMP_ERR" || true
 
                 # Dump logs per container (init + main)
                 all_containers=$(kubectl "${CTX_ARGS[@]}" -n "$NAMESPACE" get po "$pod_name" \
                   -o jsonpath='{.spec.initContainers[*].name} {.spec.containers[*].name}' 2>/dev/null || true)
                 for container in $all_containers; do
-                  kubectl "${CTX_ARGS[@]}" -n "$NAMESPACE" logs "$pod_name" -c "$container" > "${DUMP_DIR}/${pod_name}-${container}-logs.txt" 2>&1 || true
-                  kubectl "${CTX_ARGS[@]}" -n "$NAMESPACE" logs "$pod_name" -c "$container" --previous > "${DUMP_DIR}/${pod_name}-${container}-logs-previous.txt" 2>&1 || true
+                  kubectl "${CTX_ARGS[@]}" -n "$NAMESPACE" logs "$pod_name" -c "$container" --tail="$ARTIFACT_TAIL" \
+                    > "${DUMP_DIR}/${pod_name}-${container}-logs.txt" 2>&1 || true
+                  kubectl "${CTX_ARGS[@]}" -n "$NAMESPACE" logs "$pod_name" -c "$container" --previous --tail="$ARTIFACT_TAIL" \
+                    > "${DUMP_DIR}/${pod_name}-${container}-logs-previous.txt" 2>&1 || true
                 done
               done
 

--- a/.github/actions/internal-debug-failed-pods/action.yml
+++ b/.github/actions/internal-debug-failed-pods/action.yml
@@ -31,6 +31,7 @@ runs:
 
               NAMESPACE="${{ inputs.namespace }}"
               LOG_TAIL="${{ inputs.log-tail-lines }}"
+              ARTIFACT_TAIL="${{ inputs.artifact-log-tail-lines }}"
               CTX_ARGS=()
               if [[ -n "${{ inputs.context }}" ]]; then
                 CTX_ARGS=(--context="${{ inputs.context }}")
@@ -116,8 +117,8 @@ runs:
                   crash_re="${crash_re}|Access denied|Unauthorized|OutOfMemory|BindException"
                   cause=$(
                     {
-                      kubectl "${CTX_ARGS[@]}" -n "$NAMESPACE" logs "$pod_name" -c "$container" --previous 2>/dev/null || true
-                      kubectl "${CTX_ARGS[@]}" -n "$NAMESPACE" logs "$pod_name" -c "$container" 2>/dev/null || true
+                      kubectl "${CTX_ARGS[@]}" -n "$NAMESPACE" logs "$pod_name" -c "$container" --previous --tail="$ARTIFACT_TAIL" 2>/dev/null || true
+                      kubectl "${CTX_ARGS[@]}" -n "$NAMESPACE" logs "$pod_name" -c "$container" --tail="$ARTIFACT_TAIL" 2>/dev/null || true
                     } | grep -aiE "$crash_re" | head -25 || true)
                   if [[ -n "$cause" ]]; then
                     echo "::group::🚨 ${pod_name}/${container} — likely root cause"
@@ -152,6 +153,11 @@ runs:
               ARTIFACT_TAIL="${{ inputs.artifact-log-tail-lines }}"
               # Stderr of the -o yaml dumps is routed here so the .yaml files stay valid YAML.
               DUMP_ERR="${DUMP_DIR}/_dump-stderr.log"
+              # yq redaction: blank out common secret-bearing keys (+ the license key)
+              # so credentials from `helm get values` never reach the artifact.
+              REDACT_KEYS='(.. | select(key | test("(?i)(password|passphrase|secret|token|credential|apikey|accesskey|privatekey|clientsecret)"))) = "***REDACTED***"'
+              REDACT_LICENSE='(.. | select(tag == "!!map" and has("license")).license | select(tag == "!!map" and has("key")).key) = "***REDACTED***"'
+              REDACT="${REDACT_KEYS} | ${REDACT_LICENSE}"
               CTX_ARGS=()
               if [[ -n "${{ inputs.context }}" ]]; then
                 CTX_ARGS=(--context="${{ inputs.context }}")
@@ -164,7 +170,14 @@ runs:
               kubectl "${CTX_ARGS[@]}" -n "$NAMESPACE" get pvc > "${DUMP_DIR}/pvcs.txt" 2>&1 || true
               kubectl "${CTX_ARGS[@]}" -n "$NAMESPACE" get configmaps,secrets > "${DUMP_DIR}/configmaps-secrets.txt" 2>&1 || true
               helm list -n "$NAMESPACE" -o yaml "${CTX_ARGS[@]/#--context=/--kube-context=}" > "${DUMP_DIR}/helm-releases.yaml" 2>>"$DUMP_ERR" || true
-              helm get values camunda -n "$NAMESPACE" -o yaml "${CTX_ARGS[@]/#--context=/--kube-context=}" > "${DUMP_DIR}/helm-values-camunda.yaml" 2>>"$DUMP_ERR" || true
+              # Helm values can carry plaintext credentials (CI basic-auth, license) — redact via yq, or skip if unavailable.
+              if command -v yq >/dev/null 2>&1; then
+                helm get values camunda -n "$NAMESPACE" -o yaml "${CTX_ARGS[@]/#--context=/--kube-context=}" 2>>"$DUMP_ERR" \
+                  | yq "$REDACT" > "${DUMP_DIR}/helm-values-camunda.yaml" 2>>"$DUMP_ERR" || true
+              else
+                echo "yq not found; skipping helm values dump to avoid leaking secret values" \
+                  > "${DUMP_DIR}/helm-values-camunda.yaml"
+              fi
               # Rendered chart manifest, with Secret documents stripped so no
               # credential data ends up in the uploaded artifact.
               if command -v yq >/dev/null 2>&1; then

--- a/.github/actions/internal-debug-failed-pods/action.yml
+++ b/.github/actions/internal-debug-failed-pods/action.yml
@@ -14,7 +14,8 @@ inputs:
         required: false
         default: '200'
     artifact-log-tail-lines:
-        description: Max log lines captured per container in the uploaded artifact; bounds runaway/noisy logs while staying effectively complete
+        description: Max log lines per container for the artifact dump and the root-cause log scan; bounds runaway/noisy logs while staying effectively
+            complete
         required: false
         default: '100000'
     artifact-suffix:
@@ -198,10 +199,14 @@ runs:
               kubectl "${CTX_ARGS[@]}" get nodes -o wide > "${DUMP_DIR}/nodes-overview.txt" 2>&1 || true
               kubectl "${CTX_ARGS[@]}" describe nodes > "${DUMP_DIR}/nodes-describe.txt" 2>&1 || true
 
-              # In-cluster DNS (CoreDNS) config + logs — decisive for OIDC-issuer /
-              # ingress-domain resolution failures (UnknownHostException at startup).
+              # In-cluster DNS config + logs — decisive for OIDC-issuer / ingress-domain
+              # resolution failures (UnknownHostException at startup). CoreDNS lives in
+              # kube-system on kind/EKS/AKS/GKE; OpenShift/ROSA run it in openshift-dns.
               kubectl "${CTX_ARGS[@]}" -n kube-system get configmap coredns -o yaml > "${DUMP_DIR}/coredns-configmap.yaml" 2>>"$DUMP_ERR" || true
               kubectl "${CTX_ARGS[@]}" -n kube-system logs -l k8s-app=kube-dns --prefix --tail="$ARTIFACT_TAIL" > "${DUMP_DIR}/coredns-logs.txt" 2>&1 || true
+              kubectl "${CTX_ARGS[@]}" -n openshift-dns get configmap dns-default -o yaml > "${DUMP_DIR}/openshift-dns-configmap.yaml" 2>>"$DUMP_ERR" || true
+              kubectl "${CTX_ARGS[@]}" -n openshift-dns logs -l dns.operator.openshift.io/daemonset-dns=default -c dns \
+                --prefix --tail="$ARTIFACT_TAIL" > "${DUMP_DIR}/openshift-dns-logs.txt" 2>&1 || true
 
               # Dump info for ALL pods (incl. Completed init/setup jobs) — per container
               kubectl "${CTX_ARGS[@]}" -n "$NAMESPACE" get po --no-headers \

--- a/.github/actions/internal-debug-failed-pods/action.yml
+++ b/.github/actions/internal-debug-failed-pods/action.yml
@@ -101,6 +101,25 @@ runs:
                     kubectl "${CTX_ARGS[@]}" -n "$NAMESPACE" logs "$pod_name" -c "$container" --previous --tail="$LOG_TAIL" || true
                     echo "::endgroup::"
                   fi
+
+                  # Surface the likely crash cause up front: grep crash/fatal
+                  # signatures out of the previous (crashed) then current logs, so
+                  # the root cause is visible without scrolling or downloading the
+                  # artifact. Purely diagnostic — never fails the step.
+                  crash_re='Caused by:|APPLICATION FAILED TO START|[[:space:]]FATAL[[:space:]]|panic:'
+                  crash_re="${crash_re}|failed to start|invalid licen|licen[sc]e (is )?(required|invalid|missing|not)"
+                  crash_re="${crash_re}|UnknownHostException|ConnectException|Connection refused"
+                  crash_re="${crash_re}|Access denied|Unauthorized|OutOfMemory|BindException"
+                  cause=$(
+                    {
+                      kubectl "${CTX_ARGS[@]}" -n "$NAMESPACE" logs "$pod_name" -c "$container" --previous 2>/dev/null || true
+                      kubectl "${CTX_ARGS[@]}" -n "$NAMESPACE" logs "$pod_name" -c "$container" 2>/dev/null || true
+                    } | grep -aiE "$crash_re" | head -25 || true)
+                  if [[ -n "$cause" ]]; then
+                    echo "::group::🚨 ${pod_name}/${container} — likely root cause"
+                    printf '%s\n' "$cause"
+                    echo "::endgroup::"
+                  fi
                 done
               done
 

--- a/.github/actions/internal-debug-failed-pods/action.yml
+++ b/.github/actions/internal-debug-failed-pods/action.yml
@@ -158,7 +158,15 @@ runs:
               kubectl "${CTX_ARGS[@]}" -n "$NAMESPACE" get configmaps,secrets > "${DUMP_DIR}/configmaps-secrets.txt" 2>&1 || true
               helm list -n "$NAMESPACE" -o yaml "${CTX_ARGS[@]/#--context=/--kube-context=}" > "${DUMP_DIR}/helm-releases.yaml" 2>&1 || true
               helm get values camunda -n "$NAMESPACE" -o yaml "${CTX_ARGS[@]/#--context=/--kube-context=}" > "${DUMP_DIR}/helm-values-camunda.yaml" 2>&1 || true
-              helm get manifest camunda -n "$NAMESPACE" "${CTX_ARGS[@]/#--context=/--kube-context=}" > "${DUMP_DIR}/helm-manifest-camunda.yaml" 2>&1 || true
+              # Rendered chart manifest, with Secret documents stripped so no
+              # credential data ends up in the uploaded artifact.
+              if command -v yq >/dev/null 2>&1; then
+                helm get manifest camunda -n "$NAMESPACE" "${CTX_ARGS[@]/#--context=/--kube-context=}" 2>/dev/null \
+                  | yq 'select(.kind != "Secret")' > "${DUMP_DIR}/helm-manifest-camunda.yaml" 2>/dev/null || true
+              else
+                echo "yq not found; skipping helm manifest dump to avoid leaking Secret data" \
+                  > "${DUMP_DIR}/helm-manifest-camunda.yaml"
+              fi
 
               # Full workload + networking resources (yaml) for the complete picture
               kubectl "${CTX_ARGS[@]}" -n "$NAMESPACE" get deploy,sts,ds,rs,job,cronjob -o yaml > "${DUMP_DIR}/workloads.yaml" 2>&1 || true

--- a/.github/actions/internal-debug-failed-pods/action.yml
+++ b/.github/actions/internal-debug-failed-pods/action.yml
@@ -192,7 +192,9 @@ runs:
 
               # Full workload + networking resources (yaml) for the complete picture
               kubectl "${CTX_ARGS[@]}" -n "$NAMESPACE" get deploy,sts,ds,rs,job,cronjob -o yaml > "${DUMP_DIR}/workloads.yaml" 2>>"$DUMP_ERR" || true
-              kubectl "${CTX_ARGS[@]}" -n "$NAMESPACE" get ingress,httproute,gateway,networkpolicy,sa -o yaml > "${DUMP_DIR}/networking-resources.yaml" 2>>"$DUMP_ERR" || true
+              kubectl "${CTX_ARGS[@]}" -n "$NAMESPACE" get ingress,networkpolicy,sa -o yaml > "${DUMP_DIR}/networking-resources.yaml" 2>>"$DUMP_ERR" || true
+              # Gateway API kinds are CRDs — dump separately so a missing CRD can't drop the built-ins above
+              kubectl "${CTX_ARGS[@]}" -n "$NAMESPACE" get httproute,gateway -o yaml > "${DUMP_DIR}/gateway-api-resources.yaml" 2>>"$DUMP_ERR" || true
               kubectl "${CTX_ARGS[@]}" -n "$NAMESPACE" get events -o yaml > "${DUMP_DIR}/namespace-events.yaml" 2>>"$DUMP_ERR" || true
 
               # Node capacity/conditions (scheduling, OOM, disk/memory pressure)


### PR DESCRIPTION
> Diagnostics improvement to root-cause the cloud CI failures — plus the root cause it surfaced.

## Context

Cloud CI (EKS/AKS/ROSA/OpenShift) is red because OIDC-dependent components (`camunda-identity`, `connectors`, `zeebe`) go `CrashLoopBackOff`, which cascades until the `Wait for the deployment to be healthy` step times out. **Kind stays green** (no public domain in play), so the failure is domain/cloud specific and **predates** the recent ref-arch changes.

The blocker to fixing it was that the actual startup exception was never surfaced: `internal-debug-failed-pods` only tailed ~200 lines, so the crash cause was easy to miss.

## (1) Diagnostics improvement (this PR)

`internal-debug-failed-pods`:

- For each `CrashLoopBackOff`/`Error` container, add a prominent **`🚨 <pod>/<container> — likely root cause`** group that greps crash/fatal signatures (`Caused by:`, `APPLICATION FAILED TO START`, `FATAL`, `UnknownHostException`, license, connection/auth errors, OOM, …) out of the `--previous` + current logs.
- Extend the uploaded artifact to dump the **complete** cluster state so nothing needs re-running: rendered `helm get manifest`, all workloads (deploy/sts/ds/rs/job/cronjob), networking (ingress/httproute/gateway/netpol/sa), full events (yaml), node conditions (`get -o wide` + `describe`), **CoreDNS configmap + logs**, and current+previous logs for **all** pods (incl. completed init/setup jobs).

Purely diagnostic — every command is wrapped in `|| true`, never fails the step. No behaviour change to any deployment; only the failure-path debug output. Secret **values** are not dumped (names only).

## (2) Root cause found

The improved diagnostics surfaced the crash: **`java.net.UnknownHostException: <cluster>.camunda.ie`** (×12) — the OIDC issuer / ingress domain **fails to resolve in-cluster** at pod startup, so the OIDC components cannot fetch the OIDC well-known document and crash-loop.

The workflow *does* have a `Restart CoreDNS` remediation, but it runs **after** `Wait for the deployment to be healthy` — too late, because the pods need working in-cluster DNS during startup. The actual fix (reorder / harden DNS before the health wait) will be a **separate follow-up PR**; this one is just the diagnostics that made the cause visible.

## Notes

- No behaviour change to any deployment.
- Generic CI diagnostics — intended to be backported to the maintained release branches (8.7–8.9).
