### PR TITLE
chore(helm): finish source-build cleanup (vestigial eks-dual OCI ref, kind help text, renovate form)

### DIFF
--- a/aws/kubernetes/eks-dual-region/procedure/export_environment_prerequisites.sh
+++ b/aws/kubernetes/eks-dual-region/procedure/export_environment_prerequisites.sh
@@ -44,5 +44,3 @@ export CAMUNDA_RELEASE_NAME=${CAMUNDA_RELEASE_NAME:-camunda}
 # TODO: [release-duty] before the release, update the below versions to the stable release!
 # renovate: datasource=helm depName=camunda-platform registryUrl=https://helm.camunda.io versioning=regex:^14(\.(?<minor>\d+))?(\.(?<patch>\d+))?$
 export HELM_CHART_VERSION=${HELM_CHART_VERSION:-"15-dev-latest"}
-export HELM_CHART_REF=${HELM_CHART_REF:-"oci://registry.camunda.cloud/team-distribution/camunda-platform"}
-# TODO: [release-duty] before the release, update this!

--- a/aws/kubernetes/eks-dual-region/procedure/export_environment_prerequisites.sh
+++ b/aws/kubernetes/eks-dual-region/procedure/export_environment_prerequisites.sh
@@ -42,5 +42,5 @@ export CAMUNDA_NAMESPACE_1=${CAMUNDA_NAMESPACE_1:-camunda-paris}
 export CAMUNDA_RELEASE_NAME=${CAMUNDA_RELEASE_NAME:-camunda}
 
 # TODO: [release-duty] before the release, update the below versions to the stable release!
-# renovate: datasource=helm depName=camunda-platform registryUrl=https://helm.camunda.io versioning=regex:^14(\.(?<minor>\d+))?(\.(?<patch>\d+))?$
+# renovate: datasource=helm depName=camunda-platform registryUrl=https://helm.camunda.io versioning=regex:^15(\.(?<minor>\d+))?(\.(?<patch>\d+))?$
 export HELM_CHART_VERSION=${HELM_CHART_VERSION:-"15-dev-latest"}

--- a/generic/kubernetes/single-region/procedure/build-camunda-chart.sh
+++ b/generic/kubernetes/single-region/procedure/build-camunda-chart.sh
@@ -38,7 +38,7 @@ _chart_git_url="${CAMUNDA_HELM_CHART_GIT_URL:-https://github.com/camunda/camunda
 # 8.10 chart tag is *published* (not the moving 'main' tip); the default is split out
 # on its own line so the '# renovate:' inline manager can parse it (the ${VAR:-...}
 # override wrapper is not cleanly matchable).
-# renovate: datasource=github-tags depName=camunda/camunda-platform-helm versioning=regex:^camunda-platform-8\.10-(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)(?:-(?<prerelease>.+))?$
+# renovate: datasource=github-tags depName=camunda/camunda-platform-helm extractVersion=^camunda-platform-8\.10-(?<version>.+)$
 _chart_default_git_ref="camunda-platform-8.10-15.0.0-alpha2"
 # TODO: [release-duty] bump the 8.10 pin above as the 15.x line advances (keep in sync with CAMUNDA_HELM_CHART_VERSION and the helm-values).
 _chart_git_ref="${CAMUNDA_HELM_CHART_GIT_REF:-$_chart_default_git_ref}"

--- a/local/kubernetes/kind-single-region/Makefile
+++ b/local/kubernetes/kind-single-region/Makefile
@@ -131,6 +131,7 @@ domain.infra: cluster.create ingress.deploy coredns.config hosts.add certs.gener
 	@echo "    make identity-secrets.create"
 	@echo "  Deploy Camunda with your own values:"
 	@echo "    helm upgrade --install camunda <LOCAL_CHART> -n camunda --create-namespace -f your-values.yaml   # build <LOCAL_CHART> with: ./procedure/build-camunda-chart.sh"
+	@# TODO: [release-duty] at GA, revert the hint above to the published chart (helm upgrade --install camunda camunda-platform --repo https://helm.camunda.io --version <CHART_VERSION> ...); the pre-release build-camunda-chart.sh is deleted then.
 	@echo ""
 
 .PHONY: no-domain.infra
@@ -141,6 +142,7 @@ no-domain.infra: cluster.create hosts.add-keycloak operators.deploy-no-domain
 	@echo "    make identity-secrets.create"
 	@echo "  Deploy Camunda with your own values:"
 	@echo "    helm upgrade --install camunda <LOCAL_CHART> -n camunda --create-namespace -f your-values.yaml   # build <LOCAL_CHART> with: ./procedure/build-camunda-chart.sh"
+	@# TODO: [release-duty] at GA, revert the hint above to the published chart (helm upgrade --install camunda camunda-platform --repo https://helm.camunda.io --version <CHART_VERSION> ...); the pre-release build-camunda-chart.sh is deleted then.
 	@echo ""
 
 .PHONY: no-domain.clean

--- a/local/kubernetes/kind-single-region/Makefile
+++ b/local/kubernetes/kind-single-region/Makefile
@@ -130,7 +130,7 @@ domain.infra: cluster.create ingress.deploy coredns.config hosts.add certs.gener
 	@echo "  Before installing Camunda, create the required credentials secret (camunda-credentials):"
 	@echo "    make identity-secrets.create"
 	@echo "  Deploy Camunda with your own values:"
-	@echo "    helm upgrade --install camunda <LOCAL_CHART> -n camunda --create-namespace -f your-values.yaml   # build <LOCAL_CHART> with: ./procedure/build-camunda-chart.sh"
+	@echo "    helm upgrade --install camunda <LOCAL_CHART> -n camunda --create-namespace -f your-values.yaml   # <LOCAL_CHART>: run ./procedure/build-camunda-chart.sh (prints the local chart path)"
 	@# TODO: [release-duty] at GA, revert the hint above to the published chart (helm upgrade --install camunda camunda-platform --repo https://helm.camunda.io --version <CHART_VERSION> ...); the pre-release build-camunda-chart.sh is deleted then.
 	@echo ""
 
@@ -141,7 +141,7 @@ no-domain.infra: cluster.create hosts.add-keycloak operators.deploy-no-domain
 	@echo "  Before installing Camunda, create the required credentials secret (camunda-credentials):"
 	@echo "    make identity-secrets.create"
 	@echo "  Deploy Camunda with your own values:"
-	@echo "    helm upgrade --install camunda <LOCAL_CHART> -n camunda --create-namespace -f your-values.yaml   # build <LOCAL_CHART> with: ./procedure/build-camunda-chart.sh"
+	@echo "    helm upgrade --install camunda <LOCAL_CHART> -n camunda --create-namespace -f your-values.yaml   # <LOCAL_CHART>: run ./procedure/build-camunda-chart.sh (prints the local chart path)"
 	@# TODO: [release-duty] at GA, revert the hint above to the published chart (helm upgrade --install camunda camunda-platform --repo https://helm.camunda.io --version <CHART_VERSION> ...); the pre-release build-camunda-chart.sh is deleted then.
 	@echo ""
 

--- a/local/kubernetes/kind-single-region/Makefile
+++ b/local/kubernetes/kind-single-region/Makefile
@@ -130,7 +130,7 @@ domain.infra: cluster.create ingress.deploy coredns.config hosts.add certs.gener
 	@echo "  Before installing Camunda, create the required credentials secret (camunda-credentials):"
 	@echo "    make identity-secrets.create"
 	@echo "  Deploy Camunda with your own values:"
-	@echo "    helm upgrade --install camunda oci://registry.camunda.cloud/team-distribution/camunda-platform --version <CHART_VERSION> -n camunda --create-namespace -f your-values.yaml"
+	@echo "    helm upgrade --install camunda <LOCAL_CHART> -n camunda --create-namespace -f your-values.yaml   # build <LOCAL_CHART> with: ./procedure/build-camunda-chart.sh"
 	@echo ""
 
 .PHONY: no-domain.infra
@@ -140,7 +140,7 @@ no-domain.infra: cluster.create hosts.add-keycloak operators.deploy-no-domain
 	@echo "  Before installing Camunda, create the required credentials secret (camunda-credentials):"
 	@echo "    make identity-secrets.create"
 	@echo "  Deploy Camunda with your own values:"
-	@echo "    helm upgrade --install camunda oci://registry.camunda.cloud/team-distribution/camunda-platform --version <CHART_VERSION> -n camunda --create-namespace -f your-values.yaml"
+	@echo "    helm upgrade --install camunda <LOCAL_CHART> -n camunda --create-namespace -f your-values.yaml   # build <LOCAL_CHART> with: ./procedure/build-camunda-chart.sh"
 	@echo ""
 
 .PHONY: no-domain.clean

--- a/local/kubernetes/kind-single-region/procedure/build-camunda-chart.sh
+++ b/local/kubernetes/kind-single-region/procedure/build-camunda-chart.sh
@@ -64,7 +64,7 @@ _chart_git_url="${CAMUNDA_HELM_CHART_GIT_URL:-https://github.com/camunda/camunda
 # 8.10 chart tag is *published* (not the moving 'main' tip); the default is split out
 # on its own line so the '# renovate:' inline manager can parse it (the ${VAR:-...}
 # override wrapper is not cleanly matchable).
-# renovate: datasource=github-tags depName=camunda/camunda-platform-helm versioning=regex:^camunda-platform-8\.10-(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)(?:-(?<prerelease>.+))?$
+# renovate: datasource=github-tags depName=camunda/camunda-platform-helm extractVersion=^camunda-platform-8\.10-(?<version>.+)$
 _chart_default_git_ref="camunda-platform-8.10-15.0.0-alpha2"
 # TODO: [release-duty] bump the 8.10 pin above as the 15.x line advances (keep in sync with CAMUNDA_HELM_CHART_VERSION and the helm-values).
 _chart_git_ref="${CAMUNDA_HELM_CHART_GIT_REF:-$_chart_default_git_ref}"


### PR DESCRIPTION
Final cleanup finishing the source-build / private-OCI-removal effort (follows #2841, #2856, #2858). Three small, independent changes:

## 1. eks-dual — drop the vestigial `HELM_CHART_REF` OCI export
`aws/kubernetes/eks-dual-region/procedure/export_environment_prerequisites.sh` exported `HELM_CHART_REF=oci://registry.camunda.cloud/team-distribution/camunda-platform`, but **nothing reads it**: the eks-dual install is the Go test, which reads `HELM_CHART_NAME` (and `DEVELOPER.md` uses `HELM_CHART_NAME` too). CI already source-builds that path (#2858). So this is a dead reference to the private registry — removed. `HELM_CHART_VERSION` (which the Go test does read) is kept.

## 2. kind — fix the Makefile help text
`local/kubernetes/kind-single-region/Makefile` (the `domain.infra` / `no-domain.infra` targets) echoed `helm upgrade --install camunda oci://registry.camunda.cloud/… --version <CHART_VERSION> …` as the "deploy with your own values" hint, even though the kind guide source-builds (#2823/#2827). Updated to point at the local source-built chart (`build-camunda-chart.sh`), matching what `camunda-deploy-*.sh` actually do.

## 3. renovate — unify the pin annotation form
The three source-build pins used two forms: `versioning=regex:^camunda-platform-8.10-…` (generic #2841, kind #2856) vs `extractVersion=^camunda-platform-8.10-…` (eks-dual #2858). Switched the generic + kind helpers to `extractVersion` so all three match. Same behavior (track published `camunda-platform-8.10-15.x` tags, never `main`); `extractVersion` is shorter and fits the yamllint line limit everywhere.

No behavior change to any deployment — dead-code removal, help-text fix, and annotation consistency. Not merging (human action).
