### PR TITLE
docs(helm): note the release-tag Chart.yaml version offset at the source-build pins [ready]

### DIFF
--- a/.github/actions/internal-multi-region-tests/action.yml
+++ b/.github/actions/internal-multi-region-tests/action.yml
@@ -145,7 +145,8 @@ runs:
                 # TODO: [release-duty] when the pre-release line moves to the next major,
                 # bump CHART_GIT_REF and the hardcoded 8.10 in the renovate regex below.
                 # A release tag carries the previous version in Chart.yaml (tag N ships
-                # version N-1), so this builds chart 15.0.0-alpha1 / images 8.10.0-alpha1.
+                # version N-1), so the built chart is one alpha behind CHART_GIT_REF (this
+                # is intentional — the known-good set the integration tests validate).
                 # renovate: datasource=github-tags depName=camunda/camunda-platform-helm extractVersion=^camunda-platform-8\.10-(?<version>.+)$
                 CHART_GIT_REF="camunda-platform-8.10-15.0.0-alpha2"
                 CAMUNDA_VERSION="$(cat "${{ github.workspace }}/.camunda-version")"

--- a/.github/actions/internal-multi-region-tests/action.yml
+++ b/.github/actions/internal-multi-region-tests/action.yml
@@ -145,7 +145,7 @@ runs:
                 # TODO: [release-duty] when the pre-release line moves to the next major,
                 # bump CHART_GIT_REF and the hardcoded 8.10 in the renovate regex below.
                 # A release tag carries the previous version in Chart.yaml (tag N ships
-                # version N-1), so the built chart is one alpha behind CHART_GIT_REF (this
+                # version N-1), so the built chart is one prerelease behind CHART_GIT_REF (this
                 # is intentional — the known-good set the integration tests validate).
                 # renovate: datasource=github-tags depName=camunda/camunda-platform-helm extractVersion=^camunda-platform-8\.10-(?<version>.+)$
                 CHART_GIT_REF="camunda-platform-8.10-15.0.0-alpha2"

--- a/.github/actions/internal-multi-region-tests/action.yml
+++ b/.github/actions/internal-multi-region-tests/action.yml
@@ -144,6 +144,8 @@ runs:
                 # helm-version flips to a released value and this block is bypassed).
                 # TODO: [release-duty] when the pre-release line moves to the next major,
                 # bump CHART_GIT_REF and the hardcoded 8.10 in the renovate regex below.
+                # A release tag carries the previous version in Chart.yaml (tag N ships
+                # version N-1), so this builds chart 15.0.0-alpha1 / images 8.10.0-alpha1.
                 # renovate: datasource=github-tags depName=camunda/camunda-platform-helm extractVersion=^camunda-platform-8\.10-(?<version>.+)$
                 CHART_GIT_REF="camunda-platform-8.10-15.0.0-alpha2"
                 CAMUNDA_VERSION="$(cat "${{ github.workspace }}/.camunda-version")"

--- a/generic/kubernetes/single-region/procedure/build-camunda-chart.sh
+++ b/generic/kubernetes/single-region/procedure/build-camunda-chart.sh
@@ -39,7 +39,7 @@ _chart_git_url="${CAMUNDA_HELM_CHART_GIT_URL:-https://github.com/camunda/camunda
 # on its own line so the '# renovate:' inline manager can parse it (the ${VAR:-...}
 # override wrapper is not cleanly matchable). A camunda-platform-helm release tag carries
 # the previous version in its Chart.yaml (tag N ships version N-1), so the built chart is
-# one alpha behind the tag name — intentional; it's the known-good set the tests validate.
+# one prerelease behind the tag name — intentional; it's the known-good set the tests validate.
 # renovate: datasource=github-tags depName=camunda/camunda-platform-helm extractVersion=^camunda-platform-8\.10-(?<version>.+)$
 _chart_default_git_ref="camunda-platform-8.10-15.0.0-alpha2"
 # TODO: [release-duty] bump the 8.10 pin above as the 15.x line advances (keep in sync with CAMUNDA_HELM_CHART_VERSION and the helm-values).

--- a/generic/kubernetes/single-region/procedure/build-camunda-chart.sh
+++ b/generic/kubernetes/single-region/procedure/build-camunda-chart.sh
@@ -38,8 +38,8 @@ _chart_git_url="${CAMUNDA_HELM_CHART_GIT_URL:-https://github.com/camunda/camunda
 # 8.10 chart tag is *published* (not the moving 'main' tip); the default is split out
 # on its own line so the '# renovate:' inline manager can parse it (the ${VAR:-...}
 # override wrapper is not cleanly matchable). A camunda-platform-helm release tag carries
-# the previous version in its Chart.yaml (tag N ships version N-1), so this pin builds
-# chart 15.0.0-alpha1 / images 8.10.0-alpha1 — the known-good set the tests validate.
+# the previous version in its Chart.yaml (tag N ships version N-1), so the built chart is
+# one alpha behind the tag name — intentional; it's the known-good set the tests validate.
 # renovate: datasource=github-tags depName=camunda/camunda-platform-helm extractVersion=^camunda-platform-8\.10-(?<version>.+)$
 _chart_default_git_ref="camunda-platform-8.10-15.0.0-alpha2"
 # TODO: [release-duty] bump the 8.10 pin above as the 15.x line advances (keep in sync with CAMUNDA_HELM_CHART_VERSION and the helm-values).

--- a/generic/kubernetes/single-region/procedure/build-camunda-chart.sh
+++ b/generic/kubernetes/single-region/procedure/build-camunda-chart.sh
@@ -37,7 +37,9 @@ _chart_git_url="${CAMUNDA_HELM_CHART_GIT_URL:-https://github.com/camunda/camunda
 # which breaks the deployment tests. Renovate bumps the pin below only once a newer
 # 8.10 chart tag is *published* (not the moving 'main' tip); the default is split out
 # on its own line so the '# renovate:' inline manager can parse it (the ${VAR:-...}
-# override wrapper is not cleanly matchable).
+# override wrapper is not cleanly matchable). A camunda-platform-helm release tag carries
+# the previous version in its Chart.yaml (tag N ships version N-1), so this pin builds
+# chart 15.0.0-alpha1 / images 8.10.0-alpha1 — the known-good set the tests validate.
 # renovate: datasource=github-tags depName=camunda/camunda-platform-helm extractVersion=^camunda-platform-8\.10-(?<version>.+)$
 _chart_default_git_ref="camunda-platform-8.10-15.0.0-alpha2"
 # TODO: [release-duty] bump the 8.10 pin above as the 15.x line advances (keep in sync with CAMUNDA_HELM_CHART_VERSION and the helm-values).

--- a/local/kubernetes/kind-single-region/procedure/build-camunda-chart.sh
+++ b/local/kubernetes/kind-single-region/procedure/build-camunda-chart.sh
@@ -63,7 +63,9 @@ _chart_git_url="${CAMUNDA_HELM_CHART_GIT_URL:-https://github.com/camunda/camunda
 # which breaks the deployment tests. Renovate bumps the pin below only once a newer
 # 8.10 chart tag is *published* (not the moving 'main' tip); the default is split out
 # on its own line so the '# renovate:' inline manager can parse it (the ${VAR:-...}
-# override wrapper is not cleanly matchable).
+# override wrapper is not cleanly matchable). A camunda-platform-helm release tag carries
+# the previous version in its Chart.yaml (tag N ships version N-1), so this pin builds
+# chart 15.0.0-alpha1 / images 8.10.0-alpha1 — the known-good set the tests validate.
 # renovate: datasource=github-tags depName=camunda/camunda-platform-helm extractVersion=^camunda-platform-8\.10-(?<version>.+)$
 _chart_default_git_ref="camunda-platform-8.10-15.0.0-alpha2"
 # TODO: [release-duty] bump the 8.10 pin above as the 15.x line advances (keep in sync with CAMUNDA_HELM_CHART_VERSION and the helm-values).

--- a/local/kubernetes/kind-single-region/procedure/build-camunda-chart.sh
+++ b/local/kubernetes/kind-single-region/procedure/build-camunda-chart.sh
@@ -64,8 +64,8 @@ _chart_git_url="${CAMUNDA_HELM_CHART_GIT_URL:-https://github.com/camunda/camunda
 # 8.10 chart tag is *published* (not the moving 'main' tip); the default is split out
 # on its own line so the '# renovate:' inline manager can parse it (the ${VAR:-...}
 # override wrapper is not cleanly matchable). A camunda-platform-helm release tag carries
-# the previous version in its Chart.yaml (tag N ships version N-1), so this pin builds
-# chart 15.0.0-alpha1 / images 8.10.0-alpha1 — the known-good set the tests validate.
+# the previous version in its Chart.yaml (tag N ships version N-1), so the built chart is
+# one alpha behind the tag name — intentional; it's the known-good set the tests validate.
 # renovate: datasource=github-tags depName=camunda/camunda-platform-helm extractVersion=^camunda-platform-8\.10-(?<version>.+)$
 _chart_default_git_ref="camunda-platform-8.10-15.0.0-alpha2"
 # TODO: [release-duty] bump the 8.10 pin above as the 15.x line advances (keep in sync with CAMUNDA_HELM_CHART_VERSION and the helm-values).

--- a/local/kubernetes/kind-single-region/procedure/build-camunda-chart.sh
+++ b/local/kubernetes/kind-single-region/procedure/build-camunda-chart.sh
@@ -65,7 +65,7 @@ _chart_git_url="${CAMUNDA_HELM_CHART_GIT_URL:-https://github.com/camunda/camunda
 # on its own line so the '# renovate:' inline manager can parse it (the ${VAR:-...}
 # override wrapper is not cleanly matchable). A camunda-platform-helm release tag carries
 # the previous version in its Chart.yaml (tag N ships version N-1), so the built chart is
-# one alpha behind the tag name — intentional; it's the known-good set the tests validate.
+# one prerelease behind the tag name — intentional; it's the known-good set the tests validate.
 # renovate: datasource=github-tags depName=camunda/camunda-platform-helm extractVersion=^camunda-platform-8\.10-(?<version>.+)$
 _chart_default_git_ref="camunda-platform-8.10-15.0.0-alpha2"
 # TODO: [release-duty] bump the 8.10 pin above as the 15.x line advances (keep in sync with CAMUNDA_HELM_CHART_VERSION and the helm-values).


### PR DESCRIPTION
Adds a clarifying comment at the three source-build pin sites (generic + kind `build-camunda-chart.sh`, and the `internal-multi-region-tests` action) so the tag/content offset isn't surprising.

A `camunda-platform-helm` release tag carries the **previous** version in `Chart.yaml` (tag *N* ships version *N-1*): checking out `camunda-platform-8.10-15.0.0-alpha2` builds chart `15.0.0-alpha1` with `8.10.0-alpha1` images. That's intentional — it's the known-good set the integration tests validate (one step behind the bleeding edge that broke `identity` on `main`).

No behavior change (comments only). Renovate is unaffected: the annotation reads the version from the tag **name**, and the note is placed above the `# renovate:` line so the pair still parses. Companion to the DEVELOPER.md note in #2874.