### PR TITLE
ci(debug): surface crash root-cause and dump full state for failed pods (8.9 backport) [ready]

### DIFF
--- a/.github/actions/internal-debug-failed-pods/README.md
+++ b/.github/actions/internal-debug-failed-pods/README.md
@@ -11,6 +11,7 @@ Collect debug info from failed pods (CrashLoopBackOff, Error, not ready) and upl
 | `namespace` | <p>The Kubernetes namespace to inspect</p> | `true` | `""` |
 | `context` | <p>The kubectl context to use (for multi-cluster setups). If empty, the current context is used.</p> | `false` | `""` |
 | `log-tail-lines` | <p>Number of log tail lines to display in the CI output (full logs are always uploaded as artifact)</p> | `false` | `200` |
+| `artifact-log-tail-lines` | <p>Max log lines per container for the artifact dump and the root-cause log scan; bounds runaway/noisy logs while staying effectively complete</p> | `false` | `100000` |
 | `artifact-suffix` | <p>Suffix appended to the artifact name (e.g. scenario/declination identifier)</p> | `false` | `""` |
 
 
@@ -40,6 +41,12 @@ This action is a `composite` action.
     #
     # Required: false
     # Default: 200
+
+    artifact-log-tail-lines:
+    # Max log lines per container for the artifact dump and the root-cause log scan; bounds runaway/noisy logs while staying effectively complete
+    #
+    # Required: false
+    # Default: 100000
 
     artifact-suffix:
     # Suffix appended to the artifact name (e.g. scenario/declination identifier)

--- a/.github/actions/internal-debug-failed-pods/README.md
+++ b/.github/actions/internal-debug-failed-pods/README.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-Collect debug info from failed pods (CrashLoopBackOff, Error, not ready) and upload complete logs as artifact
+Collect debug info from failed pods (CrashLoopBackOff, Error, not ready) and upload logs and cluster state as an artifact
 
 ## Inputs
 
@@ -10,8 +10,8 @@ Collect debug info from failed pods (CrashLoopBackOff, Error, not ready) and upl
 | --- | --- | --- | --- |
 | `namespace` | <p>The Kubernetes namespace to inspect</p> | `true` | `""` |
 | `context` | <p>The kubectl context to use (for multi-cluster setups). If empty, the current context is used.</p> | `false` | `""` |
-| `log-tail-lines` | <p>Number of log tail lines to display in the CI output (full logs are always uploaded as artifact)</p> | `false` | `200` |
-| `artifact-log-tail-lines` | <p>Max log lines per container for the artifact dump and the root-cause log scan; bounds runaway/noisy logs while staying effectively complete</p> | `false` | `100000` |
+| `log-tail-lines` | <p>Number of log tail lines shown inline in the CI output; the artifact keeps up to artifact-log-tail-lines per container</p> | `false` | `200` |
+| `artifact-log-tail-lines` | <p>Max log lines per container kept in the artifact and scanned for the root cause; bounds runaway/noisy logs</p> | `false` | `100000` |
 | `artifact-suffix` | <p>Suffix appended to the artifact name (e.g. scenario/declination identifier)</p> | `false` | `""` |
 
 
@@ -37,13 +37,13 @@ This action is a `composite` action.
     # Default: ""
 
     log-tail-lines:
-    # Number of log tail lines to display in the CI output (full logs are always uploaded as artifact)
+    # Number of log tail lines shown inline in the CI output; the artifact keeps up to artifact-log-tail-lines per container
     #
     # Required: false
     # Default: 200
 
     artifact-log-tail-lines:
-    # Max log lines per container for the artifact dump and the root-cause log scan; bounds runaway/noisy logs while staying effectively complete
+    # Max log lines per container kept in the artifact and scanned for the root cause; bounds runaway/noisy logs
     #
     # Required: false
     # Default: 100000

--- a/.github/actions/internal-debug-failed-pods/README.md
+++ b/.github/actions/internal-debug-failed-pods/README.md
@@ -11,7 +11,7 @@ Collect debug info from failed pods (CrashLoopBackOff, Error, not ready) and upl
 | `namespace` | <p>The Kubernetes namespace to inspect</p> | `true` | `""` |
 | `context` | <p>The kubectl context to use (for multi-cluster setups). If empty, the current context is used.</p> | `false` | `""` |
 | `log-tail-lines` | <p>Number of log tail lines shown inline in the CI output; the artifact keeps up to artifact-log-tail-lines per container</p> | `false` | `200` |
-| `artifact-log-tail-lines` | <p>Max log lines per container kept in the artifact and scanned for the root cause; bounds runaway/noisy logs</p> | `false` | `100000` |
+| `artifact-log-tail-lines` | <p>Per-container log line cap for the artifact dump and root-cause scan (bounds noisy logs)</p> | `false` | `100000` |
 | `artifact-suffix` | <p>Suffix appended to the artifact name (e.g. scenario/declination identifier)</p> | `false` | `""` |
 
 
@@ -43,7 +43,7 @@ This action is a `composite` action.
     # Default: 200
 
     artifact-log-tail-lines:
-    # Max log lines per container kept in the artifact and scanned for the root cause; bounds runaway/noisy logs
+    # Per-container log line cap for the artifact dump and root-cause scan (bounds noisy logs)
     #
     # Required: false
     # Default: 100000

--- a/.github/actions/internal-debug-failed-pods/action.yml
+++ b/.github/actions/internal-debug-failed-pods/action.yml
@@ -145,10 +145,12 @@ runs:
           shell: bash
           run: |
               set -euo pipefail
+              # The dump can contain sensitive cluster context — keep every file private.
+              umask 077
 
               NAMESPACE="${{ inputs.namespace }}"
               DUMP_DIR="${RUNNER_TEMP:-/tmp}/pod-debug-dump-${NAMESPACE}"
-              ( umask 077; mkdir -p "$DUMP_DIR" )
+              mkdir -p "$DUMP_DIR"
               ARTIFACT_TAIL="${{ inputs.artifact-log-tail-lines }}"
               # Stderr of the -o yaml dumps is routed here so the .yaml files stay valid YAML.
               DUMP_ERR="${DUMP_DIR}/_dump-stderr.log"

--- a/.github/actions/internal-debug-failed-pods/action.yml
+++ b/.github/actions/internal-debug-failed-pods/action.yml
@@ -14,7 +14,7 @@ inputs:
         required: false
         default: '200'
     artifact-log-tail-lines:
-        description: Max log lines per container kept in the artifact and scanned for the root cause; bounds runaway/noisy logs
+        description: Per-container log line cap for the artifact dump and root-cause scan (bounds noisy logs)
         required: false
         default: '100000'
     artifact-suffix:
@@ -125,7 +125,7 @@ runs:
                     echo "::endgroup::"
                   fi
                 done
-              done
+              done || true
 
               # Show tail logs for healthy running pods (collapsed)
               kubectl "${CTX_ARGS[@]}" -n "$NAMESPACE" get po --no-headers \
@@ -139,7 +139,7 @@ runs:
                     --tail="$LOG_TAIL" || true
                   echo "::endgroup::"
                 done
-              done
+              done || true
 
         - name: 📦 Dump pod logs and cluster state for artifact
           shell: bash
@@ -226,7 +226,7 @@ runs:
                   kubectl "${CTX_ARGS[@]}" -n "$NAMESPACE" logs "$pod_name" -c "$container" --previous --tail="$ARTIFACT_TAIL" \
                     > "${DUMP_DIR}/${pod_name}-${container}-logs-previous.txt" 2>&1 || true
                 done
-              done
+              done || true
 
               echo "dump-dir=${DUMP_DIR}" >> "$GITHUB_OUTPUT"
           id: dump

--- a/.github/actions/internal-debug-failed-pods/action.yml
+++ b/.github/actions/internal-debug-failed-pods/action.yml
@@ -169,6 +169,9 @@ runs:
               kubectl "${CTX_ARGS[@]}" -n "$NAMESPACE" get svc,endpoints > "${DUMP_DIR}/services-endpoints.txt" 2>&1 || true
               kubectl "${CTX_ARGS[@]}" -n "$NAMESPACE" get pvc > "${DUMP_DIR}/pvcs.txt" 2>&1 || true
               kubectl "${CTX_ARGS[@]}" -n "$NAMESPACE" get configmaps,secrets > "${DUMP_DIR}/configmaps-secrets.txt" 2>&1 || true
+              # Tool + cluster versions (helps diagnose version-specific behaviour, e.g. Helm 3 vs 4)
+              kubectl "${CTX_ARGS[@]}" version > "${DUMP_DIR}/versions-kubectl.txt" 2>&1 || true
+              helm version > "${DUMP_DIR}/versions-helm.txt" 2>&1 || true
               helm list -n "$NAMESPACE" -a -o yaml "${CTX_ARGS[@]/#--context=/--kube-context=}" > "${DUMP_DIR}/helm-releases.yaml" 2>>"$DUMP_ERR" || true
               # Helm values can carry plaintext credentials (CI basic-auth, license) — redact via yq, or skip if unavailable.
               if command -v yq >/dev/null 2>&1; then

--- a/.github/actions/internal-debug-failed-pods/action.yml
+++ b/.github/actions/internal-debug-failed-pods/action.yml
@@ -38,7 +38,7 @@ runs:
               fi
 
               echo "::group::All pods in namespace ${NAMESPACE}"
-              kubectl "${CTX_ARGS[@]}" -n "$NAMESPACE" get po -o wide
+              kubectl "${CTX_ARGS[@]}" -n "$NAMESPACE" get po -o wide || true
               echo "::endgroup::"
 
               echo "::group::Helm releases"
@@ -74,7 +74,7 @@ runs:
                 echo "============================================"
 
                 echo "::group::${pod_name} - describe"
-                kubectl "${CTX_ARGS[@]}" -n "$NAMESPACE" describe po "$pod_name"
+                kubectl "${CTX_ARGS[@]}" -n "$NAMESPACE" describe po "$pod_name" || true
                 echo "::endgroup::"
 
                 # Show init container logs if any init container failed

--- a/.github/actions/internal-debug-failed-pods/action.yml
+++ b/.github/actions/internal-debug-failed-pods/action.yml
@@ -204,6 +204,8 @@ runs:
               # kube-system on kind/EKS/AKS/GKE; OpenShift/ROSA run it in openshift-dns.
               kubectl "${CTX_ARGS[@]}" -n kube-system get configmap coredns -o yaml > "${DUMP_DIR}/coredns-configmap.yaml" 2>>"$DUMP_ERR" || true
               kubectl "${CTX_ARGS[@]}" -n kube-system logs -l k8s-app=kube-dns --prefix --tail="$ARTIFACT_TAIL" > "${DUMP_DIR}/coredns-logs.txt" 2>&1 || true
+              # Some clusters label CoreDNS app=coredns instead of k8s-app=kube-dns (cf. kubernetes-restart-coredns).
+              kubectl "${CTX_ARGS[@]}" -n kube-system logs -l app=coredns --prefix --tail="$ARTIFACT_TAIL" >> "${DUMP_DIR}/coredns-logs.txt" 2>&1 || true
               kubectl "${CTX_ARGS[@]}" -n openshift-dns get configmap dns-default -o yaml > "${DUMP_DIR}/openshift-dns-configmap.yaml" 2>>"$DUMP_ERR" || true
               kubectl "${CTX_ARGS[@]}" -n openshift-dns logs -l dns.operator.openshift.io/daemonset-dns=default -c dns \
                 --prefix --tail="$ARTIFACT_TAIL" > "${DUMP_DIR}/openshift-dns-logs.txt" 2>&1 || true

--- a/.github/actions/internal-debug-failed-pods/action.yml
+++ b/.github/actions/internal-debug-failed-pods/action.yml
@@ -1,6 +1,6 @@
 ---
 name: Debug failed Pods
-description: Collect debug info from failed pods (CrashLoopBackOff, Error, not ready) and upload complete logs as artifact
+description: Collect debug info from failed pods (CrashLoopBackOff, Error, not ready) and upload logs and cluster state as an artifact
 inputs:
     namespace:
         description: The Kubernetes namespace to inspect
@@ -10,12 +10,11 @@ inputs:
         required: false
         default: ''
     log-tail-lines:
-        description: Number of log tail lines to display in the CI output (full logs are always uploaded as artifact)
+        description: Number of log tail lines shown inline in the CI output; the artifact keeps up to artifact-log-tail-lines per container
         required: false
         default: '200'
     artifact-log-tail-lines:
-        description: Max log lines per container for the artifact dump and the root-cause log scan; bounds runaway/noisy logs while staying effectively
-            complete
+        description: Max log lines per container kept in the artifact and scanned for the root cause; bounds runaway/noisy logs
         required: false
         default: '100000'
     artifact-suffix:
@@ -142,7 +141,7 @@ runs:
                 done
               done
 
-        - name: 📦 Dump complete Pod logs for artifact
+        - name: 📦 Dump pod logs and cluster state for artifact
           shell: bash
           run: |
               set -euo pipefail

--- a/.github/actions/internal-debug-failed-pods/action.yml
+++ b/.github/actions/internal-debug-failed-pods/action.yml
@@ -13,6 +13,11 @@ inputs:
         description: Number of log tail lines to display in the CI output (full logs are always uploaded as artifact)
         required: false
         default: '200'
+    artifact-log-tail-lines:
+        description: Max log lines per container for the artifact dump and the root-cause log scan; bounds runaway/noisy logs while staying effectively
+            complete
+        required: false
+        default: '100000'
     artifact-suffix:
         description: Suffix appended to the artifact name (e.g. scenario/declination identifier)
         required: false
@@ -27,6 +32,7 @@ runs:
 
               NAMESPACE="${{ inputs.namespace }}"
               LOG_TAIL="${{ inputs.log-tail-lines }}"
+              ARTIFACT_TAIL="${{ inputs.artifact-log-tail-lines }}"
               CTX_ARGS=()
               if [[ -n "${{ inputs.context }}" ]]; then
                 CTX_ARGS=(--context="${{ inputs.context }}")
@@ -100,6 +106,25 @@ runs:
                     kubectl "${CTX_ARGS[@]}" -n "$NAMESPACE" logs "$pod_name" -c "$container" --previous --tail="$LOG_TAIL" || true
                     echo "::endgroup::"
                   fi
+
+                  # Surface the likely crash cause up front: grep crash/fatal
+                  # signatures out of the previous (crashed) then current logs, so
+                  # the root cause is visible without scrolling or downloading the
+                  # artifact. Purely diagnostic — never fails the step.
+                  crash_re='Caused by:|APPLICATION FAILED TO START|[[:space:]]FATAL[[:space:]]|panic:'
+                  crash_re="${crash_re}|failed to start|invalid licen|licen[sc]e (is )?(required|invalid|missing|not)"
+                  crash_re="${crash_re}|UnknownHostException|ConnectException|Connection refused"
+                  crash_re="${crash_re}|Access denied|Unauthorized|OutOfMemory|BindException"
+                  cause=$(
+                    {
+                      kubectl "${CTX_ARGS[@]}" -n "$NAMESPACE" logs "$pod_name" -c "$container" --previous --tail="$ARTIFACT_TAIL" 2>/dev/null || true
+                      kubectl "${CTX_ARGS[@]}" -n "$NAMESPACE" logs "$pod_name" -c "$container" --tail="$ARTIFACT_TAIL" 2>/dev/null || true
+                    } | grep -aiE "$crash_re" | head -25 || true)
+                  if [[ -n "$cause" ]]; then
+                    echo "::group::🚨 ${pod_name}/${container} — likely root cause"
+                    printf '%s\n' "$cause"
+                    echo "::endgroup::"
+                  fi
                 done
               done
 
@@ -125,6 +150,15 @@ runs:
               NAMESPACE="${{ inputs.namespace }}"
               DUMP_DIR="/tmp/pod-debug-dump-${NAMESPACE}"
               mkdir -p "$DUMP_DIR"
+              ARTIFACT_TAIL="${{ inputs.artifact-log-tail-lines }}"
+              # Stderr of the -o yaml dumps is routed here so the .yaml files stay valid YAML.
+              DUMP_ERR="${DUMP_DIR}/_dump-stderr.log"
+              # yq redaction: blank out common secret-bearing keys (+ the license key)
+              # so credentials from `helm get values` never reach the artifact. The key is
+              # filtered to strings first so array indices (int keys) don't break `test`.
+              REDACT_KEYS='(.. | select((key | tag) == "!!str") | select(key | test("(?i)(pass|secret|token|credential|apikey|accesskey|privatekey)"))) = "***REDACTED***"'
+              REDACT_LICENSE='(.. | select(tag == "!!map" and has("license")).license | select(tag == "!!map" and has("key")).key) = "***REDACTED***"'
+              REDACT="${REDACT_KEYS} | ${REDACT_LICENSE}"
               CTX_ARGS=()
               if [[ -n "${{ inputs.context }}" ]]; then
                 CTX_ARGS=(--context="${{ inputs.context }}")
@@ -136,22 +170,60 @@ runs:
               kubectl "${CTX_ARGS[@]}" -n "$NAMESPACE" get svc,endpoints > "${DUMP_DIR}/services-endpoints.txt" 2>&1 || true
               kubectl "${CTX_ARGS[@]}" -n "$NAMESPACE" get pvc > "${DUMP_DIR}/pvcs.txt" 2>&1 || true
               kubectl "${CTX_ARGS[@]}" -n "$NAMESPACE" get configmaps,secrets > "${DUMP_DIR}/configmaps-secrets.txt" 2>&1 || true
-              helm list -n "$NAMESPACE" -a -o yaml "${CTX_ARGS[@]/#--context=/--kube-context=}" > "${DUMP_DIR}/helm-releases.yaml" 2>&1 || true
-              helm get values camunda -n "$NAMESPACE" -o yaml "${CTX_ARGS[@]/#--context=/--kube-context=}" > "${DUMP_DIR}/helm-values-camunda.yaml" 2>&1 || true
+              helm list -n "$NAMESPACE" -a -o yaml "${CTX_ARGS[@]/#--context=/--kube-context=}" > "${DUMP_DIR}/helm-releases.yaml" 2>>"$DUMP_ERR" || true
+              # Helm values can carry plaintext credentials (CI basic-auth, license) — redact via yq, or skip if unavailable.
+              if command -v yq >/dev/null 2>&1; then
+                helm get values camunda -n "$NAMESPACE" -o yaml "${CTX_ARGS[@]/#--context=/--kube-context=}" 2>>"$DUMP_ERR" \
+                  | yq "$REDACT" > "${DUMP_DIR}/helm-values-camunda.yaml" 2>>"$DUMP_ERR" || true
+              else
+                echo "yq not found; skipping helm values dump to avoid leaking secret values" \
+                  > "${DUMP_DIR}/helm-values-camunda.yaml"
+              fi
+              # Rendered chart manifest, with Secret documents stripped so no
+              # credential data ends up in the uploaded artifact.
+              if command -v yq >/dev/null 2>&1; then
+                helm get manifest camunda -n "$NAMESPACE" "${CTX_ARGS[@]/#--context=/--kube-context=}" 2>>"$DUMP_ERR" \
+                  | yq 'select(.kind != "Secret")' > "${DUMP_DIR}/helm-manifest-camunda.yaml" 2>>"$DUMP_ERR" || true
+              else
+                echo "yq not found; skipping helm manifest dump to avoid leaking Secret data" \
+                  > "${DUMP_DIR}/helm-manifest-camunda.yaml"
+              fi
 
-              # Dump info for all non-Completed pods (per container)
+              # Full workload + networking resources (yaml) for the complete picture
+              kubectl "${CTX_ARGS[@]}" -n "$NAMESPACE" get deploy,sts,ds,rs,job,cronjob -o yaml > "${DUMP_DIR}/workloads.yaml" 2>>"$DUMP_ERR" || true
+              kubectl "${CTX_ARGS[@]}" -n "$NAMESPACE" get ingress,networkpolicy,sa -o yaml > "${DUMP_DIR}/networking-resources.yaml" 2>>"$DUMP_ERR" || true
+              # Gateway API kinds are CRDs — dump separately so a missing CRD can't drop the built-ins above
+              kubectl "${CTX_ARGS[@]}" -n "$NAMESPACE" get httproute,gateway -o yaml > "${DUMP_DIR}/gateway-api-resources.yaml" 2>>"$DUMP_ERR" || true
+              kubectl "${CTX_ARGS[@]}" -n "$NAMESPACE" get events -o yaml > "${DUMP_DIR}/namespace-events.yaml" 2>>"$DUMP_ERR" || true
+
+              # Node capacity/conditions (scheduling, OOM, disk/memory pressure)
+              kubectl "${CTX_ARGS[@]}" get nodes -o wide > "${DUMP_DIR}/nodes-overview.txt" 2>&1 || true
+              kubectl "${CTX_ARGS[@]}" describe nodes > "${DUMP_DIR}/nodes-describe.txt" 2>&1 || true
+
+              # In-cluster DNS config + logs — decisive for OIDC-issuer / ingress-domain
+              # resolution failures (UnknownHostException at startup). CoreDNS lives in
+              # kube-system on kind/EKS/AKS/GKE; OpenShift/ROSA run it in openshift-dns.
+              kubectl "${CTX_ARGS[@]}" -n kube-system get configmap coredns -o yaml > "${DUMP_DIR}/coredns-configmap.yaml" 2>>"$DUMP_ERR" || true
+              kubectl "${CTX_ARGS[@]}" -n kube-system logs -l k8s-app=kube-dns --prefix --tail="$ARTIFACT_TAIL" > "${DUMP_DIR}/coredns-logs.txt" 2>&1 || true
+              kubectl "${CTX_ARGS[@]}" -n openshift-dns get configmap dns-default -o yaml > "${DUMP_DIR}/openshift-dns-configmap.yaml" 2>>"$DUMP_ERR" || true
+              kubectl "${CTX_ARGS[@]}" -n openshift-dns logs -l dns.operator.openshift.io/daemonset-dns=default -c dns \
+                --prefix --tail="$ARTIFACT_TAIL" > "${DUMP_DIR}/openshift-dns-logs.txt" 2>&1 || true
+
+              # Dump info for ALL pods (incl. Completed init/setup jobs) — per container
               kubectl "${CTX_ARGS[@]}" -n "$NAMESPACE" get po --no-headers \
-                | awk '!/Completed/{print $1}' | while read -r pod_name; do
+                | awk '{print $1}' | while read -r pod_name; do
                 echo "Dumping info for pod: ${pod_name}"
                 kubectl "${CTX_ARGS[@]}" -n "$NAMESPACE" describe po "$pod_name" > "${DUMP_DIR}/${pod_name}-describe.txt" 2>&1 || true
-                kubectl "${CTX_ARGS[@]}" -n "$NAMESPACE" get po "$pod_name" -o yaml > "${DUMP_DIR}/${pod_name}-manifest.yaml" 2>&1 || true
+                kubectl "${CTX_ARGS[@]}" -n "$NAMESPACE" get po "$pod_name" -o yaml > "${DUMP_DIR}/${pod_name}-manifest.yaml" 2>>"$DUMP_ERR" || true
 
                 # Dump logs per container (init + main)
                 all_containers=$(kubectl "${CTX_ARGS[@]}" -n "$NAMESPACE" get po "$pod_name" \
                   -o jsonpath='{.spec.initContainers[*].name} {.spec.containers[*].name}' 2>/dev/null || true)
                 for container in $all_containers; do
-                  kubectl "${CTX_ARGS[@]}" -n "$NAMESPACE" logs "$pod_name" -c "$container" > "${DUMP_DIR}/${pod_name}-${container}-logs.txt" 2>&1 || true
-                  kubectl "${CTX_ARGS[@]}" -n "$NAMESPACE" logs "$pod_name" -c "$container" --previous > "${DUMP_DIR}/${pod_name}-${container}-logs-previous.txt" 2>&1 || true
+                  kubectl "${CTX_ARGS[@]}" -n "$NAMESPACE" logs "$pod_name" -c "$container" --tail="$ARTIFACT_TAIL" \
+                    > "${DUMP_DIR}/${pod_name}-${container}-logs.txt" 2>&1 || true
+                  kubectl "${CTX_ARGS[@]}" -n "$NAMESPACE" logs "$pod_name" -c "$container" --previous --tail="$ARTIFACT_TAIL" \
+                    > "${DUMP_DIR}/${pod_name}-${container}-logs-previous.txt" 2>&1 || true
                 done
               done
 

--- a/.github/actions/internal-debug-failed-pods/action.yml
+++ b/.github/actions/internal-debug-failed-pods/action.yml
@@ -147,8 +147,8 @@ runs:
               set -euo pipefail
 
               NAMESPACE="${{ inputs.namespace }}"
-              DUMP_DIR="/tmp/pod-debug-dump-${NAMESPACE}"
-              mkdir -p "$DUMP_DIR"
+              DUMP_DIR="${RUNNER_TEMP:-/tmp}/pod-debug-dump-${NAMESPACE}"
+              ( umask 077; mkdir -p "$DUMP_DIR" )
               ARTIFACT_TAIL="${{ inputs.artifact-log-tail-lines }}"
               # Stderr of the -o yaml dumps is routed here so the .yaml files stay valid YAML.
               DUMP_ERR="${DUMP_DIR}/_dump-stderr.log"


### PR DESCRIPTION
Backport of #2865 to `stable/8.9`.

Improves `internal-debug-failed-pods` so cloud-CI failures can be root-caused without re-running:

- **`🚨 <pod>/<container> — likely root cause`** group that greps crash/fatal signatures (`Caused by:`, `APPLICATION FAILED TO START`, `FATAL`, `UnknownHostException`, license, connection/auth errors, OOM, …) out of the previous + current logs.
- **Comprehensive artifact dump**: secret-stripped `helm get manifest`, redacted `helm get values` (secret-bearing keys + license key blanked), all workloads, built-in networking split from Gateway API CRDs, full events (yaml), node conditions, **CoreDNS + OpenShift `openshift-dns` config/logs**, and current+previous logs for all pods (incl. completed init jobs), bounded by the new `artifact-log-tail-lines` input.

Purely diagnostic — every command is wrapped in `|| true`, never fails the step; no behaviour change to any deployment. Secret **values** are not written to the artifact.

**8.9-specific:** `helm list` keeps the `-a` flag (8.9 ships Helm 3, where `-a`/`--all` still exists — main dropped it for Helm 4).

Not backported to 8.7/8.8: the `internal-debug-failed-pods` action does not exist and is unreferenced there (those branches debug inline in the workflows).
