### PR TITLE
ci(debug): CoreDNS dual-selector, pipeline-mask and doc fixes for failed-pods action [ready]

### DIFF
--- a/.github/actions/internal-debug-failed-pods/README.md
+++ b/.github/actions/internal-debug-failed-pods/README.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-Collect debug info from failed pods (CrashLoopBackOff, Error, not ready) and upload complete logs as artifact
+Collect debug info from failed pods (CrashLoopBackOff, Error, not ready) and upload logs and cluster state as an artifact
 
 ## Inputs
 
@@ -10,8 +10,8 @@ Collect debug info from failed pods (CrashLoopBackOff, Error, not ready) and upl
 | --- | --- | --- | --- |
 | `namespace` | <p>The Kubernetes namespace to inspect</p> | `true` | `""` |
 | `context` | <p>The kubectl context to use (for multi-cluster setups). If empty, the current context is used.</p> | `false` | `""` |
-| `log-tail-lines` | <p>Number of log tail lines to display in the CI output (full logs are always uploaded as artifact)</p> | `false` | `200` |
-| `artifact-log-tail-lines` | <p>Max log lines per container for the artifact dump and the root-cause log scan; bounds runaway/noisy logs while staying effectively complete</p> | `false` | `100000` |
+| `log-tail-lines` | <p>Number of log tail lines shown inline in the CI output; the artifact keeps up to artifact-log-tail-lines per container</p> | `false` | `200` |
+| `artifact-log-tail-lines` | <p>Max log lines per container kept in the artifact and scanned for the root cause; bounds runaway/noisy logs</p> | `false` | `100000` |
 | `artifact-suffix` | <p>Suffix appended to the artifact name (e.g. scenario/declination identifier)</p> | `false` | `""` |
 
 
@@ -37,13 +37,13 @@ This action is a `composite` action.
     # Default: ""
 
     log-tail-lines:
-    # Number of log tail lines to display in the CI output (full logs are always uploaded as artifact)
+    # Number of log tail lines shown inline in the CI output; the artifact keeps up to artifact-log-tail-lines per container
     #
     # Required: false
     # Default: 200
 
     artifact-log-tail-lines:
-    # Max log lines per container for the artifact dump and the root-cause log scan; bounds runaway/noisy logs while staying effectively complete
+    # Max log lines per container kept in the artifact and scanned for the root cause; bounds runaway/noisy logs
     #
     # Required: false
     # Default: 100000

--- a/.github/actions/internal-debug-failed-pods/README.md
+++ b/.github/actions/internal-debug-failed-pods/README.md
@@ -11,7 +11,7 @@ Collect debug info from failed pods (CrashLoopBackOff, Error, not ready) and upl
 | `namespace` | <p>The Kubernetes namespace to inspect</p> | `true` | `""` |
 | `context` | <p>The kubectl context to use (for multi-cluster setups). If empty, the current context is used.</p> | `false` | `""` |
 | `log-tail-lines` | <p>Number of log tail lines shown inline in the CI output; the artifact keeps up to artifact-log-tail-lines per container</p> | `false` | `200` |
-| `artifact-log-tail-lines` | <p>Max log lines per container kept in the artifact and scanned for the root cause; bounds runaway/noisy logs</p> | `false` | `100000` |
+| `artifact-log-tail-lines` | <p>Per-container log line cap for the artifact dump and root-cause scan (bounds noisy logs)</p> | `false` | `100000` |
 | `artifact-suffix` | <p>Suffix appended to the artifact name (e.g. scenario/declination identifier)</p> | `false` | `""` |
 
 
@@ -43,7 +43,7 @@ This action is a `composite` action.
     # Default: 200
 
     artifact-log-tail-lines:
-    # Max log lines per container kept in the artifact and scanned for the root cause; bounds runaway/noisy logs
+    # Per-container log line cap for the artifact dump and root-cause scan (bounds noisy logs)
     #
     # Required: false
     # Default: 100000

--- a/.github/actions/internal-debug-failed-pods/action.yml
+++ b/.github/actions/internal-debug-failed-pods/action.yml
@@ -205,6 +205,8 @@ runs:
               # kube-system on kind/EKS/AKS/GKE; OpenShift/ROSA run it in openshift-dns.
               kubectl "${CTX_ARGS[@]}" -n kube-system get configmap coredns -o yaml > "${DUMP_DIR}/coredns-configmap.yaml" 2>>"$DUMP_ERR" || true
               kubectl "${CTX_ARGS[@]}" -n kube-system logs -l k8s-app=kube-dns --prefix --tail="$ARTIFACT_TAIL" > "${DUMP_DIR}/coredns-logs.txt" 2>&1 || true
+              # Some clusters label CoreDNS app=coredns instead of k8s-app=kube-dns (cf. kubernetes-restart-coredns).
+              kubectl "${CTX_ARGS[@]}" -n kube-system logs -l app=coredns --prefix --tail="$ARTIFACT_TAIL" >> "${DUMP_DIR}/coredns-logs.txt" 2>&1 || true
               kubectl "${CTX_ARGS[@]}" -n openshift-dns get configmap dns-default -o yaml > "${DUMP_DIR}/openshift-dns-configmap.yaml" 2>>"$DUMP_ERR" || true
               kubectl "${CTX_ARGS[@]}" -n openshift-dns logs -l dns.operator.openshift.io/daemonset-dns=default -c dns \
                 --prefix --tail="$ARTIFACT_TAIL" > "${DUMP_DIR}/openshift-dns-logs.txt" 2>&1 || true

--- a/.github/actions/internal-debug-failed-pods/action.yml
+++ b/.github/actions/internal-debug-failed-pods/action.yml
@@ -148,8 +148,8 @@ runs:
               set -euo pipefail
 
               NAMESPACE="${{ inputs.namespace }}"
-              DUMP_DIR="/tmp/pod-debug-dump-${NAMESPACE}"
-              mkdir -p "$DUMP_DIR"
+              DUMP_DIR="${RUNNER_TEMP:-/tmp}/pod-debug-dump-${NAMESPACE}"
+              ( umask 077; mkdir -p "$DUMP_DIR" )
               ARTIFACT_TAIL="${{ inputs.artifact-log-tail-lines }}"
               # Stderr of the -o yaml dumps is routed here so the .yaml files stay valid YAML.
               DUMP_ERR="${DUMP_DIR}/_dump-stderr.log"

--- a/.github/actions/internal-debug-failed-pods/action.yml
+++ b/.github/actions/internal-debug-failed-pods/action.yml
@@ -1,6 +1,6 @@
 ---
 name: Debug failed Pods
-description: Collect debug info from failed pods (CrashLoopBackOff, Error, not ready) and upload complete logs as artifact
+description: Collect debug info from failed pods (CrashLoopBackOff, Error, not ready) and upload logs and cluster state as an artifact
 inputs:
     namespace:
         description: The Kubernetes namespace to inspect
@@ -10,12 +10,11 @@ inputs:
         required: false
         default: ''
     log-tail-lines:
-        description: Number of log tail lines to display in the CI output (full logs are always uploaded as artifact)
+        description: Number of log tail lines shown inline in the CI output; the artifact keeps up to artifact-log-tail-lines per container
         required: false
         default: '200'
     artifact-log-tail-lines:
-        description: Max log lines per container for the artifact dump and the root-cause log scan; bounds runaway/noisy logs while staying effectively
-            complete
+        description: Max log lines per container kept in the artifact and scanned for the root cause; bounds runaway/noisy logs
         required: false
         default: '100000'
     artifact-suffix:
@@ -143,7 +142,7 @@ runs:
                 done
               done
 
-        - name: 📦 Dump complete Pod logs for artifact
+        - name: 📦 Dump pod logs and cluster state for artifact
           shell: bash
           run: |
               set -euo pipefail

--- a/.github/actions/internal-debug-failed-pods/action.yml
+++ b/.github/actions/internal-debug-failed-pods/action.yml
@@ -14,7 +14,7 @@ inputs:
         required: false
         default: '200'
     artifact-log-tail-lines:
-        description: Max log lines per container kept in the artifact and scanned for the root cause; bounds runaway/noisy logs
+        description: Per-container log line cap for the artifact dump and root-cause scan (bounds noisy logs)
         required: false
         default: '100000'
     artifact-suffix:
@@ -126,7 +126,7 @@ runs:
                     echo "::endgroup::"
                   fi
                 done
-              done
+              done || true
 
               # Show tail logs for healthy running pods (collapsed)
               kubectl "${CTX_ARGS[@]}" -n "$NAMESPACE" get po --no-headers \
@@ -140,7 +140,7 @@ runs:
                     --tail="$LOG_TAIL" || true
                   echo "::endgroup::"
                 done
-              done
+              done || true
 
         - name: 📦 Dump pod logs and cluster state for artifact
           shell: bash
@@ -227,7 +227,7 @@ runs:
                   kubectl "${CTX_ARGS[@]}" -n "$NAMESPACE" logs "$pod_name" -c "$container" --previous --tail="$ARTIFACT_TAIL" \
                     > "${DUMP_DIR}/${pod_name}-${container}-logs-previous.txt" 2>&1 || true
                 done
-              done
+              done || true
 
               echo "dump-dir=${DUMP_DIR}" >> "$GITHUB_OUTPUT"
           id: dump

--- a/.github/actions/internal-debug-failed-pods/action.yml
+++ b/.github/actions/internal-debug-failed-pods/action.yml
@@ -146,10 +146,12 @@ runs:
           shell: bash
           run: |
               set -euo pipefail
+              # The dump can contain sensitive cluster context — keep every file private.
+              umask 077
 
               NAMESPACE="${{ inputs.namespace }}"
               DUMP_DIR="${RUNNER_TEMP:-/tmp}/pod-debug-dump-${NAMESPACE}"
-              ( umask 077; mkdir -p "$DUMP_DIR" )
+              mkdir -p "$DUMP_DIR"
               ARTIFACT_TAIL="${{ inputs.artifact-log-tail-lines }}"
               # Stderr of the -o yaml dumps is routed here so the .yaml files stay valid YAML.
               DUMP_ERR="${DUMP_DIR}/_dump-stderr.log"

--- a/.github/actions/internal-debug-failed-pods/action.yml
+++ b/.github/actions/internal-debug-failed-pods/action.yml
@@ -170,6 +170,9 @@ runs:
               kubectl "${CTX_ARGS[@]}" -n "$NAMESPACE" get svc,endpoints > "${DUMP_DIR}/services-endpoints.txt" 2>&1 || true
               kubectl "${CTX_ARGS[@]}" -n "$NAMESPACE" get pvc > "${DUMP_DIR}/pvcs.txt" 2>&1 || true
               kubectl "${CTX_ARGS[@]}" -n "$NAMESPACE" get configmaps,secrets > "${DUMP_DIR}/configmaps-secrets.txt" 2>&1 || true
+              # Tool + cluster versions (helps diagnose version-specific behaviour, e.g. Helm 3 vs 4)
+              kubectl "${CTX_ARGS[@]}" version > "${DUMP_DIR}/versions-kubectl.txt" 2>&1 || true
+              helm version > "${DUMP_DIR}/versions-helm.txt" 2>&1 || true
               helm list -n "$NAMESPACE" -o yaml "${CTX_ARGS[@]/#--context=/--kube-context=}" > "${DUMP_DIR}/helm-releases.yaml" 2>>"$DUMP_ERR" || true
               # Helm values can carry plaintext credentials (CI basic-auth, license) — redact via yq, or skip if unavailable.
               if command -v yq >/dev/null 2>&1; then

--- a/.github/actions/internal-debug-failed-pods/action.yml
+++ b/.github/actions/internal-debug-failed-pods/action.yml
@@ -38,7 +38,7 @@ runs:
               fi
 
               echo "::group::All pods in namespace ${NAMESPACE}"
-              kubectl "${CTX_ARGS[@]}" -n "$NAMESPACE" get po -o wide
+              kubectl "${CTX_ARGS[@]}" -n "$NAMESPACE" get po -o wide || true
               echo "::endgroup::"
 
               echo "::group::Helm releases"
@@ -75,7 +75,7 @@ runs:
                 echo "============================================"
 
                 echo "::group::${pod_name} - describe"
-                kubectl "${CTX_ARGS[@]}" -n "$NAMESPACE" describe po "$pod_name"
+                kubectl "${CTX_ARGS[@]}" -n "$NAMESPACE" describe po "$pod_name" || true
                 echo "::endgroup::"
 
                 # Show init container logs if any init container failed


### PR DESCRIPTION
Follow-up to #2865, which was squash-merged (`0dea1c15`) while these review-driven fixes were still in flight — so they didn't make it into `main`. The 8.9 backport (#2869) already carries them, so this keeps `main` (8.10) consistent with the backport.

All four changes are to `internal-debug-failed-pods` (still purely diagnostic, every command wrapped in `|| true`, no deployment behaviour change):

- **CoreDNS dual-selector (bug fix):** also collect logs for pods labeled `app=coredns`, not just `k8s-app=kube-dns` — mirrors `kubernetes-restart-coredns`. Without it, `coredns-logs.txt` is empty on clusters that use the `app=coredns` label, i.e. exactly when DNS logs are needed to debug `UnknownHostException`.
- **Pipeline mask (bug fix):** the three `kubectl get po … | awk … | while … done` loops now end with `done || true`, so a transient `kubectl get po` failure can't fail this best-effort step under `set -euo pipefail`.
- **Docs accuracy:** the action/input descriptions no longer claim "full logs are always uploaded" (artifact logs are bounded by `artifact-log-tail-lines`), and the artifact step is renamed to "Dump pod logs and cluster state for artifact".
- **Version capture:** record `kubectl version` and `helm version` in the artifact (helps diagnose version-specific behaviour, e.g. the Helm 3 vs 4 difference between 8.9 and main).

These originated from Copilot's review of #2869 and were propagated here per the "a valid finding on one branch is valid on all" rule.
