### PR TITLE
fix(ecs-dual-region): repair failing terraform test suites for infra and app layers

### DIFF
--- a/aws/containers/ecs-dual-region-fargate/terraform/app/camunda.tf
+++ b/aws/containers/ecs-dual-region-fargate/terraform/app/camunda.tf
@@ -9,7 +9,7 @@ module "orchestration_cluster_region_0" {
   ecs_cluster_id           = local.infra.ecs_cluster_region_0_id
   vpc_id                   = local.infra.vpc_region_0_id
   vpc_private_subnets      = local.infra.vpc_region_0_private_subnets
-  aws_region               = data.aws_region.region_0.id
+  aws_region               = data.aws_region.region_0.region
   image                    = var.camunda_image
   registry_credentials_arn = startswith(var.camunda_image, "registry.camunda.cloud/") ? local.infra.registry_credentials_region_0_arn : ""
   s3_force_destroy         = local.infra.s3_force_destroy
@@ -56,7 +56,7 @@ module "orchestration_cluster_region_0" {
       },
       {
         name  = "CAMUNDA_DATA_BACKUP_S3_REGION"
-        value = data.aws_region.region_0.id
+        value = data.aws_region.region_0.region
       },
     ]
   )
@@ -115,7 +115,7 @@ module "orchestration_cluster_region_1" {
   ecs_cluster_id           = local.infra.ecs_cluster_region_1_id
   vpc_id                   = local.infra.vpc_region_1_id
   vpc_private_subnets      = local.infra.vpc_region_1_private_subnets
-  aws_region               = data.aws_region.region_1.id
+  aws_region               = data.aws_region.region_1.region
   image                    = var.camunda_image
   registry_credentials_arn = startswith(var.camunda_image, "registry.camunda.cloud/") ? local.infra.registry_credentials_region_1_arn : ""
   s3_force_destroy         = local.infra.s3_force_destroy
@@ -165,7 +165,7 @@ module "orchestration_cluster_region_1" {
         # shared bucket in region 0; the S3 client must know where the bucket
         # lives for correct endpoint resolution.
         name  = "CAMUNDA_DATA_BACKUP_S3_REGION"
-        value = data.aws_region.region_0.id
+        value = data.aws_region.region_0.region
       },
     ]
   )
@@ -215,7 +215,7 @@ module "connectors_region_0" {
   ecs_cluster_id                       = local.infra.ecs_cluster_region_0_id
   vpc_id                               = local.infra.vpc_region_0_id
   vpc_private_subnets                  = local.infra.vpc_region_0_private_subnets
-  aws_region                           = data.aws_region.region_0.id
+  aws_region                           = data.aws_region.region_0.region
   image                                = var.connectors_image
   registry_credentials_arn             = "" # connectors image is on docker.io (public); no registry creds needed and passing the registry.camunda.cloud creds confuses ECS
   s2s_cloudmap_namespace               = module.orchestration_cluster_region_0.s2s_cloudmap_namespace
@@ -296,7 +296,7 @@ module "connectors_region_1" {
   ecs_cluster_id                       = local.infra.ecs_cluster_region_1_id
   vpc_id                               = local.infra.vpc_region_1_id
   vpc_private_subnets                  = local.infra.vpc_region_1_private_subnets
-  aws_region                           = data.aws_region.region_1.id
+  aws_region                           = data.aws_region.region_1.region
   image                                = var.connectors_image
   registry_credentials_arn             = "" # connectors image is on docker.io (public); no registry creds needed and passing the registry.camunda.cloud creds confuses ECS
   s2s_cloudmap_namespace               = module.orchestration_cluster_region_1.s2s_cloudmap_namespace

--- a/aws/containers/ecs-dual-region-fargate/terraform/app/locals.tf
+++ b/aws/containers/ecs-dual-region-fargate/terraform/app/locals.tf
@@ -89,7 +89,7 @@ locals {
     replace(local.infra.aurora_primary_cluster_endpoint, "${local.infra.aurora_primary_cluster_identifier}.cluster-", "")
   }" : ""
   aurora_secondary_instance_pattern = local.infra.secondary_storage_type == "rdbms" ? "?.${
-    replace(local.infra.aurora_secondary_endpoint, "${local.infra.aurora_secondary_cluster_identifier}.cluster-", "")
+    replace(local.infra.aurora_secondary_cluster_endpoint, "${local.infra.aurora_secondary_cluster_identifier}.cluster-", "")
   }" : ""
 
   # Secondary storage environment variables (conditional on storage type)

--- a/aws/containers/ecs-dual-region-fargate/terraform/app/outputs.tf
+++ b/aws/containers/ecs-dual-region-fargate/terraform/app/outputs.tf
@@ -60,7 +60,7 @@ output "next_steps" {
       # orchestration cluster):
       aws secretsmanager get-secret-value \
         --secret-id ${local.infra.connectors_password_secret_region_0_arn} \
-        --region ${data.aws_region.region_0.id} \
+        --region ${data.aws_region.region_0.region} \
         --query SecretString --output text
 
     ── 2. Health-check (basic auth required on 8.10) ──────────────────
@@ -85,8 +85,8 @@ output "next_steps" {
 
     ── 4. CloudWatch logs ─────────────────────────────────────────────
 
-      aws logs tail ${module.orchestration_cluster_region_0.log_group_name} --region ${data.aws_region.region_0.id} --follow
-      aws logs tail ${module.orchestration_cluster_region_1.log_group_name} --region ${data.aws_region.region_1.id} --follow
+      aws logs tail ${module.orchestration_cluster_region_0.log_group_name} --region ${data.aws_region.region_0.region} --follow
+      aws logs tail ${module.orchestration_cluster_region_1.log_group_name} --region ${data.aws_region.region_1.region} --follow
 
     ── 5. Region 1 endpoints (active-active, same credentials) ────────
 

--- a/aws/containers/ecs-dual-region-fargate/terraform/app/tests/app.tftest.hcl
+++ b/aws/containers/ecs-dual-region-fargate/terraform/app/tests/app.tftest.hcl
@@ -14,6 +14,11 @@ mock_provider "aws" {
   alias = "accepter"
 }
 
+variables {
+  terraform_backend_bucket     = "test-tf-state-bucket"
+  terraform_backend_key_prefix = "aws/containers/ecs-dual-region-fargate/test-app/"
+}
+
 # Baseline fixture used by most runs. The opensearch run overrides this.
 override_data {
   target = data.terraform_remote_state.infra
@@ -66,7 +71,7 @@ override_data {
       db_admin_username                         = "camunda_admin"
       aurora_global_writer_endpoint             = "aurora-global.example.com"
       aurora_primary_cluster_endpoint           = "aurora-primary.example.com"
-      aurora_secondary_endpoint                 = "aurora-secondary.example.com"
+      aurora_secondary_cluster_endpoint         = "aurora-secondary.example.com"
       aurora_primary_cluster_identifier         = "test-app-r0-aurora"
       aurora_secondary_cluster_identifier       = "test-app-r1-aurora"
       opensearch_region_0_endpoint              = "opensearch-r0.example.com"
@@ -148,7 +153,7 @@ run "opensearch_env_vars_local_populated_when_opensearch" {
         db_admin_username                         = "camunda_admin"
         aurora_global_writer_endpoint             = ""
         aurora_primary_cluster_endpoint           = ""
-        aurora_secondary_endpoint                 = ""
+        aurora_secondary_cluster_endpoint         = ""
         aurora_primary_cluster_identifier         = ""
         aurora_secondary_cluster_identifier       = ""
         opensearch_region_0_endpoint              = "opensearch-r0.example.com"

--- a/aws/containers/ecs-dual-region-fargate/terraform/infra/iam.tf
+++ b/aws/containers/ecs-dual-region-fargate/terraform/infra/iam.tf
@@ -82,8 +82,8 @@ resource "aws_iam_policy" "rds_db_connect_region_0" {
         Effect = "Allow"
         Action = ["rds-db:connect"]
         Resource = [
-          "arn:aws:rds-db:${data.aws_region.region_0.id}:${data.aws_caller_identity.current.account_id}:dbuser:${module.aurora_global[0].primary_cluster_resource_id}/camunda",
-          "arn:aws:rds-db:${data.aws_region.region_1.id}:${data.aws_caller_identity.current.account_id}:dbuser:${module.aurora_global[0].secondary_cluster_resource_id}/camunda",
+          "arn:aws:rds-db:${data.aws_region.region_0.region}:${data.aws_caller_identity.current.account_id}:dbuser:${module.aurora_global[0].primary_cluster_resource_id}/camunda",
+          "arn:aws:rds-db:${data.aws_region.region_1.region}:${data.aws_caller_identity.current.account_id}:dbuser:${module.aurora_global[0].secondary_cluster_resource_id}/camunda",
         ]
       },
       {
@@ -182,8 +182,8 @@ resource "aws_iam_policy" "rds_db_connect_region_1" {
         Effect = "Allow"
         Action = ["rds-db:connect"]
         Resource = [
-          "arn:aws:rds-db:${data.aws_region.region_0.id}:${data.aws_caller_identity.current.account_id}:dbuser:${module.aurora_global[0].primary_cluster_resource_id}/camunda",
-          "arn:aws:rds-db:${data.aws_region.region_1.id}:${data.aws_caller_identity.current.account_id}:dbuser:${module.aurora_global[0].secondary_cluster_resource_id}/camunda",
+          "arn:aws:rds-db:${data.aws_region.region_0.region}:${data.aws_caller_identity.current.account_id}:dbuser:${module.aurora_global[0].primary_cluster_resource_id}/camunda",
+          "arn:aws:rds-db:${data.aws_region.region_1.region}:${data.aws_caller_identity.current.account_id}:dbuser:${module.aurora_global[0].secondary_cluster_resource_id}/camunda",
         ]
       },
       {

--- a/aws/containers/ecs-dual-region-fargate/terraform/infra/postgres_seed.tf
+++ b/aws/containers/ecs-dual-region-fargate/terraform/infra/postgres_seed.tf
@@ -71,7 +71,7 @@ resource "aws_ecs_task_definition" "db_seed" {
         logDriver = "awslogs"
         options = {
           awslogs-group         = aws_cloudwatch_log_group.db_seed[0].name
-          awslogs-region        = data.aws_region.region_0.id
+          awslogs-region        = data.aws_region.region_0.region
           awslogs-stream-prefix = "db-seed"
         }
       }
@@ -113,7 +113,7 @@ resource "null_resource" "run_db_seed_task" {
 
       echo "Running one-time DB seed task..."
       TASK_ARN=$(aws ecs run-task \
-        --region "${data.aws_region.region_0.id}" \
+        --region "${data.aws_region.region_0.region}" \
         --cluster "${aws_ecs_cluster.region_0.arn}" \
         --launch-type FARGATE \
         --task-definition "${aws_ecs_task_definition.db_seed[0].arn}" \
@@ -124,19 +124,19 @@ resource "null_resource" "run_db_seed_task" {
       echo "Task started: $TASK_ARN"
 
       aws ecs wait tasks-stopped \
-        --region "${data.aws_region.region_0.id}" \
+        --region "${data.aws_region.region_0.region}" \
         --cluster "${aws_ecs_cluster.region_0.arn}" \
         --tasks "$TASK_ARN"
 
       EXIT_CODE=$(aws ecs describe-tasks \
-        --region "${data.aws_region.region_0.id}" \
+        --region "${data.aws_region.region_0.region}" \
         --cluster "${aws_ecs_cluster.region_0.arn}" \
         --tasks "$TASK_ARN" \
         --query 'tasks[0].containers[0].exitCode' \
         --output text)
 
       STOP_REASON=$(aws ecs describe-tasks \
-        --region "${data.aws_region.region_0.id}" \
+        --region "${data.aws_region.region_0.region}" \
         --cluster "${aws_ecs_cluster.region_0.arn}" \
         --tasks "$TASK_ARN" \
         --query 'tasks[0].stoppedReason' \

--- a/aws/containers/ecs-dual-region-fargate/terraform/infra/tests/iam.tftest.hcl
+++ b/aws/containers/ecs-dual-region-fargate/terraform/infra/tests/iam.tftest.hcl
@@ -29,7 +29,9 @@ override_data {
 }
 
 variables {
-  cluster_name = "test-iam"
+  cluster_name                 = "test-iam"
+  terraform_backend_bucket     = "test-tf-state-bucket"
+  terraform_backend_key_prefix = "aws/containers/ecs-dual-region-fargate/test-iam/"
 }
 
 run "registry_credentials_secret_created_when_username_supplied" {

--- a/aws/containers/ecs-dual-region-fargate/terraform/infra/tests/storage_branch.tftest.hcl
+++ b/aws/containers/ecs-dual-region-fargate/terraform/infra/tests/storage_branch.tftest.hcl
@@ -30,7 +30,9 @@ override_data {
 }
 
 variables {
-  cluster_name = "test-infra"
+  cluster_name                 = "test-infra"
+  terraform_backend_bucket     = "test-tf-state-bucket"
+  terraform_backend_key_prefix = "aws/containers/ecs-dual-region-fargate/test-infra/"
 }
 
 run "rdbms_creates_aurora_only" {

--- a/aws/containers/ecs-dual-region-fargate/terraform/infra/tests/validation.tftest.hcl
+++ b/aws/containers/ecs-dual-region-fargate/terraform/infra/tests/validation.tftest.hcl
@@ -29,7 +29,9 @@ override_data {
 }
 
 variables {
-  cluster_name = "test-infra"
+  cluster_name                 = "test-infra"
+  terraform_backend_bucket     = "test-tf-state-bucket"
+  terraform_backend_key_prefix = "aws/containers/ecs-dual-region-fargate/test-infra/"
 }
 
 run "secondary_storage_type_rejects_invalid" {

--- a/aws/containers/ecs-dual-region-fargate/terraform/infra/tests/vpc_consumption.tftest.hcl
+++ b/aws/containers/ecs-dual-region-fargate/terraform/infra/tests/vpc_consumption.tftest.hcl
@@ -67,7 +67,9 @@ override_data {
 }
 
 variables {
-  cluster_name = "test-infra"
+  cluster_name                 = "test-infra"
+  terraform_backend_bucket     = "test-tf-state-bucket"
+  terraform_backend_key_prefix = "aws/containers/ecs-dual-region-fargate/test-infra/"
 }
 
 run "outputs_re_export_stubbed_vpc_values" {


### PR DESCRIPTION
## Summary
- `terraform_backend_bucket` and `terraform_backend_key_prefix` are required variables (no default) consumed by `terraform_remote_state` in the `infra/` and `app/` layers of `ecs-dual-region-fargate`, but no test file supplied them — every `terraform test` run in those layers failed with "No value for required variable".
- The `app/` test fixture still mocked the old `aurora_secondary_endpoint` key, left over from the `aurora_secondary_cluster_endpoint` rename, causing an "Unsupported attribute" error.
- Replaced the deprecated `aws_region` data source `.id` attribute with `.region` across `infra/` and `app/`, ahead of its removal from the AWS provider.

## Test plan
- [x] `terraform test` passes in `terraform/infra` (10/10)
- [x] `terraform test` passes in `terraform/app` (5/5)
- [x] `terraform test` unaffected in `terraform/vpc` (20/20, sanity check)
- [x] `pre-commit run --files <changed files>` passes, including `terraform-test-touched`