### PR TITLE
chore(helm): drop chart-inert values keys flagged by unknown-keys check

### DIFF
--- a/aws/kubernetes/eks-single-region-irsa/helm-values/values-domain.yml
+++ b/aws/kubernetes/eks-single-region-irsa/helm-values/values-domain.yml
@@ -43,8 +43,6 @@ global:
     identity:
         auth:
             enabled: true
-            identity:
-                redirectUrl: https://${CAMUNDA_DOMAIN}/managementidentity
             webModeler:
                 redirectUrl: https://${CAMUNDA_DOMAIN}/modeler
             optimize:

--- a/aws/kubernetes/eks-single-region/helm-values/values-domain.yml
+++ b/aws/kubernetes/eks-single-region/helm-values/values-domain.yml
@@ -28,8 +28,6 @@ global:
     identity:
         auth:
             enabled: true
-            identity:
-                redirectUrl: https://${CAMUNDA_DOMAIN}/managementidentity
             webModeler:
                 redirectUrl: https://${CAMUNDA_DOMAIN}/modeler
             optimize:

--- a/azure/kubernetes/aks-single-region-rdbms/helm-values/values-domain.yml
+++ b/azure/kubernetes/aks-single-region-rdbms/helm-values/values-domain.yml
@@ -32,8 +32,6 @@ global:
     identity:
         auth:
             enabled: true
-            identity:
-                redirectUrl: https://${CAMUNDA_DOMAIN}/managementidentity
             webModeler:
                 redirectUrl: https://${CAMUNDA_DOMAIN}/modeler
 
@@ -71,7 +69,6 @@ webModeler:
 
     restapi:
         externalDatabase:
-            enabled: true
             url: jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_WEBMODELER_NAME}?sslmode=require
             username: ${DB_WEBMODELER_USERNAME}
             secret:

--- a/azure/kubernetes/aks-single-region-rdbms/helm-values/values-no-domain.yml
+++ b/azure/kubernetes/aks-single-region-rdbms/helm-values/values-no-domain.yml
@@ -82,7 +82,6 @@ webModeler:
 
     restapi:
         externalDatabase:
-            enabled: true
             url: jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_WEBMODELER_NAME}?sslmode=require
             username: ${DB_WEBMODELER_USERNAME}
             secret:

--- a/azure/kubernetes/aks-single-region/helm-values/values-domain.yml
+++ b/azure/kubernetes/aks-single-region/helm-values/values-domain.yml
@@ -29,8 +29,6 @@ global:
     identity:
         auth:
             enabled: true
-            identity:
-                redirectUrl: https://${CAMUNDA_DOMAIN}/managementidentity
             webModeler:
                 redirectUrl: https://${CAMUNDA_DOMAIN}/modeler
             optimize:
@@ -70,7 +68,6 @@ webModeler:
 
     restapi:
         externalDatabase:
-            enabled: true
             url: jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_WEBMODELER_NAME}?sslmode=require
             username: ${DB_WEBMODELER_USERNAME}
             secret:

--- a/azure/kubernetes/aks-single-region/helm-values/values-no-domain.yml
+++ b/azure/kubernetes/aks-single-region/helm-values/values-no-domain.yml
@@ -65,7 +65,6 @@ webModeler:
 
     restapi:
         externalDatabase:
-            enabled: true
             url: jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_WEBMODELER_NAME}?sslmode=require
             username: ${DB_WEBMODELER_USERNAME}
             secret:

--- a/generic/kubernetes/operator-based/postgresql/camunda-webmodeler-values.yml
+++ b/generic/kubernetes/operator-based/postgresql/camunda-webmodeler-values.yml
@@ -15,7 +15,6 @@ webModeler:
     # Use external PostgreSQL for WebModeler
     restapi:
         externalDatabase:
-            enabled: true
             host: pg-webmodeler-rw
             port: 5432
             database: webmodeler

--- a/generic/kubernetes/single-region/helm-values/values-oidc-no-domain.yml
+++ b/generic/kubernetes/single-region/helm-values/values-oidc-no-domain.yml
@@ -20,8 +20,6 @@
 global:
     identity:
         auth:
-            identity:
-                redirectUrl: http://localhost:8085/auth/login-callback
             optimize:
                 redirectUrl: http://localhost:8083/api/authentication/callback
             webModeler:

--- a/generic/kubernetes/single-region/helm-values/values-oidc.yml
+++ b/generic/kubernetes/single-region/helm-values/values-oidc.yml
@@ -56,7 +56,6 @@ global:
                 audience: ${IDENTITY_CLIENT_ID}
                 existingSecret: identity-secret-for-components
                 existingSecretKey: identity-client-secret
-                redirectUrl: https://${CAMUNDA_DOMAIN}/auth/login-callback
 
             optimize:
                 clientId: ${OPTIMIZE_CLIENT_ID}

--- a/generic/openshift/single-region/helm-values/domain.yml
+++ b/generic/openshift/single-region/helm-values/domain.yml
@@ -7,8 +7,6 @@ global:
     host: ${CAMUNDA_DOMAIN}
     identity:
         auth:
-            identity:
-                redirectUrl: https://${CAMUNDA_DOMAIN}/managementidentity
             webModeler:
                 redirectUrl: https://${CAMUNDA_DOMAIN}/modeler
             optimize:

--- a/local/kubernetes/kind-single-region/helm-values/values-domain.yml
+++ b/local/kubernetes/kind-single-region/helm-values/values-domain.yml
@@ -25,9 +25,6 @@ global:
                     existingSecret: camunda-credentials
                     existingSecretKey: identity-admin-client-token
 
-            identity:
-                redirectUrl: https://camunda.example.com/managementidentity
-
             optimize:
                 redirectUrl: https://camunda.example.com/optimize
                 secret:
@@ -47,8 +44,6 @@ global:
 
 connectors:
     enabled: true
-    inbound:
-        mode: disabled
     resources:
         requests:
             cpu: 100m

--- a/local/kubernetes/kind-single-region/helm-values/values-no-domain.yml
+++ b/local/kubernetes/kind-single-region/helm-values/values-no-domain.yml
@@ -23,9 +23,6 @@ global:
                     existingSecret: camunda-credentials
                     existingSecretKey: identity-admin-client-token
 
-            identity:
-                redirectUrl: http://localhost:8085
-
             optimize:
                 redirectUrl: http://localhost:8083
                 secret:
@@ -37,8 +34,6 @@ global:
 
 connectors:
     enabled: true
-    inbound:
-        mode: disabled
     resources:
         requests:
             cpu: 100m


### PR DESCRIPTION
## Problem

The `internal-helm-deprecation-check` action runs a second validation (`check-unknown-keys`) that flags deployed values keys not present in the chart's `values.schema.json`. On the reference architectures this surfaces a handful of keys the `camunda-platform` chart (15.0.0-alpha3) **silently ignores** (example: [Kind run comment](https://github.com/camunda/camunda-deployment-references/pull/2871#issuecomment-4923604330)).

Verified each against the chart source: some are genuine schema gaps on the chart side (tracked upstream — see below), but three are **inert keys on our side** and are removed here.

## What this PR removes (chart-inert, verified behaviour-preserving)

| Key | Why it is inert in 15.x | Files |
|---|---|---|
| `connectors.inbound` (`mode: disabled`) | Obsolete 14.x key. 15.x has no `connectors.inbound` in values/templates; inbound webhook/polling are gated on `global.noSecondaryStorage`. | kind (domain, no-domain) |
| `webModeler.restapi.externalDatabase.enabled` | Web-modeler keys its external DB off `externalDatabase.url`/`.host`; only `identity.externalDatabase` has an `.enabled` gate. | azure aks-single-region(+rdbms), operator-based snippet |
| `global.identity.auth.identity.redirectUrl` | The chart consumes `redirectUrl` only for `optimize`/`webModeler` (schema + templates confirm); Identity's redirect is derived from `identity.fullURL`. | aws eks-single(+irsa), azure aks-single(+rdbms), openshift single-region, generic single-region OIDC overlays, kind |

## Verification

- Chart source (`camunda-platform-8.10-15.0.0-alpha3`) inspected: none of the three keys are read by any template, and none appear in the chart `values.yaml`.
- **Full-chart `helm template` render is byte-identical** with vs. without `global.identity.auth.identity.redirectUrl` (only the chart's auto-generated random pusher secret differs between renders).
- The **valid** neighbours are kept: `identity.externalDatabase.enabled`, `global.identity.auth.optimize.redirectUrl`, `global.identity.auth.webModeler.redirectUrl`, and the OIDC `identity.clientId`/`audience`/`secret`.
- `pre-commit run` clean on all 12 files.

## Not in scope

The remaining unknown keys are **chart schema gaps**, not ours — the chart consumes them but `values.schema.json` only leaves them under `additionalProperties: true`:
- `camundaHub.webModeler.{image,restapi,websockets,…}` (only `persistence` is documented)
- `orchestration.security.initialization.defaultRoles.admin.clients` (only `users` is documented)

These are being reported/fixed upstream in `camunda/camunda-platform-helm` (issue + PR); tracked via camunda/camunda-platform-helm#4564.

## Relation to #2871

Independent of #2871 (deprecation-key migration). Edits touch different lines of the shared single-region values files, so the two should merge without conflict; whichever lands first, the other rebases.
