### PR TITLE
fix(helm): migrate remaining deprecated keys to extraConfiguration (chart alpha3)

### DIFF
--- a/.github/actions/internal-helm-deprecation-check/README.md
+++ b/.github/actions/internal-helm-deprecation-check/README.md
@@ -38,7 +38,7 @@ See: https://github.com/camunda/camunda-platform-helm/issues/4564
 | `release-name` | <p>The Helm release name to check</p> | `false` | `camunda` |
 | `namespace` | <p>The Kubernetes namespace where the release is deployed</p> | `false` | `camunda` |
 | `kube-context` | <p>The Kubernetes context to use (optional, defaults to current context)</p> | `false` | `""` |
-| `exclude-patterns` | <p>Newline-separated list of fixed strings (one pattern per line) to exclude from warnings and errors. Messages containing any of these strings are ignored. Patterns are matched per line, so a space-separated value is treated as a single pattern, not several.</p> | `false` | `webModeler.restapi.mail.fromAddress webModeler.restapi.mail.fromName orchestration.exporters.camunda.enabled` |
+| `exclude-patterns` | <p>Newline-separated list of fixed strings (one pattern per line) to exclude from warnings and errors. Messages containing any of these strings are ignored. Patterns are matched per line, so a space-separated value is treated as a single pattern, not several.</p> | `false` | `""` |
 | `check-unknown-keys` | <p>When set to 'true', deployed values are validated against a strict version of the chart's JSON Schema to detect unknown keys (typos, removed properties). The schema is automatically extracted from the deployed chart. See: https://github.com/camunda/camunda-platform-helm/issues/4564</p> | `false` | `true` |
 | `local-chart-path` | <p>Optional path to a locally source-built chart directory (one that contains values.schema.json). When set, the unknown-keys check reads the schema from there instead of pulling the chart from a registry, so the pre-release (dev) line needs no private OCI registry authentication.</p> | `false` | `""` |
 | `comment-section-key` | <p>Optional extra identifier mixed into the PR comment section ID. Use this when the same workflow + job + release-name + namespace tuple runs more than once (e.g. across matrix entries) and each run should produce its own section in the shared PR comment.</p> | `false` | `""` |
@@ -84,7 +84,7 @@ This action is a `composite` action.
     # space-separated value is treated as a single pattern, not several.
     #
     # Required: false
-    # Default: webModeler.restapi.mail.fromAddress webModeler.restapi.mail.fromName orchestration.exporters.camunda.enabled
+    # Default: ""
 
     check-unknown-keys:
     # When set to 'true', deployed values are validated against a strict

--- a/.github/actions/internal-helm-deprecation-check/action.yml
+++ b/.github/actions/internal-helm-deprecation-check/action.yml
@@ -49,16 +49,7 @@ inputs:
             strings are ignored. Patterns are matched per line, so a
             space-separated value is treated as a single pattern, not several.
         required: false
-        # TODO(camunda-platform-helm#6507): these excludes are a workaround for an
-        # upstream chart bug — the keys are deprecated toward `extraConfiguration`
-        # but can't be migrated there (one is still `required`, the other is a
-        # template-time toggle). Remove the matching line(s) below once that is
-        # fixed upstream (or chart v16 / Camunda 8.11 removes the keys).
-        # https://github.com/camunda/camunda-platform-helm/issues/6507
-        default: |-
-            webModeler.restapi.mail.fromAddress
-            webModeler.restapi.mail.fromName
-            orchestration.exporters.camunda.enabled
+        default: ''
     check-unknown-keys:
         description: |
             When set to 'true', deployed values are validated against a strict

--- a/.github/actions/internal-multi-region-tests/action.yml
+++ b/.github/actions/internal-multi-region-tests/action.yml
@@ -148,7 +148,7 @@ runs:
                 # version N-1), so the built chart is one prerelease behind CHART_GIT_REF (this
                 # is intentional — the known-good set the integration tests validate).
                 # renovate: datasource=github-tags depName=camunda/camunda-platform-helm extractVersion=^camunda-platform-8\.10-(?<version>.+)$
-                CHART_GIT_REF="camunda-platform-8.10-15.0.0-alpha2"
+                CHART_GIT_REF="camunda-platform-8.10-15.0.0-alpha3"
                 CAMUNDA_VERSION="$(cat "${{ github.workspace }}/.camunda-version")"
                 CHART_CHECKOUT="$(mktemp -d)/camunda-platform-helm"
                 git clone --depth 1 --branch "$CHART_GIT_REF" \

--- a/aws/kubernetes/eks-dual-region/helm-values/camunda-values.yml
+++ b/aws/kubernetes/eks-dual-region/helm-values/camunda-values.yml
@@ -49,12 +49,20 @@ orchestration:
     data:
         secondaryStorage:
             type: elasticsearch
-    # Disable the Camunda and Zeebe exporters as we use region specific ones below
+    # Disable the Zeebe exporter as we use the region-specific exporters (env) below.
     exporters:
-        camunda:
-            enabled: false
         zeebe:
             enabled: false
+    # Disable the inbuilt Camunda exporter via unified configuration. The values key
+    # orchestration.exporters.camunda.enabled is deprecated in chart 8.10 (removed in
+    # v16); it is a template toggle, so it is migrated to the equivalent app-config key.
+    extraConfiguration:
+        - file: orchestration-camunda-exporter.yaml
+          content: |
+              camunda:
+                data:
+                  secondary-storage:
+                    autoconfigure-camunda-exporter: false
     env:
         - name: CAMUNDA_CLUSTER_PARTITIONCOUNT
           value: '8'

--- a/aws/kubernetes/eks-single-region-irsa/helm-values/values-domain.yml
+++ b/aws/kubernetes/eks-single-region-irsa/helm-values/values-domain.yml
@@ -173,4 +173,12 @@ webModeler:
             secret:
                 existingSecret: webmodeler-secret
                 existingSecretKey: smtp-password
-            fromAddress: changeme@example.com   # change this required value
+        # from-address is deprecated as a values key in chart 8.10 (removed in v16),
+        # so the sender address is supplied via unified configuration instead.
+        extraConfiguration:
+            - file: webmodeler-mail.yaml
+              content: |
+                  camunda:
+                    modeler:
+                      mail:
+                        from-address: changeme@example.com   # change this required value

--- a/aws/kubernetes/eks-single-region-irsa/helm-values/values-domain.yml
+++ b/aws/kubernetes/eks-single-region-irsa/helm-values/values-domain.yml
@@ -43,8 +43,6 @@ global:
     identity:
         auth:
             enabled: true
-            identity:
-                redirectUrl: https://${CAMUNDA_DOMAIN}/managementidentity
             webModeler:
                 redirectUrl: https://${CAMUNDA_DOMAIN}/modeler
             optimize:

--- a/aws/kubernetes/eks-single-region-irsa/helm-values/values-no-domain.yml
+++ b/aws/kubernetes/eks-single-region-irsa/helm-values/values-no-domain.yml
@@ -134,4 +134,12 @@ webModeler:
             secret:
                 existingSecret: webmodeler-secret
                 existingSecretKey: smtp-password
-            fromAddress: changeme@example.com   # change this required value
+        # from-address is deprecated as a values key in chart 8.10 (removed in v16),
+        # so the sender address is supplied via unified configuration instead.
+        extraConfiguration:
+            - file: webmodeler-mail.yaml
+              content: |
+                  camunda:
+                    modeler:
+                      mail:
+                        from-address: changeme@example.com   # change this required value

--- a/aws/kubernetes/eks-single-region/helm-values/values-domain.yml
+++ b/aws/kubernetes/eks-single-region/helm-values/values-domain.yml
@@ -28,8 +28,6 @@ global:
     identity:
         auth:
             enabled: true
-            identity:
-                redirectUrl: https://${CAMUNDA_DOMAIN}/managementidentity
             webModeler:
                 redirectUrl: https://${CAMUNDA_DOMAIN}/modeler
             optimize:

--- a/aws/kubernetes/eks-single-region/helm-values/values-domain.yml
+++ b/aws/kubernetes/eks-single-region/helm-values/values-domain.yml
@@ -134,4 +134,12 @@ webModeler:
             secret:
                 existingSecret: webmodeler-secret
                 existingSecretKey: smtp-password
-            fromAddress: changeme@example.com   # change this required value
+        # from-address is deprecated as a values key in chart 8.10 (removed in v16),
+        # so the sender address is supplied via unified configuration instead.
+        extraConfiguration:
+            - file: webmodeler-mail.yaml
+              content: |
+                  camunda:
+                    modeler:
+                      mail:
+                        from-address: changeme@example.com   # change this required value

--- a/aws/kubernetes/eks-single-region/helm-values/values-no-domain.yml
+++ b/aws/kubernetes/eks-single-region/helm-values/values-no-domain.yml
@@ -78,7 +78,15 @@ webModeler:
             secret:
                 existingSecret: webmodeler-secret
                 existingSecretKey: smtp-password
-            fromAddress: changeme@example.com   # change this required value
+        # from-address is deprecated as a values key in chart 8.10 (removed in v16),
+        # so the sender address is supplied via unified configuration instead.
+        extraConfiguration:
+            - file: webmodeler-mail.yaml
+              content: |
+                  camunda:
+                    modeler:
+                      mail:
+                        from-address: changeme@example.com   # change this required value
 
 orchestration:
     data:

--- a/azure/kubernetes/aks-single-region-rdbms/helm-values/values-domain.yml
+++ b/azure/kubernetes/aks-single-region-rdbms/helm-values/values-domain.yml
@@ -32,8 +32,6 @@ global:
     identity:
         auth:
             enabled: true
-            identity:
-                redirectUrl: https://${CAMUNDA_DOMAIN}/managementidentity
             webModeler:
                 redirectUrl: https://${CAMUNDA_DOMAIN}/modeler
 
@@ -71,7 +69,6 @@ webModeler:
 
     restapi:
         externalDatabase:
-            enabled: true
             url: jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_WEBMODELER_NAME}?sslmode=require
             username: ${DB_WEBMODELER_USERNAME}
             secret:

--- a/azure/kubernetes/aks-single-region-rdbms/helm-values/values-domain.yml
+++ b/azure/kubernetes/aks-single-region-rdbms/helm-values/values-domain.yml
@@ -82,7 +82,15 @@ webModeler:
             secret:
                 existingSecret: webmodeler-secret
                 existingSecretKey: smtp-password
-            fromAddress: changeme@example.com
+        # from-address is deprecated as a values key in chart 8.10 (removed in v16),
+        # so the sender address is supplied via unified configuration instead.
+        extraConfiguration:
+            - file: webmodeler-mail.yaml
+              content: |
+                  camunda:
+                    modeler:
+                      mail:
+                        from-address: changeme@example.com
 
 
 # Optimize requires Elasticsearch and is not available in RDBMS mode
@@ -94,10 +102,18 @@ orchestration:
     contextPath: /
 
     exporters:
-        camunda:
-            enabled: false
         rdbms:
             enabled: true
+    # Disable the inbuilt Camunda exporter via unified configuration. The values key
+    # orchestration.exporters.camunda.enabled is deprecated in chart 8.10 (removed in
+    # v16); it is a template toggle, so it is migrated to the equivalent app-config key.
+    extraConfiguration:
+        - file: orchestration-camunda-exporter.yaml
+          content: |
+              camunda:
+                data:
+                  secondary-storage:
+                    autoconfigure-camunda-exporter: false
 
     data:
         secondaryStorage:

--- a/azure/kubernetes/aks-single-region-rdbms/helm-values/values-no-domain.yml
+++ b/azure/kubernetes/aks-single-region-rdbms/helm-values/values-no-domain.yml
@@ -90,7 +90,6 @@ webModeler:
 
     restapi:
         externalDatabase:
-            enabled: true
             url: jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_WEBMODELER_NAME}?sslmode=require
             username: ${DB_WEBMODELER_USERNAME}
             secret:

--- a/azure/kubernetes/aks-single-region-rdbms/helm-values/values-no-domain.yml
+++ b/azure/kubernetes/aks-single-region-rdbms/helm-values/values-no-domain.yml
@@ -55,10 +55,18 @@ optimize:
 # RDBMS secondary storage configuration
 orchestration:
     exporters:
-        camunda:
-            enabled: false
         rdbms:
             enabled: true
+    # Disable the inbuilt Camunda exporter via unified configuration. The values key
+    # orchestration.exporters.camunda.enabled is deprecated in chart 8.10 (removed in
+    # v16); it is a template toggle, so it is migrated to the equivalent app-config key.
+    extraConfiguration:
+        - file: orchestration-camunda-exporter.yaml
+          content: |
+              camunda:
+                data:
+                  secondary-storage:
+                    autoconfigure-camunda-exporter: false
 
     data:
         secondaryStorage:
@@ -93,4 +101,12 @@ webModeler:
             secret:
                 existingSecret: webmodeler-secret
                 existingSecretKey: smtp-password
-            fromAddress: changeme@example.com
+        # from-address is deprecated as a values key in chart 8.10 (removed in v16),
+        # so the sender address is supplied via unified configuration instead.
+        extraConfiguration:
+            - file: webmodeler-mail.yaml
+              content: |
+                  camunda:
+                    modeler:
+                      mail:
+                        from-address: changeme@example.com

--- a/azure/kubernetes/aks-single-region/helm-values/values-domain.yml
+++ b/azure/kubernetes/aks-single-region/helm-values/values-domain.yml
@@ -29,8 +29,6 @@ global:
     identity:
         auth:
             enabled: true
-            identity:
-                redirectUrl: https://${CAMUNDA_DOMAIN}/managementidentity
             webModeler:
                 redirectUrl: https://${CAMUNDA_DOMAIN}/modeler
             optimize:
@@ -70,7 +68,6 @@ webModeler:
 
     restapi:
         externalDatabase:
-            enabled: true
             url: jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_WEBMODELER_NAME}?sslmode=require
             username: ${DB_WEBMODELER_USERNAME}
             secret:

--- a/azure/kubernetes/aks-single-region/helm-values/values-domain.yml
+++ b/azure/kubernetes/aks-single-region/helm-values/values-domain.yml
@@ -81,7 +81,15 @@ webModeler:
             secret:
                 existingSecret: webmodeler-secret
                 existingSecretKey: smtp-password
-            fromAddress: changeme@example.com
+        # from-address is deprecated as a values key in chart 8.10 (removed in v16),
+        # so the sender address is supplied via unified configuration instead.
+        extraConfiguration:
+            - file: webmodeler-mail.yaml
+              content: |
+                  camunda:
+                    modeler:
+                      mail:
+                        from-address: changeme@example.com
 
 
 optimize:

--- a/azure/kubernetes/aks-single-region/helm-values/values-no-domain.yml
+++ b/azure/kubernetes/aks-single-region/helm-values/values-no-domain.yml
@@ -76,4 +76,12 @@ webModeler:
             secret:
                 existingSecret: webmodeler-secret
                 existingSecretKey: smtp-password
-            fromAddress: changeme@example.com
+        # from-address is deprecated as a values key in chart 8.10 (removed in v16),
+        # so the sender address is supplied via unified configuration instead.
+        extraConfiguration:
+            - file: webmodeler-mail.yaml
+              content: |
+                  camunda:
+                    modeler:
+                      mail:
+                        from-address: changeme@example.com

--- a/azure/kubernetes/aks-single-region/helm-values/values-no-domain.yml
+++ b/azure/kubernetes/aks-single-region/helm-values/values-no-domain.yml
@@ -65,7 +65,6 @@ webModeler:
 
     restapi:
         externalDatabase:
-            enabled: true
             url: jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_WEBMODELER_NAME}?sslmode=require
             username: ${DB_WEBMODELER_USERNAME}
             secret:

--- a/generic/kubernetes/operator-based/postgresql/camunda-rdbms-values.yml
+++ b/generic/kubernetes/operator-based/postgresql/camunda-rdbms-values.yml
@@ -11,10 +11,18 @@
 # Orchestration secondary storage configuration (RDBMS instead of Elasticsearch)
 orchestration:
     exporters:
-        camunda:
-            enabled: false
         rdbms:
             enabled: true
+    # Disable the inbuilt Camunda exporter via unified configuration. The values key
+    # orchestration.exporters.camunda.enabled is deprecated in chart 8.10 (removed in
+    # v16); it is a template toggle, so it is migrated to the equivalent app-config key.
+    extraConfiguration:
+        - file: orchestration-camunda-exporter.yaml
+          content: |
+              camunda:
+                data:
+                  secondary-storage:
+                    autoconfigure-camunda-exporter: false
     data:
         secondaryStorage:
             type: rdbms

--- a/generic/kubernetes/operator-based/postgresql/camunda-webmodeler-values.yml
+++ b/generic/kubernetes/operator-based/postgresql/camunda-webmodeler-values.yml
@@ -15,7 +15,6 @@ webModeler:
     # Use external PostgreSQL for WebModeler
     restapi:
         externalDatabase:
-            enabled: true
             host: pg-webmodeler-rw
             port: 5432
             database: webmodeler

--- a/generic/kubernetes/operator-based/postgresql/camunda-webmodeler-values.yml
+++ b/generic/kubernetes/operator-based/postgresql/camunda-webmodeler-values.yml
@@ -24,7 +24,14 @@ webModeler:
                 existingSecret: pg-webmodeler-secret
                 existingSecretKey: password
 
-        # Mail configuration (required)
-        mail:
-            fromAddress: noreply@camunda.local
-            fromName: Camunda Platform
+        # Mail configuration (required). The from-address/from-name values keys are
+        # deprecated in chart 8.10 (removed in v16), so they are supplied via unified
+        # configuration instead.
+        extraConfiguration:
+            - file: webmodeler-mail.yaml
+              content: |
+                  camunda:
+                    modeler:
+                      mail:
+                        from-address: noreply@camunda.local
+                        from-name: Camunda Platform

--- a/generic/kubernetes/single-region/helm-values/values-oidc-no-domain.yml
+++ b/generic/kubernetes/single-region/helm-values/values-oidc-no-domain.yml
@@ -20,8 +20,6 @@
 global:
     identity:
         auth:
-            identity:
-                redirectUrl: http://localhost:8085/auth/login-callback
             optimize:
                 redirectUrl: http://localhost:8083/api/authentication/callback
             webModeler:

--- a/generic/kubernetes/single-region/helm-values/values-oidc.yml
+++ b/generic/kubernetes/single-region/helm-values/values-oidc.yml
@@ -56,7 +56,6 @@ global:
                 audience: ${IDENTITY_CLIENT_ID}
                 existingSecret: identity-secret-for-components
                 existingSecretKey: identity-client-secret
-                redirectUrl: https://${CAMUNDA_DOMAIN}/auth/login-callback
 
             optimize:
                 clientId: ${OPTIMIZE_CLIENT_ID}

--- a/generic/kubernetes/single-region/procedure/build-camunda-chart.sh
+++ b/generic/kubernetes/single-region/procedure/build-camunda-chart.sh
@@ -41,7 +41,7 @@ _chart_git_url="${CAMUNDA_HELM_CHART_GIT_URL:-https://github.com/camunda/camunda
 # the previous version in its Chart.yaml (tag N ships version N-1), so the built chart is
 # one prerelease behind the tag name — intentional; it's the known-good set the tests validate.
 # renovate: datasource=github-tags depName=camunda/camunda-platform-helm extractVersion=^camunda-platform-8\.10-(?<version>.+)$
-_chart_default_git_ref="camunda-platform-8.10-15.0.0-alpha2"
+_chart_default_git_ref="camunda-platform-8.10-15.0.0-alpha3"
 # TODO: [release-duty] bump the 8.10 pin above as the 15.x line advances (keep in sync with CAMUNDA_HELM_CHART_VERSION and the helm-values).
 _chart_git_ref="${CAMUNDA_HELM_CHART_GIT_REF:-$_chart_default_git_ref}"
 _default_checkout_dir="$_repo_root/.camunda-platform-helm"

--- a/generic/openshift/dual-region/helm-values/values-base.yml
+++ b/generic/openshift/dual-region/helm-values/values-base.yml
@@ -46,12 +46,20 @@ orchestration:
         secondaryStorage:
             type: elasticsearch
     clusterSize: '8'
-    # Disable the Camunda and Zeebe exporters as we use region specific ones below
+    # Disable the Zeebe exporter as we use the region-specific exporters (env) below.
     exporters:
-        camunda:
-            enabled: false
         zeebe:
             enabled: false
+    # Disable the inbuilt Camunda exporter via unified configuration. The values key
+    # orchestration.exporters.camunda.enabled is deprecated in chart 8.10 (removed in
+    # v16); it is a template toggle, so it is migrated to the equivalent app-config key.
+    extraConfiguration:
+        - file: orchestration-camunda-exporter.yaml
+          content: |
+              camunda:
+                data:
+                  secondary-storage:
+                    autoconfigure-camunda-exporter: false
     env:
         - name: CAMUNDA_CLUSTER_PARTITIONCOUNT
           value: '8'

--- a/generic/openshift/single-region/helm-values/base.yml
+++ b/generic/openshift/single-region/helm-values/base.yml
@@ -62,4 +62,12 @@ webModeler:
             secret:
                 existingSecret: webmodeler-secret
                 existingSecretKey: smtp-password
-            fromAddress: changeme@example.com   # change this required value
+        # from-address is deprecated as a values key in chart 8.10 (removed in v16),
+        # so the sender address is supplied via unified configuration instead.
+        extraConfiguration:
+            - file: webmodeler-mail.yaml
+              content: |
+                  camunda:
+                    modeler:
+                      mail:
+                        from-address: changeme@example.com   # change this required value

--- a/generic/openshift/single-region/helm-values/domain.yml
+++ b/generic/openshift/single-region/helm-values/domain.yml
@@ -7,8 +7,6 @@ global:
     host: ${CAMUNDA_DOMAIN}
     identity:
         auth:
-            identity:
-                redirectUrl: https://${CAMUNDA_DOMAIN}/managementidentity
             webModeler:
                 redirectUrl: https://${CAMUNDA_DOMAIN}/modeler
             optimize:

--- a/local/kubernetes/kind-single-region/helm-values/values-domain.yml
+++ b/local/kubernetes/kind-single-region/helm-values/values-domain.yml
@@ -25,9 +25,6 @@ global:
                     existingSecret: camunda-credentials
                     existingSecretKey: identity-admin-client-token
 
-            identity:
-                redirectUrl: https://camunda.example.com/managementidentity
-
             optimize:
                 redirectUrl: https://camunda.example.com/optimize
                 secret:
@@ -47,8 +44,6 @@ global:
 
 connectors:
     enabled: true
-    inbound:
-        mode: disabled
     resources:
         requests:
             cpu: 100m

--- a/local/kubernetes/kind-single-region/helm-values/values-no-domain.yml
+++ b/local/kubernetes/kind-single-region/helm-values/values-no-domain.yml
@@ -23,9 +23,6 @@ global:
                     existingSecret: camunda-credentials
                     existingSecretKey: identity-admin-client-token
 
-            identity:
-                redirectUrl: http://localhost:8085
-
             optimize:
                 redirectUrl: http://localhost:8083
                 secret:
@@ -37,8 +34,6 @@ global:
 
 connectors:
     enabled: true
-    inbound:
-        mode: disabled
     resources:
         requests:
             cpu: 100m

--- a/local/kubernetes/kind-single-region/procedure/build-camunda-chart.sh
+++ b/local/kubernetes/kind-single-region/procedure/build-camunda-chart.sh
@@ -67,7 +67,7 @@ _chart_git_url="${CAMUNDA_HELM_CHART_GIT_URL:-https://github.com/camunda/camunda
 # the previous version in its Chart.yaml (tag N ships version N-1), so the built chart is
 # one prerelease behind the tag name — intentional; it's the known-good set the tests validate.
 # renovate: datasource=github-tags depName=camunda/camunda-platform-helm extractVersion=^camunda-platform-8\.10-(?<version>.+)$
-_chart_default_git_ref="camunda-platform-8.10-15.0.0-alpha2"
+_chart_default_git_ref="camunda-platform-8.10-15.0.0-alpha3"
 # TODO: [release-duty] bump the 8.10 pin above as the 15.x line advances (keep in sync with CAMUNDA_HELM_CHART_VERSION and the helm-values).
 _chart_git_ref="${CAMUNDA_HELM_CHART_GIT_REF:-$_chart_default_git_ref}"
 _default_checkout_dir="$(cd "$_chart_src_dir/.." && pwd)/.camunda-platform-helm"


### PR DESCRIPTION
> **Combined PR** — this now bundles the two related 8.10 Helm-values changes into one branch / one review / one CI cycle (they touch overlapping files). Two logical commits:
> 1. `fix(helm)` — migrate remaining deprecated keys → `extraConfiguration` (+ chart pin `alpha2→alpha3`) — *below*.
> 2. `chore(helm)` — drop 3 chart-inert keys flagged by the unknown-keys check (`connectors.inbound`, `webModeler.restapi.externalDatabase.enabled`, `global.identity.auth.identity.redirectUrl`); render verified byte-identical. Supersedes and folds in #2873.

---

## Problem

#2812 migrated most 8.10 deprecated Helm keys to unified configuration, but **two key families could not be migrated** on chart `alpha2` and were temporarily filtered by `internal-helm-deprecation-check` (`exclude-patterns`):

- `webModeler.restapi.mail.fromAddress` / `fromName` — the web-modeler restapi template still flagged `from-address` as `required`, so removing the values key aborted `helm template`.
- `orchestration.exporters.camunda.enabled` — a template-time toggle driving the chart's `hasCamundaExporter` helper, so `extraConfiguration` could not influence it.

This was reported upstream as camunda/camunda-platform-helm#6507 and tracked downstream in camunda/team-infrastructure-experience#1167.

## What unblocked this

camunda/camunda-platform-helm#6516 (merged upstream, released in tag **`camunda-platform-8.10-15.0.0-alpha3`**) makes both keys migratable:

- the mail `from-address` `required` guard is relaxed to also accept `camunda.modeler.mail.from-address` supplied via `extraConfiguration`;
- a new `orchestration.camundaExporterEnabled` helper makes `hasCamundaExporter` honor `camunda.data.secondary-storage.autoconfigure-camunda-exporter` from `extraConfiguration`.

## What this PR does

**1. Migrates the two remaining key families** (behaviour-preserving):

| Key | Migration | Files |
|---|---|---|
| `orchestration.exporters.camunda.enabled: false` | `orchestration.extraConfiguration` → `camunda.data.secondary-storage.autoconfigure-camunda-exporter: false` | eks-dual, openshift-dual (dual-region); operator-based, azure-rdbms domain/no-domain (RDBMS) |
| `webModeler.restapi.mail.fromAddress` / `fromName` | `webModeler.restapi.extraConfiguration` → `camunda.modeler.mail.from-address` / `from-name` | aws eks-single(+irsa), azure aks-single(+rdbms), openshift single-region, operator-based |

**2. Drops the workaround**: removes all three `exclude-patterns` (and the `TODO(6507)` note) from `internal-helm-deprecation-check/action.yml`; regenerates its README.

**3. Bumps the source-build chart pin `alpha2` → `alpha3`** so CI builds a chart that carries the fix. All deployments source-build this pinned tag, so the pin lives in three places:
- `generic/kubernetes/single-region/procedure/build-camunda-chart.sh`
- `local/kubernetes/kind-single-region/procedure/build-camunda-chart.sh`
- `.github/actions/internal-multi-region-tests/action.yml`

> The migration and the pin bump are coupled: the migrated values **only** render on `alpha3` (on `alpha2` the mail render aborts on the `required` guard and the dual-region inbuilt exporter is silently re-enabled). They must land together.

## Verification

Built the chart from `alpha3` (`camunda-platform-8.10-15.0.0-alpha3`, identical to the #6516 merge) and rendered before/after for every pattern:

- **Behaviour-preserving** — the only delta in the rendered Orchestration / web-modeler config is the added `spring.config.import` file; `zeebe.broker.exporters: {}` stays empty (inbuilt exporter **not** re-enabled) and `autoconfigure-camunda-exporter: false` is preserved (the template-time helper reads it from `extraConfiguration`). `from-name` override confirmed via Spring `spring.config.import` precedence (imported docs override the importing file).
- **Warnings cleared** — `configmap-warnings` render: before → the 3 `[camunda][warning] DEPRECATION` lines; after → none. Real values files render with **0** deprecation warnings on `alpha3`.
- `pre-commit run` clean on all changed files (incl. action README regeneration).

## Out of scope / follow-up

The broader **Camunda Hub migration** (`webModeler.enabled` → `camundaHub.enabled`, moving overrides under `camundaHub.*`) tracked in camunda/team-infrastructure-experience#1167 is **not** included here — it is a larger, separate change. This PR only completes the "drop the mail/exporter excludes" acceptance criterion.

## Backports

Deprecations and the chart pin are specific to the 8.10 pre-release line on `main`. Backports to `stable/*` should be evaluated per branch, not applied blindly.

Refs: camunda/camunda-platform-helm#6507, camunda/camunda-platform-helm#6516, camunda/team-infrastructure-experience#1167

