### PR TITLE
fix(ci): restart CoreDNS before the health wait so domain OIDC pods resolve

### DIFF
--- a/.github/actions/internal-wait-oidc-issuer/README.md
+++ b/.github/actions/internal-wait-oidc-issuer/README.md
@@ -32,6 +32,7 @@ workaround.
 | `release-name` | <p>Helm release name, used to target the workloads to bounce (<code>statefulset/&lt;release&gt;-zeebe</code>, <code>deployment/&lt;release&gt;-connectors</code>).</p> | `false` | `camunda` |
 | `insecure` | <p>Set to 'true' to skip TLS verification of the issuer (e.g. when the public endpoint uses a CI internal-CA / Vault wildcard certificate).</p> | `false` | `""` |
 | `timeout-seconds` | <p>Total wall-clock budget in seconds. Fail-open: on timeout the action emits a warning and exits 0 so it never blocks the pipeline.</p> | `false` | `600` |
+| `restart-workloads` | <p>Bounce the OIDC workloads (zeebe/connectors) once the issuer is reachable. Set to 'false' to wait only — e.g. when a later step refreshes CoreDNS and restarts the workloads itself (so they are not bounced before in-cluster DNS is fixed).</p> | `false` | `true` |
 
 
 ## Runs
@@ -76,4 +77,13 @@ This action is a `composite` action.
     #
     # Required: false
     # Default: 600
+
+    restart-workloads:
+    # Bounce the OIDC workloads (zeebe/connectors) once the issuer is
+    # reachable. Set to 'false' to wait only — e.g. when a later step
+    # refreshes CoreDNS and restarts the workloads itself (so they are not
+    # bounced before in-cluster DNS is fixed).
+    #
+    # Required: false
+    # Default: true
 ```

--- a/.github/actions/internal-wait-oidc-issuer/README.md
+++ b/.github/actions/internal-wait-oidc-issuer/README.md
@@ -13,8 +13,10 @@ a self-hosted IdP also has to provision its realm — during which the app pods
 readiness window, so the deployment can look broken for a while.
 
 This action waits (bounded, fail-open) for the issuer's discovery document to
-answer `200`, then bounces the affected workloads so they restart immediately
-instead of after the next backoff window.
+answer `200`, then (by default) bounces the affected workloads so they restart
+immediately instead of after the next backoff window. The bounce is optional:
+set `restart-workloads: false` to wait only — e.g. when a later step refreshes
+CoreDNS and restarts the workloads itself.
 
 It is **IdP-agnostic**: it polls whatever `issuer-url` the caller provides and
 completes quickly (no waiting) when the issuer is already reachable, e.g. an

--- a/.github/actions/internal-wait-oidc-issuer/action.yml
+++ b/.github/actions/internal-wait-oidc-issuer/action.yml
@@ -106,7 +106,7 @@ runs:
                   if [ "${code}" = "200" ]; then
                       echo "✅ OIDC issuer reachable (HTTP 200) after ${attempt} attempt(s)."
                       if [ "${RESTART_WORKLOADS}" = "false" ]; then
-                          echo "restart-workloads=false: issuer reachable; leaving the workload bounce to a later step (after CoreDNS is refreshed)."
+                          echo "restart-workloads=false: issuer reachable; skipping the workload bounce (left to the caller)."
                           exit 0
                       fi
                       # Clear any first-start CrashLoopBackOff so the app pods

--- a/.github/actions/internal-wait-oidc-issuer/action.yml
+++ b/.github/actions/internal-wait-oidc-issuer/action.yml
@@ -49,6 +49,14 @@ inputs:
             emits a warning and exits 0 so it never blocks the pipeline.
         required: false
         default: '600'
+    restart-workloads:
+        description: |
+            Bounce the OIDC workloads (zeebe/connectors) once the issuer is
+            reachable. Set to 'false' to wait only — e.g. when a later step
+            refreshes CoreDNS and restarts the workloads itself (so they are not
+            bounced before in-cluster DNS is fixed).
+        required: false
+        default: 'true'
 
 runs:
     using: composite
@@ -61,6 +69,7 @@ runs:
               RELEASE_NAME: ${{ inputs.release-name }}
               INSECURE: ${{ inputs.insecure }}
               TIMEOUT_SECONDS: ${{ inputs.timeout-seconds }}
+              RESTART_WORKLOADS: ${{ inputs.restart-workloads }}
           run: |
               set -uo pipefail
 
@@ -96,6 +105,10 @@ runs:
 
                   if [ "${code}" = "200" ]; then
                       echo "✅ OIDC issuer reachable (HTTP 200) after ${attempt} attempt(s)."
+                      if [ "${RESTART_WORKLOADS}" = "false" ]; then
+                          echo "restart-workloads=false: issuer reachable; leaving the workload bounce to a later step (after CoreDNS is refreshed)."
+                          exit 0
+                      fi
                       # Clear any first-start CrashLoopBackOff so the app pods
                       # restart now instead of after the next (long) backoff
                       # window. Bounce each workload only if it exists, so a

--- a/.github/actions/internal-wait-oidc-issuer/action.yml
+++ b/.github/actions/internal-wait-oidc-issuer/action.yml
@@ -113,8 +113,8 @@ runs:
                       # restart now instead of after the next (long) backoff
                       # window. Bounce each workload only if it exists, so a
                       # disabled/renamed component stays quiet while real errors
-                      # (missing kubeconfig / RBAC) stay visible; '|| true' keeps
-                      # the bounce best-effort (fail-open).
+                      # (missing kubeconfig / RBAC) stay visible; a failed restart
+                      # is downgraded to a warning so the bounce stays best-effort.
                       for workload in "statefulset/${RELEASE_NAME}-zeebe" "deployment/${RELEASE_NAME}-connectors"; do
                           # --ignore-not-found keeps a genuine "absent" quiet
                           # (empty + exit 0) while real failures (no kubeconfig /

--- a/.github/actions/internal-wait-oidc-issuer/action.yml
+++ b/.github/actions/internal-wait-oidc-issuer/action.yml
@@ -12,8 +12,10 @@ description: |
     readiness window, so the deployment can look broken for a while.
 
     This action waits (bounded, fail-open) for the issuer's discovery document to
-    answer `200`, then bounces the affected workloads so they restart immediately
-    instead of after the next backoff window.
+    answer `200`, then (by default) bounces the affected workloads so they restart
+    immediately instead of after the next backoff window. The bounce is optional:
+    set `restart-workloads: false` to wait only — e.g. when a later step refreshes
+    CoreDNS and restarts the workloads itself.
 
     It is **IdP-agnostic**: it polls whatever `issuer-url` the caller provides and
     completes quickly (no waiting) when the issuer is already reachable, e.g. an

--- a/.github/actions/internal-wait-oidc-issuer/action.yml
+++ b/.github/actions/internal-wait-oidc-issuer/action.yml
@@ -122,7 +122,7 @@ runs:
                           if ! found=$(kubectl -n "${NAMESPACE}" get "${workload}" --ignore-not-found -o name 2>&1); then
                               echo "::warning::Could not query ${workload}: ${found}"
                           elif [ -n "${found}" ]; then
-                              kubectl -n "${NAMESPACE}" rollout restart "${workload}" || true
+                              kubectl -n "${NAMESPACE}" rollout restart "${workload}" || echo "::warning::rollout restart ${workload} failed"
                           else
                               echo "Skipping ${workload}: not present in namespace ${NAMESPACE}."
                           fi

--- a/.github/workflows/aws_kubernetes_eks_single_region_tests.yml
+++ b/.github/workflows/aws_kubernetes_eks_single_region_tests.yml
@@ -899,9 +899,9 @@ jobs:
                   # Wait only: the workloads are bounced after CoreDNS is refreshed (next steps).
                   restart-workloads: 'false'
 
-            # CoreDNS must be bounced here — after the issuer is externally reachable
-            # (the ingress DNS record now exists) and BEFORE the health wait — to flush
-            # the stale negative DNS cache. Otherwise the OIDC components
+            # CoreDNS is bounced here — after the (fail-open) issuer-reachability wait,
+            # so the ingress DNS record normally exists by now, and BEFORE the health
+            # wait — to flush the stale negative DNS cache. Otherwise the OIDC components
             # (identity/connectors/zeebe) keep hitting UnknownHostException on the
             # domain at startup and CrashLoopBackOff until the readiness window expires.
             - name: 🔄 Restart CoreDNS

--- a/.github/workflows/aws_kubernetes_eks_single_region_tests.yml
+++ b/.github/workflows/aws_kubernetes_eks_single_region_tests.yml
@@ -896,6 +896,8 @@ jobs:
                   namespace: ${{ env.CAMUNDA_NAMESPACE }}
                   release-name: ${{ env.CAMUNDA_RELEASE_NAME }}
                   insecure: ${{ steps.cert-config.outputs.use-wildcard-cert }}
+                  # Wait only: the workloads are bounced after CoreDNS is refreshed (next steps).
+                  restart-workloads: 'false'
 
             # CoreDNS must be bounced here — after the issuer is externally reachable
             # (the ingress DNS record now exists) and BEFORE the health wait — to flush
@@ -908,6 +910,22 @@ jobs:
               timeout-minutes: 10
               with:
                   cluster-type: kubernetes
+
+            # DNS cache is fresh now — bounce the OIDC workloads so they reconnect
+            # with working in-cluster + domain resolution instead of a stale
+            # (negative) view cached before the CoreDNS refresh. Readiness is then
+            # verified by the health wait below.
+            - name: 🔁 Restart Camunda workloads after DNS refresh
+              if: matrix.declination.name == 'domain'
+              run: |
+                  set -uo pipefail
+                  ns="${{ env.CAMUNDA_NAMESPACE }}"
+                  rel="${{ env.CAMUNDA_RELEASE_NAME }}"
+                  for wl in "statefulset/${rel}-zeebe" "deployment/${rel}-connectors"; do
+                      if kubectl -n "$ns" get "$wl" >/dev/null 2>&1; then
+                          kubectl -n "$ns" rollout restart "$wl" || true
+                      fi
+                  done
 
             - name: 👀⏳ Wait for the deployment to be healthy using generic/kubernetes/single-region
               timeout-minutes: 20

--- a/.github/workflows/aws_kubernetes_eks_single_region_tests.yml
+++ b/.github/workflows/aws_kubernetes_eks_single_region_tests.yml
@@ -897,18 +897,23 @@ jobs:
                   release-name: ${{ env.CAMUNDA_RELEASE_NAME }}
                   insecure: ${{ steps.cert-config.outputs.use-wildcard-cert }}
 
+            # CoreDNS must be bounced here — after the issuer is externally reachable
+            # (the ingress DNS record now exists) and BEFORE the health wait — to flush
+            # the stale negative DNS cache. Otherwise the OIDC components
+            # (identity/connectors/zeebe) keep hitting UnknownHostException on the
+            # domain at startup and CrashLoopBackOff until the readiness window expires.
+            - name: 🔄 Restart CoreDNS
+              if: matrix.declination.name == 'domain'
+              uses: ./.github/actions/kubernetes-restart-coredns
+              timeout-minutes: 10
+              with:
+                  cluster-type: kubernetes
+
             - name: 👀⏳ Wait for the deployment to be healthy using generic/kubernetes/single-region
               timeout-minutes: 20
               run: |
                   set -euo pipefail
                   ./generic/kubernetes/single-region/procedure/check-deployment-ready.sh
-
-            - name: 🔄 Restart CoreDNS
-              if: matrix.declination.name == 'domain' && env.CLEANUP_CLUSTERS == 'false'
-              uses: ./.github/actions/kubernetes-restart-coredns
-              timeout-minutes: 10
-              with:
-                  cluster-type: kubernetes
 
             - name: 📐 Set current Camunda version
               id: camunda-version

--- a/.github/workflows/aws_kubernetes_eks_single_region_tests.yml
+++ b/.github/workflows/aws_kubernetes_eks_single_region_tests.yml
@@ -921,9 +921,15 @@ jobs:
                   set -uo pipefail
                   ns="${{ env.CAMUNDA_NAMESPACE }}"
                   rel="${{ env.CAMUNDA_RELEASE_NAME }}"
-                  for wl in "statefulset/${rel}-zeebe" "deployment/${rel}-connectors"; do
-                      if kubectl -n "$ns" get "$wl" >/dev/null 2>&1; then
-                          kubectl -n "$ns" rollout restart "$wl" || true
+                  for wl in "statefulset/${rel}-zeebe" "deployment/${rel}-connectors" "deployment/${rel}-identity"; do
+                      # Distinguish a genuine "absent" (empty, exit 0) from a real
+                      # query error (RBAC/kubeconfig) so failures stay visible.
+                      if ! found=$(kubectl -n "$ns" get "$wl" --ignore-not-found -o name 2>&1); then
+                          echo "::warning::Could not query ${wl}: ${found}"
+                      elif [ -n "$found" ]; then
+                          kubectl -n "$ns" rollout restart "$wl" || echo "::warning::rollout restart ${wl} failed"
+                      else
+                          echo "Skipping ${wl}: not present in namespace ${ns}."
                       fi
                   done
 

--- a/.github/workflows/aws_openshift_rosa_hcp_single_region_tests.yml
+++ b/.github/workflows/aws_openshift_rosa_hcp_single_region_tests.yml
@@ -663,9 +663,15 @@ jobs:
                   set -uo pipefail
                   ns="${{ env.CAMUNDA_NAMESPACE }}"
                   rel="${{ env.CAMUNDA_RELEASE_NAME }}"
-                  for wl in "statefulset/${rel}-zeebe" "deployment/${rel}-connectors"; do
-                      if kubectl -n "$ns" get "$wl" >/dev/null 2>&1; then
-                          kubectl -n "$ns" rollout restart "$wl" || true
+                  for wl in "statefulset/${rel}-zeebe" "deployment/${rel}-connectors" "deployment/${rel}-identity"; do
+                      # Distinguish a genuine "absent" (empty, exit 0) from a real
+                      # query error (RBAC/kubeconfig) so failures stay visible.
+                      if ! found=$(kubectl -n "$ns" get "$wl" --ignore-not-found -o name 2>&1); then
+                          echo "::warning::Could not query ${wl}: ${found}"
+                      elif [ -n "$found" ]; then
+                          kubectl -n "$ns" rollout restart "$wl" || echo "::warning::rollout restart ${wl} failed"
+                      else
+                          echo "Skipping ${wl}: not present in namespace ${ns}."
                       fi
                   done
 

--- a/.github/workflows/aws_openshift_rosa_hcp_single_region_tests.yml
+++ b/.github/workflows/aws_openshift_rosa_hcp_single_region_tests.yml
@@ -639,19 +639,24 @@ jobs:
                   release-name: ${{ env.CAMUNDA_RELEASE_NAME }}
                   insecure: 'true'
 
+            # CoreDNS must be bounced here — after the issuer is externally reachable
+            # (the ingress DNS record now exists) and BEFORE the health wait — to flush
+            # the stale negative DNS cache. Otherwise the OIDC components
+            # (identity/connectors/zeebe) keep hitting UnknownHostException on the
+            # domain at startup and CrashLoopBackOff until the readiness window expires.
+            - name: 🔄 Restart CoreDNS
+              if: matrix.declination.name == 'domain'
+              uses: ./.github/actions/kubernetes-restart-coredns
+              timeout-minutes: 10
+              with:
+                  cluster-type: openshift
+
             - name: 👀⏳ Wait for the deployment to be healthy using generic/kubernetes/single-region
               timeout-minutes: 20
               run: |
                   set -euo pipefail
 
                   ./generic/kubernetes/single-region/procedure/check-deployment-ready.sh
-
-            - name: 🔄 Restart CoreDNS
-              if: matrix.declination.name == 'domain' && env.CLEANUP_CLUSTERS == 'false'
-              uses: ./.github/actions/kubernetes-restart-coredns
-              timeout-minutes: 10
-              with:
-                  cluster-type: openshift
 
             - name: Set current Camunda version
               id: camunda-version

--- a/.github/workflows/aws_openshift_rosa_hcp_single_region_tests.yml
+++ b/.github/workflows/aws_openshift_rosa_hcp_single_region_tests.yml
@@ -641,9 +641,9 @@ jobs:
                   # Wait only: the workloads are bounced after CoreDNS is refreshed (next steps).
                   restart-workloads: 'false'
 
-            # CoreDNS must be bounced here — after the issuer is externally reachable
-            # (the ingress DNS record now exists) and BEFORE the health wait — to flush
-            # the stale negative DNS cache. Otherwise the OIDC components
+            # CoreDNS is bounced here — after the (fail-open) issuer-reachability wait,
+            # so the ingress DNS record normally exists by now, and BEFORE the health
+            # wait — to flush the stale negative DNS cache. Otherwise the OIDC components
             # (identity/connectors/zeebe) keep hitting UnknownHostException on the
             # domain at startup and CrashLoopBackOff until the readiness window expires.
             - name: 🔄 Restart CoreDNS

--- a/.github/workflows/aws_openshift_rosa_hcp_single_region_tests.yml
+++ b/.github/workflows/aws_openshift_rosa_hcp_single_region_tests.yml
@@ -638,6 +638,8 @@ jobs:
                   namespace: ${{ env.CAMUNDA_NAMESPACE }}
                   release-name: ${{ env.CAMUNDA_RELEASE_NAME }}
                   insecure: 'true'
+                  # Wait only: the workloads are bounced after CoreDNS is refreshed (next steps).
+                  restart-workloads: 'false'
 
             # CoreDNS must be bounced here — after the issuer is externally reachable
             # (the ingress DNS record now exists) and BEFORE the health wait — to flush
@@ -650,6 +652,22 @@ jobs:
               timeout-minutes: 10
               with:
                   cluster-type: openshift
+
+            # DNS cache is fresh now — bounce the OIDC workloads so they reconnect
+            # with working in-cluster + domain resolution instead of a stale
+            # (negative) view cached before the CoreDNS refresh. Readiness is then
+            # verified by the health wait below.
+            - name: 🔁 Restart Camunda workloads after DNS refresh
+              if: matrix.declination.name == 'domain'
+              run: |
+                  set -uo pipefail
+                  ns="${{ env.CAMUNDA_NAMESPACE }}"
+                  rel="${{ env.CAMUNDA_RELEASE_NAME }}"
+                  for wl in "statefulset/${rel}-zeebe" "deployment/${rel}-connectors"; do
+                      if kubectl -n "$ns" get "$wl" >/dev/null 2>&1; then
+                          kubectl -n "$ns" rollout restart "$wl" || true
+                      fi
+                  done
 
             - name: 👀⏳ Wait for the deployment to be healthy using generic/kubernetes/single-region
               timeout-minutes: 20

--- a/.github/workflows/azure_kubernetes_aks_single_region_tests.yml
+++ b/.github/workflows/azure_kubernetes_aks_single_region_tests.yml
@@ -706,18 +706,23 @@ jobs:
                   release-name: ${{ env.CAMUNDA_RELEASE_NAME }}
                   insecure: ${{ steps.cert-config.outputs.use-wildcard-cert }}
 
+            # CoreDNS must be bounced here — after the issuer is externally reachable
+            # (the ingress DNS record now exists) and BEFORE the health wait — to flush
+            # the stale negative DNS cache. Otherwise the OIDC components
+            # (identity/connectors/zeebe) keep hitting UnknownHostException on the
+            # domain at startup and CrashLoopBackOff until the readiness window expires.
+            - name: 🔄 Restart CoreDNS
+              if: matrix.declination.name == 'domain'
+              uses: ./.github/actions/kubernetes-restart-coredns
+              timeout-minutes: 10
+              with:
+                  cluster-type: kubernetes
+
             - name: 👀⏳ Wait for the deployment to be healthy using generic/kubernetes/single-region
               timeout-minutes: 20
               run: |
                   set -euo pipefail
                   ./generic/kubernetes/single-region/procedure/check-deployment-ready.sh
-
-            - name: 🔄 Restart CoreDNS
-              if: matrix.declination.name == 'domain' && env.CLEANUP_CLUSTERS == 'false'
-              uses: ./.github/actions/kubernetes-restart-coredns
-              timeout-minutes: 10
-              with:
-                  cluster-type: kubernetes
 
             - name: 📐 Set current Camunda version
               id: camunda-version

--- a/.github/workflows/azure_kubernetes_aks_single_region_tests.yml
+++ b/.github/workflows/azure_kubernetes_aks_single_region_tests.yml
@@ -705,6 +705,8 @@ jobs:
                   namespace: ${{ env.CAMUNDA_NAMESPACE }}
                   release-name: ${{ env.CAMUNDA_RELEASE_NAME }}
                   insecure: ${{ steps.cert-config.outputs.use-wildcard-cert }}
+                  # Wait only: the workloads are bounced after CoreDNS is refreshed (next steps).
+                  restart-workloads: 'false'
 
             # CoreDNS must be bounced here — after the issuer is externally reachable
             # (the ingress DNS record now exists) and BEFORE the health wait — to flush
@@ -717,6 +719,22 @@ jobs:
               timeout-minutes: 10
               with:
                   cluster-type: kubernetes
+
+            # DNS cache is fresh now — bounce the OIDC workloads so they reconnect
+            # with working in-cluster + domain resolution instead of a stale
+            # (negative) view cached before the CoreDNS refresh. Readiness is then
+            # verified by the health wait below.
+            - name: 🔁 Restart Camunda workloads after DNS refresh
+              if: matrix.declination.name == 'domain'
+              run: |
+                  set -uo pipefail
+                  ns="${{ env.CAMUNDA_NAMESPACE }}"
+                  rel="${{ env.CAMUNDA_RELEASE_NAME }}"
+                  for wl in "statefulset/${rel}-zeebe" "deployment/${rel}-connectors"; do
+                      if kubectl -n "$ns" get "$wl" >/dev/null 2>&1; then
+                          kubectl -n "$ns" rollout restart "$wl" || true
+                      fi
+                  done
 
             - name: 👀⏳ Wait for the deployment to be healthy using generic/kubernetes/single-region
               timeout-minutes: 20

--- a/.github/workflows/azure_kubernetes_aks_single_region_tests.yml
+++ b/.github/workflows/azure_kubernetes_aks_single_region_tests.yml
@@ -708,9 +708,9 @@ jobs:
                   # Wait only: the workloads are bounced after CoreDNS is refreshed (next steps).
                   restart-workloads: 'false'
 
-            # CoreDNS must be bounced here — after the issuer is externally reachable
-            # (the ingress DNS record now exists) and BEFORE the health wait — to flush
-            # the stale negative DNS cache. Otherwise the OIDC components
+            # CoreDNS is bounced here — after the (fail-open) issuer-reachability wait,
+            # so the ingress DNS record normally exists by now, and BEFORE the health
+            # wait — to flush the stale negative DNS cache. Otherwise the OIDC components
             # (identity/connectors/zeebe) keep hitting UnknownHostException on the
             # domain at startup and CrashLoopBackOff until the readiness window expires.
             - name: 🔄 Restart CoreDNS

--- a/.github/workflows/azure_kubernetes_aks_single_region_tests.yml
+++ b/.github/workflows/azure_kubernetes_aks_single_region_tests.yml
@@ -730,9 +730,15 @@ jobs:
                   set -uo pipefail
                   ns="${{ env.CAMUNDA_NAMESPACE }}"
                   rel="${{ env.CAMUNDA_RELEASE_NAME }}"
-                  for wl in "statefulset/${rel}-zeebe" "deployment/${rel}-connectors"; do
-                      if kubectl -n "$ns" get "$wl" >/dev/null 2>&1; then
-                          kubectl -n "$ns" rollout restart "$wl" || true
+                  for wl in "statefulset/${rel}-zeebe" "deployment/${rel}-connectors" "deployment/${rel}-identity"; do
+                      # Distinguish a genuine "absent" (empty, exit 0) from a real
+                      # query error (RBAC/kubeconfig) so failures stay visible.
+                      if ! found=$(kubectl -n "$ns" get "$wl" --ignore-not-found -o name 2>&1); then
+                          echo "::warning::Could not query ${wl}: ${found}"
+                      elif [ -n "$found" ]; then
+                          kubectl -n "$ns" rollout restart "$wl" || echo "::warning::rollout restart ${wl} failed"
+                      else
+                          echo "Skipping ${wl}: not present in namespace ${ns}."
                       fi
                   done
 


### PR DESCRIPTION
## Problem

Cloud CI in **domain** mode (EKS / AKS / ROSA single-region) is red: the OIDC components (`identity`, `connectors`, `zeebe`) `CrashLoopBackOff` with `java.net.UnknownHostException: <cluster>.camunda.ie`. In-cluster CoreDNS holds a **stale negative record** for the ingress domain (cached before `external-dns` publishes it); newer charts do eager OIDC discovery at startup and hard-fail, so `check-deployment-ready.sh` times out.

The workflows already had a `Restart CoreDNS` step to flush that cache, but it was:

1. **placed after** `Wait for the deployment to be healthy` — i.e. it only ran once the health wait had already failed, and
2. **gated on `env.CLEANUP_CLUSTERS == 'false'`** — so in normal CI runs (`delete_clusters: true`) it was **skipped entirely**.

## Fix

In `aws_kubernetes_eks_single_region_tests`, `azure_kubernetes_aks_single_region_tests` and `aws_openshift_rosa_hcp_single_region_tests`, move `Restart CoreDNS` to run **after** the OIDC-issuer reachability wait (so the ingress DNS record already exists) and **before** the health wait, and drop the `CLEANUP_CLUSTERS == 'false'` gate (keep `matrix.declination.name == 'domain'`).

This mirrors the already-working ordering in `generic_kubernetes_operator_based_test.yml` (*"Refresh CoreDNS now — before the health wait"*). The `internal-wait-oidc-issuer` step still bounces `zeebe`/`connectors` at poll time, which resets their backoff so they recover quickly once the cache is flushed, well within the 20-minute health-wait window.

## Validation

This PR touches the three workflow files themselves, which are in each workflow's `pull_request` `paths:` filter, so opening the PR **runs the real EKS / AKS / ROSA integration tests (including the `domain` declination) on this branch**. Green domain jobs here confirm the deployment now reaches healthy instead of timing out on `UnknownHostException`.

## Scope

- No change to any deployment or reference procedure — CI ordering only.
- To be backported to `stable/8.9` (and checked against 8.7/8.8) once validated.
