### PR TITLE
docs(eks-dual): source-build the dev chart in DEVELOPER.md instead of the private OCI [ready]

### DIFF
--- a/aws/kubernetes/eks-dual-region/DEVELOPER.md
+++ b/aws/kubernetes/eks-dual-region/DEVELOPER.md
@@ -63,8 +63,8 @@ Otherwise defaults to published Helm versions and the latest stable release.
 # repo, so build it from source (no private registry) and point HELM_CHART_NAME at the
 # local chart directory — the test installs from a local path (see InstallUpgradeC8Helm).
 # Note: a camunda-platform-helm release tag carries the *previous* version in Chart.yaml
-# (tag N ships version N-1), so this tag's chart is 15.0.0-alpha1 (the known-good set the
-# integration tests validate); the deployed image tags come from GLOBAL_IMAGE_TAG below.
+# (tag N ships version N-1), so this tag's chart is one alpha behind the tag name (the
+# known-good set the tests validate); the deployed image tags come from GLOBAL_IMAGE_TAG below.
 export HELM_CHART_VERSION=15-dev-latest
 CHART_DIR="$(mktemp -d)"
 git clone --depth 1 --branch camunda-platform-8.10-15.0.0-alpha2 \

--- a/aws/kubernetes/eks-dual-region/DEVELOPER.md
+++ b/aws/kubernetes/eks-dual-region/DEVELOPER.md
@@ -59,9 +59,14 @@ go test --count=1 -v -timeout 120m -run TestAWSDNSChaining
 Otherwise defaults to published Helm versions and the latest stable release.
 
 ```bash
-# Overwriting to dev-latest helm chart
-export HELM_CHART_VERSION=14-dev-latest
-export HELM_CHART_NAME=oci://registry.camunda.cloud/team-distribution/camunda-platform
+# Overwriting to the pre-release (dev) chart. It isn't published to the public Helm
+# repo, so build it from source (no private registry) and point HELM_CHART_NAME at the
+# local chart directory — the test installs from a local path (see InstallUpgradeC8Helm).
+export HELM_CHART_VERSION=15-dev-latest
+git clone --depth 1 --branch camunda-platform-8.10-15.0.0-alpha2 \
+  https://github.com/camunda/camunda-platform-helm.git /tmp/camunda-platform-helm
+helm dependency update /tmp/camunda-platform-helm/charts/camunda-platform-8.10
+export HELM_CHART_NAME=/tmp/camunda-platform-helm/charts/camunda-platform-8.10
 export GLOBAL_IMAGE_TAG=SNAPSHOT
 
 # Otherwise it's sufficient to set the helm chart version or rely on the default.

--- a/aws/kubernetes/eks-dual-region/DEVELOPER.md
+++ b/aws/kubernetes/eks-dual-region/DEVELOPER.md
@@ -62,6 +62,9 @@ Otherwise defaults to published Helm versions and the latest stable release.
 # Overwriting to the pre-release (dev) chart. It isn't published to the public Helm
 # repo, so build it from source (no private registry) and point HELM_CHART_NAME at the
 # local chart directory — the test installs from a local path (see InstallUpgradeC8Helm).
+# Note: a camunda-platform-helm release tag carries the *previous* version in Chart.yaml
+# (tag N ships version N-1), so this builds 15.0.0-alpha1 / images 8.10.0-alpha1 — the
+# known-good set the integration tests validate.
 export HELM_CHART_VERSION=15-dev-latest
 CHART_DIR="$(mktemp -d)/camunda-platform-helm"
 git clone --depth 1 --branch camunda-platform-8.10-15.0.0-alpha2 \

--- a/aws/kubernetes/eks-dual-region/DEVELOPER.md
+++ b/aws/kubernetes/eks-dual-region/DEVELOPER.md
@@ -63,10 +63,11 @@ Otherwise defaults to published Helm versions and the latest stable release.
 # repo, so build it from source (no private registry) and point HELM_CHART_NAME at the
 # local chart directory — the test installs from a local path (see InstallUpgradeC8Helm).
 export HELM_CHART_VERSION=15-dev-latest
+CHART_DIR="$(mktemp -d)/camunda-platform-helm"
 git clone --depth 1 --branch camunda-platform-8.10-15.0.0-alpha2 \
-  https://github.com/camunda/camunda-platform-helm.git /tmp/camunda-platform-helm
-helm dependency update /tmp/camunda-platform-helm/charts/camunda-platform-8.10
-export HELM_CHART_NAME=/tmp/camunda-platform-helm/charts/camunda-platform-8.10
+  https://github.com/camunda/camunda-platform-helm.git "$CHART_DIR"
+helm dependency update "$CHART_DIR/charts/camunda-platform-8.10"
+export HELM_CHART_NAME="$CHART_DIR/charts/camunda-platform-8.10"
 export GLOBAL_IMAGE_TAG=SNAPSHOT
 
 # Otherwise it's sufficient to set the helm chart version or rely on the default.

--- a/aws/kubernetes/eks-dual-region/DEVELOPER.md
+++ b/aws/kubernetes/eks-dual-region/DEVELOPER.md
@@ -63,10 +63,10 @@ Otherwise defaults to published Helm versions and the latest stable release.
 # repo, so build it from source (no private registry) and point HELM_CHART_NAME at the
 # local chart directory — the test installs from a local path (see InstallUpgradeC8Helm).
 # Note: a camunda-platform-helm release tag carries the *previous* version in Chart.yaml
-# (tag N ships version N-1), so this builds 15.0.0-alpha1 / images 8.10.0-alpha1 — the
-# known-good set the integration tests validate.
+# (tag N ships version N-1), so this tag's chart is 15.0.0-alpha1 (the known-good set the
+# integration tests validate); the deployed image tags come from GLOBAL_IMAGE_TAG below.
 export HELM_CHART_VERSION=15-dev-latest
-CHART_DIR="$(mktemp -d)/camunda-platform-helm"
+CHART_DIR="$(mktemp -d)"
 git clone --depth 1 --branch camunda-platform-8.10-15.0.0-alpha2 \
   https://github.com/camunda/camunda-platform-helm.git "$CHART_DIR"
 helm dependency update "$CHART_DIR/charts/camunda-platform-8.10"


### PR DESCRIPTION
Removes the last private-OCI reference in the eks-dual guide's developer docs. `DEVELOPER.md` still told developers to override with `HELM_CHART_NAME=oci://registry.camunda.cloud/team-distribution/camunda-platform` for the pre-release chart. Since the dev chart isn't on the public Helm repo, the example now builds it from source (clone the pinned tag + `helm dependency update`) and points `HELM_CHART_NAME` at the local chart dir — matching what CI does (#2858) and the Go test's local-chart-path support.

Follow-up to #2870 / #2858. Not merging (human action).