### PR TITLE
[Backport stable/8.9] fix(eks): boost single-region node pools to 6 and run CI tests on SPOT

### DIFF
--- a/.github/actions/aws-kubernetes-eks-single-region-create/README.md
+++ b/.github/actions/aws-kubernetes-eks-single-region-create/README.md
@@ -27,6 +27,8 @@ Supports conditional deployment of Aurora PostgreSQL and OpenSearch.
 | `private-vpc` | <p>The VPC within which the cluster resides will only have private subnets, meaning that it cannot be accessed at all from the public Internet (empty will fallback on default value of the module)</p> | `false` | `""` |
 | `deploy-aurora` | <p>Deploy Aurora PostgreSQL database</p> | `false` | `true` |
 | `deploy-opensearch` | <p>Deploy OpenSearch domain</p> | `false` | `true` |
+| `np-capacity-type` | <p>Override the node pool capacity type (ON_DEMAND or SPOT). When empty, the value defined in the reference cluster.tf is used. Tests use SPOT for cost efficiency (see https://github.com/camunda/camunda-deployment-references/issues/109).</p> | `false` | `""` |
+| `np-instance-types` | <p>Override the node pool instance types as a comma-separated list (e.g. "m6i.xlarge,m5.xlarge,m5a.xlarge"). When empty, the value defined in the reference cluster.tf is used. Providing several same-size types improves SPOT availability.</p> | `false` | `""` |
 
 
 ## Outputs
@@ -144,4 +146,20 @@ This action is a `composite` action.
     #
     # Required: false
     # Default: true
+
+    np-capacity-type:
+    # Override the node pool capacity type (ON_DEMAND or SPOT). When empty, the value
+    # defined in the reference cluster.tf is used. Tests use SPOT for cost efficiency
+    # (see https://github.com/camunda/camunda-deployment-references/issues/109).
+    #
+    # Required: false
+    # Default: ""
+
+    np-instance-types:
+    # Override the node pool instance types as a comma-separated list (e.g.
+    # "m6i.xlarge,m5.xlarge,m5a.xlarge"). When empty, the value defined in the reference
+    # cluster.tf is used. Providing several same-size types improves SPOT availability.
+    #
+    # Required: false
+    # Default: ""
 ```

--- a/.github/actions/aws-kubernetes-eks-single-region-create/action.yml
+++ b/.github/actions/aws-kubernetes-eks-single-region-create/action.yml
@@ -61,6 +61,18 @@ inputs:
     deploy-opensearch:
         description: Deploy OpenSearch domain
         default: 'true'
+    np-capacity-type:
+        description: |
+            Override the node pool capacity type (ON_DEMAND or SPOT). When empty, the value
+            defined in the reference cluster.tf is used. Tests use SPOT for cost efficiency
+            (see https://github.com/camunda/camunda-deployment-references/issues/109).
+        default: ''
+    np-instance-types:
+        description: |
+            Override the node pool instance types as a comma-separated list (e.g.
+            "m6i.xlarge,m5.xlarge,m5a.xlarge"). When empty, the value defined in the reference
+            cluster.tf is used. Providing several same-size types improves SPOT availability.
+        default: ''
 
 outputs:
     terraform-state-url-cluster:
@@ -179,6 +191,50 @@ runs:
                 sed -i -E "s/(^\s*private_vpc\s*=\s*)[a-z]+/\1${{ inputs.private-vpc }}/" cluster.tf
               else
                 echo "No private-vpc value provided, skipping private modification."
+              fi
+
+              # Optional CI-only node pool overrides (see issue #109): run tests on
+              # cost-efficient SPOT capacity with diversified instance types. The reference
+              # cluster.tf passes these as literal module arguments (not wired to root
+              # variables), so there is no -var to override; patch the file in place instead.
+              _np_capacity_type="${{ inputs.np-capacity-type }}"
+              if [ -n "${_np_capacity_type}" ]; then
+                # Validate early so a typo fails fast with a clear message instead of a
+                # cryptic Terraform error (or a silently wrong capacity type) later on.
+                if [ "${_np_capacity_type}" != "ON_DEMAND" ] && [ "${_np_capacity_type}" != "SPOT" ]; then
+                  echo "::error::Invalid np-capacity-type '${_np_capacity_type}'; allowed values are ON_DEMAND or SPOT."
+                  exit 1
+                fi
+                sed -i -E "s/(np_capacity_type\s*=\s*\")[^\"]*(\")/\1${_np_capacity_type}\2/" cluster.tf
+              fi
+              _np_instance_types="${{ inputs.np-instance-types }}"
+              if [ -n "${_np_instance_types}" ]; then
+                # Convert the comma-separated list into an HCL list literal, trimming
+                # surrounding whitespace and dropping empty entries so a loosely formatted
+                # input (spaces or a trailing comma) still yields valid HCL.
+                IFS=',' read -ra _np_types <<< "${_np_instance_types}"
+                _np_hcl="["
+                for _np_type in "${_np_types[@]}"; do
+                  # Strip leading and trailing whitespace, then skip empty entries.
+                  _np_type="${_np_type#"${_np_type%%[![:space:]]*}"}"
+                  _np_type="${_np_type%"${_np_type##*[![:space:]]}"}"
+                  [ -z "${_np_type}" ] && continue
+                  # Validate the token against an AWS instance-type shape (family.size,
+                  # both of which may contain hyphens, e.g. c7i-flex.large or
+                  # m7i.metal-48xl) so stray characters (quotes, newlines, ...) can't
+                  # inject invalid content into the generated HCL list.
+                  if [[ ! "${_np_type}" =~ ^[a-z0-9-]+\.[a-z0-9-]+$ ]]; then
+                    echo "::error::Invalid np-instance-types entry '${_np_type}'; expected an AWS instance type such as m6i.xlarge."
+                    exit 1
+                  fi
+                  _np_hcl+="\"${_np_type}\", "
+                done
+                _np_hcl="${_np_hcl%, }]"
+                if [ "${_np_hcl}" = "[]" ]; then
+                  echo "::error::np-instance-types contained no valid entries: '${_np_instance_types}'."
+                  exit 1
+                fi
+                sed -i -E "s|(np_instance_types\s*=\s*).*|\1${_np_hcl}|" cluster.tf
               fi
 
               echo "Displaying templated cluster.tf file:"

--- a/.github/actions/internal-camunda-chart-tests/action.yml
+++ b/.github/actions/internal-camunda-chart-tests/action.yml
@@ -535,13 +535,58 @@ runs:
               C8_SM_CHECKS_PATH="${{ inputs.tests-c8-sm-checks-repo-path }}"
               chmod +x "$C8_SM_CHECKS_PATH/checks/kube/connectivity.sh"
 
-              # Skip ingress checks if no domain is configured
+              # Build the connectivity.sh arguments; skip ingress checks when no
+              # domain is configured (or when explicitly requested).
+              connectivity_args=(-n "$NAMESPACE")
               if [[ -z "$CAMUNDA_DOMAIN" ]] || [[ "${{ inputs.skip-c8sm-connectivity-ingress-class-check }}" == "true" ]]; then
                 echo "ℹ️ No domain configured, skipping ingress checks"
-                "$C8_SM_CHECKS_PATH/checks/kube/connectivity.sh" -n "$NAMESPACE" -i
-              else
-                "$C8_SM_CHECKS_PATH/checks/kube/connectivity.sh" -n "$NAMESPACE"
+                connectivity_args+=(-i)
               fi
+
+              # The sweep runs `kubectl exec` into every pod to probe every
+              # Service. `kubectl exec` has no client-side deadline, so a pod
+              # that goes momentarily unresponsive mid-sweep (restart, node or
+              # volume hiccup) makes a single exec hang and would otherwise burn
+              # the whole step's timeout budget. Bound each attempt with
+              # `timeout` and retry a few times so a transient hiccup fails fast
+              # and recovers; a genuine connectivity problem still fails once the
+              # retry budget is exhausted.
+              C8SM_CONNECTIVITY_TIMEOUT_SECONDS="${C8SM_CONNECTIVITY_TIMEOUT_SECONDS:-360}"
+              C8SM_CONNECTIVITY_RETRIES="${C8SM_CONNECTIVITY_RETRIES:-3}"
+              C8SM_CONNECTIVITY_RETRY_DELAY="${C8SM_CONNECTIVITY_RETRY_DELAY:-15}"
+
+              # Validate the (overridable) tuning knobs up front so a bad value
+              # fails fast with a clear message instead of a terse mid-loop error.
+              if ! [[ "$C8SM_CONNECTIVITY_TIMEOUT_SECONDS" =~ ^[1-9][0-9]*$ ]]; then
+                  echo "::error::C8SM_CONNECTIVITY_TIMEOUT_SECONDS must be a positive integer (got '$C8SM_CONNECTIVITY_TIMEOUT_SECONDS')."
+                  exit 1
+              fi
+              if ! [[ "$C8SM_CONNECTIVITY_RETRIES" =~ ^[1-9][0-9]*$ ]]; then
+                  echo "::error::C8SM_CONNECTIVITY_RETRIES must be a positive integer (got '$C8SM_CONNECTIVITY_RETRIES')."
+                  exit 1
+              fi
+              if ! [[ "$C8SM_CONNECTIVITY_RETRY_DELAY" =~ ^[0-9]+$ ]]; then
+                  echo "::error::C8SM_CONNECTIVITY_RETRY_DELAY must be a non-negative integer (got '$C8SM_CONNECTIVITY_RETRY_DELAY')."
+                  exit 1
+              fi
+
+              attempt=1
+              while true; do
+                  # -k gives the sweep a grace period to exit on SIGTERM before
+                  # it is SIGKILLed, so a wedged `kubectl exec` cannot linger.
+                  if timeout -k 30 "$C8SM_CONNECTIVITY_TIMEOUT_SECONDS" \
+                      "$C8_SM_CHECKS_PATH/checks/kube/connectivity.sh" "${connectivity_args[@]}"; then
+                      echo "✅ Kubernetes connectivity check passed (attempt ${attempt}/${C8SM_CONNECTIVITY_RETRIES})."
+                      break
+                  fi
+                  if [[ "$attempt" -ge "$C8SM_CONNECTIVITY_RETRIES" ]]; then
+                      echo "::error::Connectivity check failed after ${C8SM_CONNECTIVITY_RETRIES} attempt(s) (each bounded to ${C8SM_CONNECTIVITY_TIMEOUT_SECONDS}s)."
+                      exit 1
+                  fi
+                  echo "::warning::Connectivity check failed/timed out (attempt ${attempt}/${C8SM_CONNECTIVITY_RETRIES}); retrying in ${C8SM_CONNECTIVITY_RETRY_DELAY}s..."
+                  attempt=$(( attempt + 1 ))
+                  sleep "$C8SM_CONNECTIVITY_RETRY_DELAY"
+              done
 
         - name: 🧪 C8-SM-CHECKS - Run AWS IRSA Check
           if: ${{ inputs.enable-c8sm-irsa-check == 'true' }}

--- a/.github/actions/internal-camunda-chart-tests/action.yml
+++ b/.github/actions/internal-camunda-chart-tests/action.yml
@@ -535,58 +535,50 @@ runs:
               C8_SM_CHECKS_PATH="${{ inputs.tests-c8-sm-checks-repo-path }}"
               chmod +x "$C8_SM_CHECKS_PATH/checks/kube/connectivity.sh"
 
-              # Build the connectivity.sh arguments; skip ingress checks when no
-              # domain is configured (or when explicitly requested).
+              # Build the connectivity.sh arguments, skipping the ingress
+              # checks when there is no domain to resolve, or when the caller
+              # explicitly opts out (distinct messages so the logs are clear).
               connectivity_args=(-n "$NAMESPACE")
-              if [[ -z "$CAMUNDA_DOMAIN" ]] || [[ "${{ inputs.skip-c8sm-connectivity-ingress-class-check }}" == "true" ]]; then
-                echo "ℹ️ No domain configured, skipping ingress checks"
+              if [[ -z "$CAMUNDA_DOMAIN" ]]; then
+                echo "ℹ️ No domain configured; skipping ingress checks."
+                connectivity_args+=(-i)
+              elif [[ "${{ inputs.skip-c8sm-connectivity-ingress-class-check }}" == "true" ]]; then
+                echo "ℹ️ skip-c8sm-connectivity-ingress-class-check=true; skipping ingress checks."
                 connectivity_args+=(-i)
               fi
 
               # The sweep runs `kubectl exec` into every pod to probe every
               # Service. `kubectl exec` has no client-side deadline, so a pod
               # that goes momentarily unresponsive mid-sweep (restart, node or
-              # volume hiccup) makes a single exec hang and would otherwise burn
-              # the whole step's timeout budget. Bound each attempt with
-              # `timeout` and retry a few times so a transient hiccup fails fast
-              # and recovers; a genuine connectivity problem still fails once the
-              # retry budget is exhausted.
-              C8SM_CONNECTIVITY_TIMEOUT_SECONDS="${C8SM_CONNECTIVITY_TIMEOUT_SECONDS:-360}"
-              C8SM_CONNECTIVITY_RETRIES="${C8SM_CONNECTIVITY_RETRIES:-3}"
-              C8SM_CONNECTIVITY_RETRY_DELAY="${C8SM_CONNECTIVITY_RETRY_DELAY:-15}"
-
-              # Validate the (overridable) tuning knobs up front so a bad value
-              # fails fast with a clear message instead of a terse mid-loop error.
+              # volume hiccup) makes a single exec hang and would otherwise
+              # silently consume the whole step timeout, failing with an opaque
+              # "The action has timed out". Bound the sweep with `timeout` so a
+              # wedged exec fails fast with a clear message instead. The budget
+              # is deliberately generous: a healthy sweep of a large namespace
+              # probes hundreds of Service×pod pairs and legitimately takes
+              # ~10-15 min, so this must stay well above that (and below the
+              # step's own timeout-minutes) to avoid killing a slow-but-healthy
+              # run.
+              C8SM_CONNECTIVITY_TIMEOUT_SECONDS="${C8SM_CONNECTIVITY_TIMEOUT_SECONDS:-1200}"
               if ! [[ "$C8SM_CONNECTIVITY_TIMEOUT_SECONDS" =~ ^[1-9][0-9]*$ ]]; then
                   echo "::error::C8SM_CONNECTIVITY_TIMEOUT_SECONDS must be a positive integer (got '$C8SM_CONNECTIVITY_TIMEOUT_SECONDS')."
                   exit 1
               fi
-              if ! [[ "$C8SM_CONNECTIVITY_RETRIES" =~ ^[1-9][0-9]*$ ]]; then
-                  echo "::error::C8SM_CONNECTIVITY_RETRIES must be a positive integer (got '$C8SM_CONNECTIVITY_RETRIES')."
-                  exit 1
-              fi
-              if ! [[ "$C8SM_CONNECTIVITY_RETRY_DELAY" =~ ^[0-9]+$ ]]; then
-                  echo "::error::C8SM_CONNECTIVITY_RETRY_DELAY must be a non-negative integer (got '$C8SM_CONNECTIVITY_RETRY_DELAY')."
-                  exit 1
-              fi
 
-              attempt=1
-              while true; do
-                  # -k gives the sweep a grace period to exit on SIGTERM before
-                  # it is SIGKILLed, so a wedged `kubectl exec` cannot linger.
-                  if timeout -k 30 "$C8SM_CONNECTIVITY_TIMEOUT_SECONDS" \
-                      "$C8_SM_CHECKS_PATH/checks/kube/connectivity.sh" "${connectivity_args[@]}"; then
-                      echo "✅ Kubernetes connectivity check passed (attempt ${attempt}/${C8SM_CONNECTIVITY_RETRIES})."
-                      break
+              # -k 30 escalates to SIGKILL 30s after the initial SIGTERM so a
+              # wedged exec cannot linger past the budget.
+              rc=0
+              timeout -k 30 "$C8SM_CONNECTIVITY_TIMEOUT_SECONDS" \
+                  "$C8_SM_CHECKS_PATH/checks/kube/connectivity.sh" "${connectivity_args[@]}" || rc=$?
+              if [[ "$rc" -ne 0 ]]; then
+                  if [[ "$rc" -eq 124 ]]; then
+                      echo "::error::Connectivity check timed out after ${C8SM_CONNECTIVITY_TIMEOUT_SECONDS}s (a pod likely went unresponsive mid-sweep); re-run to retry."
+                  else
+                      echo "::error::Kubernetes connectivity check failed (exit ${rc})."
                   fi
-                  if [[ "$attempt" -ge "$C8SM_CONNECTIVITY_RETRIES" ]]; then
-                      echo "::error::Connectivity check failed after ${C8SM_CONNECTIVITY_RETRIES} attempt(s) (each bounded to ${C8SM_CONNECTIVITY_TIMEOUT_SECONDS}s)."
-                      exit 1
-                  fi
-                  echo "::warning::Connectivity check failed/timed out (attempt ${attempt}/${C8SM_CONNECTIVITY_RETRIES}); retrying in ${C8SM_CONNECTIVITY_RETRY_DELAY}s..."
-                  attempt=$(( attempt + 1 ))
-                  sleep "$C8SM_CONNECTIVITY_RETRY_DELAY"
-              done
+                  exit 1
+              fi
+              echo "✅ Kubernetes connectivity check passed."
 
         - name: 🧪 C8-SM-CHECKS - Run AWS IRSA Check
           if: ${{ inputs.enable-c8sm-irsa-check == 'true' }}

--- a/.github/workflows/generic_kubernetes_operator_based_test.yml
+++ b/.github/workflows/generic_kubernetes_operator_based_test.yml
@@ -234,6 +234,11 @@ jobs:
                   ref-arch: eks-single-region
                   deploy-aurora: 'false'      # Disabled - using CloudNativePG operator instead
                   deploy-opensearch: 'false'  # Disabled - using ECK operator instead
+                  # Cost-efficient SPOT capacity for tests, with diversified same-size
+                  # instance types to improve availability (see issue #109). Spot
+                  # interruptions are tolerated via job re-runs.
+                  np-capacity-type: SPOT
+                  np-instance-types: m6i.xlarge,m6a.xlarge,m5.xlarge,m5a.xlarge,m5d.xlarge
                   tags: >
                       {
                         "ci-run-id": "${{ github.run_id }}",

--- a/aws/kubernetes/eks-single-region-irsa/terraform/cluster/cluster.tf
+++ b/aws/kubernetes/eks-single-region-irsa/terraform/cluster/cluster.tf
@@ -24,8 +24,13 @@ module "eks_cluster" {
   cluster_node_ipv4_cidr    = "10.192.0.0/16"
 
   # Default node type for the Kubernetes cluster
-  np_instance_types     = ["m6i.xlarge"]
-  np_desired_node_count = 4
+  np_instance_types = ["m6i.xlarge"]
+  # 6 nodes spread across 3 AZs (best-effort, roughly 2 per AZ) give enough headroom
+  # to host the full Camunda stack (3 Zeebe brokers + 3 Elasticsearch + all web apps)
+  # together with the ingress add-ons, and keep AZ-pinned EBS volumes schedulable.
+  np_desired_node_count = 6
+  # Use stable on-demand capacity by default.
+  np_capacity_type = "ON_DEMAND"
 
   # Prevent the cluster to be accessed at all from the public Internet if true
   private_vpc        = false

--- a/aws/kubernetes/eks-single-region-irsa/terraform/cluster/test/golden/tfplan-golden.json
+++ b/aws/kubernetes/eks-single-region-irsa/terraform/cluster/test/golden/tfplan-golden.json
@@ -332,7 +332,7 @@
                     "remote_access": [],
                     "scaling_config": [
                       {
-                        "desired_size": 4,
+                        "desired_size": 6,
                         "max_size": 10,
                         "min_size": 1
                       }

--- a/aws/kubernetes/eks-single-region/terraform/cluster/cluster.tf
+++ b/aws/kubernetes/eks-single-region/terraform/cluster/cluster.tf
@@ -24,8 +24,13 @@ module "eks_cluster" {
   cluster_node_ipv4_cidr    = "10.192.0.0/16"
 
   # Default node type for the Kubernetes cluster
-  np_instance_types     = ["m6i.xlarge"]
-  np_desired_node_count = 4
+  np_instance_types = ["m6i.xlarge"]
+  # 6 nodes spread across 3 AZs (best-effort, roughly 2 per AZ) give enough headroom
+  # to host the full Camunda stack (3 Zeebe brokers + 3 Elasticsearch + all web apps)
+  # together with the ingress add-ons, and keep AZ-pinned EBS volumes schedulable.
+  np_desired_node_count = 6
+  # Use stable on-demand capacity by default.
+  np_capacity_type = "ON_DEMAND"
 
   # Prevent the cluster to be accessed at all from the public Internet if true
   private_vpc        = false

--- a/aws/kubernetes/eks-single-region/terraform/cluster/test/golden/tfplan-golden.json
+++ b/aws/kubernetes/eks-single-region/terraform/cluster/test/golden/tfplan-golden.json
@@ -332,7 +332,7 @@
                     "remote_access": [],
                     "scaling_config": [
                       {
-                        "desired_size": 4,
+                        "desired_size": 6,
                         "max_size": 10,
                         "min_size": 1
                       }


### PR DESCRIPTION
# Description
Backport of #2825 to `stable/8.9`.

Created manually because the automated backport failed to push: the change touches `.github/workflows/generic_kubernetes_operator_based_test.yml` and the backport GitHub App lacks the `workflows` permission. The cherry-pick of `040501f3` applies cleanly — the golden-file delta is exactly `desired_size: 4 → 6` on both modules.

relates to #109