### PR TITLE
test(ecs-dual-region): add Terraform golden plan coverage for vpc, infra and app

### DIFF
--- a/.github/workflows/aws_ecs_dual_region_fargate_golden.yml
+++ b/.github/workflows/aws_ecs_dual_region_fargate_golden.yml
@@ -1,0 +1,105 @@
+---
+name: Tests - Golden - AWS Containers ECS Dual Region Fargate
+
+on:
+    workflow_dispatch:
+    pull_request:
+        paths:
+            - .github/workflows/aws_ecs_dual_region_fargate_golden.yml
+            - .github/actions/aws-configure-cli/**
+            - .github/actions/internal-terraform-golden-plan/**
+            - .tool-versions
+            - aws/containers/ecs-dual-region-fargate/terraform/**
+            - aws/modules/transit-gateway/**
+
+# limit to a single execution per actor of this workflow
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
+env:
+    IS_SCHEDULE: ${{ (contains(github.head_ref, 'schedules/') || github.event_name == 'schedule') && 'true' || 'false' }}
+
+    AWS_PROFILE: infraex
+    AWS_REGION: eu-west-2
+    S3_BACKEND_BUCKET: tests-ra-aws-rosa-hcp-tf-state-eu-central-1
+    S3_BUCKET_REGION: eu-central-1
+    S3_BUCKET_KEY: golden.tfstate
+
+    MODULE_DIR_BASE: ./aws/containers/ecs-dual-region-fargate/terraform/
+
+jobs:
+    triage:
+        runs-on: ubuntu-slim
+        outputs:
+            should_skip: ${{ steps.skip_check.outputs.should_skip }}
+        steps:
+            - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+            - name: Check labels
+              id: skip_check
+              uses: ./.github/actions/internal-triage-skip
+
+    compare:
+        runs-on: ubuntu-latest
+        needs:
+            - triage
+        if: needs.triage.outputs.should_skip == 'false'
+        permissions:
+            contents: write
+            pull-requests: write
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+            - name: Install asdf tools with cache
+              uses: camunda/infraex-common-config/./.github/actions/asdf-install-tooling@bde1b69728d323c1c2d02e19153a8e00382eec4a # 1.8.0
+
+            - name: Configure AWS CLI
+              uses: ./.github/actions/aws-configure-cli
+              with:
+                  vault-addr: ${{ secrets.VAULT_ADDR }}
+                  vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+                  vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+                  aws-profile: ${{ env.AWS_PROFILE }}
+                  aws-region: ${{ env.AWS_REGION }}
+
+            # infra/ and app/ are intentionally excluded from golden plan
+            # coverage. Both read a sibling state via data.terraform_remote_state
+            # (infra reads vpc, app reads infra) and infra additionally reads
+            # live data.aws_subnet resources from the vpc outputs, so neither can
+            # be planned standalone against an empty backend. This mirrors the
+            # rosa-hcp-dual-region/terraform/peering exclusion. They also opt out
+            # of `just regenerate-golden-file-all` by not providing a
+            # test/golden/golden.tfvars marker (see camunda/camunda-deployment-references#2761).
+            #
+            # - name: Run Terraform Golden Plan Comparison - Infra
+            #   uses: ./.github/actions/internal-terraform-golden-plan
+            #   env:
+            #       GH_TOKEN: ${{ github.token }}
+            #   with:
+            #       module-dir: ${{ env.MODULE_DIR_BASE }}infra/
+            #       s3-bucket-region: ${{ env.S3_BUCKET_REGION }}
+            #       s3-backend-bucket: ${{ env.S3_BACKEND_BUCKET }}
+            #       s3-bucket-key: ${{ env.S3_BUCKET_KEY }}
+            #
+            # - name: Run Terraform Golden Plan Comparison - App
+            #   uses: ./.github/actions/internal-terraform-golden-plan
+            #   env:
+            #       GH_TOKEN: ${{ github.token }}
+            #   with:
+            #       module-dir: ${{ env.MODULE_DIR_BASE }}app/
+            #       s3-bucket-region: ${{ env.S3_BUCKET_REGION }}
+            #       s3-backend-bucket: ${{ env.S3_BACKEND_BUCKET }}
+            #       s3-bucket-key: ${{ env.S3_BUCKET_KEY }}
+
+            # Only the vpc/ state is plannable standalone: it relies solely on
+            # data.aws_availability_zones and creates its resources from scratch.
+            - name: Run Terraform Golden Plan Comparison - VPC
+              uses: ./.github/actions/internal-terraform-golden-plan
+              env:
+                  GH_TOKEN: ${{ github.token }}
+              with:
+                  module-dir: ${{ env.MODULE_DIR_BASE }}vpc/
+                  s3-bucket-region: ${{ env.S3_BUCKET_REGION }}
+                  s3-backend-bucket: ${{ env.S3_BACKEND_BUCKET }}
+                  s3-bucket-key: ${{ env.S3_BUCKET_KEY }}

--- a/.github/workflows/aws_ecs_dual_region_fargate_golden.yml
+++ b/.github/workflows/aws_ecs_dual_region_fargate_golden.yml
@@ -6,10 +6,16 @@ on:
     pull_request:
         paths:
             - .github/workflows/aws_ecs_dual_region_fargate_golden.yml
-            - .github/actions/aws-configure-cli/**
             - .github/actions/internal-terraform-golden-plan/**
             - .tool-versions
             - aws/containers/ecs-dual-region-fargate/terraform/**
+            # Shared modules rendered into the golden plans: vpc/ uses
+            # transit-gateway; infra/ uses aurora-global and opensearch; app/
+            # uses ecs. A change to any of these alters a committed golden file,
+            # so the comparison must re-run when they do.
+            - aws/modules/ecs/**
+            - aws/modules/aurora-global/**
+            - aws/modules/opensearch/**
             - aws/modules/transit-gateway/**
 
 # limit to a single execution per actor of this workflow
@@ -63,43 +69,38 @@ jobs:
                   aws-profile: ${{ env.AWS_PROFILE }}
                   aws-region: ${{ env.AWS_REGION }}
 
-            # infra/ and app/ are intentionally excluded from golden plan
-            # coverage. Both read a sibling state via data.terraform_remote_state
-            # (infra reads vpc, app reads infra) and infra additionally reads
-            # live data.aws_subnet resources from the vpc outputs, so neither can
-            # be planned standalone against an empty backend. This mirrors the
-            # rosa-hcp-dual-region/terraform/peering exclusion. They also opt out
-            # of `just regenerate-golden-file-all` by not providing a
-            # test/golden/golden.tfvars marker (see camunda/camunda-deployment-references#2761).
-            #
-            # - name: Run Terraform Golden Plan Comparison - Infra
-            #   uses: ./.github/actions/internal-terraform-golden-plan
-            #   env:
-            #       GH_TOKEN: ${{ github.token }}
-            #   with:
-            #       module-dir: ${{ env.MODULE_DIR_BASE }}infra/
-            #       s3-bucket-region: ${{ env.S3_BUCKET_REGION }}
-            #       s3-backend-bucket: ${{ env.S3_BACKEND_BUCKET }}
-            #       s3-bucket-key: ${{ env.S3_BUCKET_KEY }}
-            #
-            # - name: Run Terraform Golden Plan Comparison - App
-            #   uses: ./.github/actions/internal-terraform-golden-plan
-            #   env:
-            #       GH_TOKEN: ${{ github.token }}
-            #   with:
-            #       module-dir: ${{ env.MODULE_DIR_BASE }}app/
-            #       s3-bucket-region: ${{ env.S3_BUCKET_REGION }}
-            #       s3-backend-bucket: ${{ env.S3_BACKEND_BUCKET }}
-            #       s3-bucket-key: ${{ env.S3_BUCKET_KEY }}
-
-            # Only the vpc/ state is plannable standalone: it relies solely on
-            # data.aws_availability_zones and creates its resources from scratch.
+            # The three states are planned independently. vpc/ is plannable as-is;
+            # infra/ and app/ read a sibling state via terraform_remote_state (and
+            # infra/ does live subnet lookups), which the golden fixtures under each
+            # state's test/fixtures/golden/ neutralise with a static snapshot so the
+            # plan is deterministic and offline. app/ is the most valuable of the
+            # three — it captures the Camunda ECS task/service configuration.
             - name: Run Terraform Golden Plan Comparison - VPC
               uses: ./.github/actions/internal-terraform-golden-plan
               env:
                   GH_TOKEN: ${{ github.token }}
               with:
                   module-dir: ${{ env.MODULE_DIR_BASE }}vpc/
+                  s3-bucket-region: ${{ env.S3_BUCKET_REGION }}
+                  s3-backend-bucket: ${{ env.S3_BACKEND_BUCKET }}
+                  s3-bucket-key: ${{ env.S3_BUCKET_KEY }}
+
+            - name: Run Terraform Golden Plan Comparison - Infra
+              uses: ./.github/actions/internal-terraform-golden-plan
+              env:
+                  GH_TOKEN: ${{ github.token }}
+              with:
+                  module-dir: ${{ env.MODULE_DIR_BASE }}infra/
+                  s3-bucket-region: ${{ env.S3_BUCKET_REGION }}
+                  s3-backend-bucket: ${{ env.S3_BACKEND_BUCKET }}
+                  s3-bucket-key: ${{ env.S3_BUCKET_KEY }}
+
+            - name: Run Terraform Golden Plan Comparison - App
+              uses: ./.github/actions/internal-terraform-golden-plan
+              env:
+                  GH_TOKEN: ${{ github.token }}
+              with:
+                  module-dir: ${{ env.MODULE_DIR_BASE }}app/
                   s3-bucket-region: ${{ env.S3_BUCKET_REGION }}
                   s3-backend-bucket: ${{ env.S3_BACKEND_BUCKET }}
                   s3-bucket-key: ${{ env.S3_BUCKET_KEY }}

--- a/.github/workflows/aws_ecs_dual_region_fargate_golden.yml
+++ b/.github/workflows/aws_ecs_dual_region_fargate_golden.yml
@@ -32,8 +32,6 @@ env:
     S3_BUCKET_REGION: eu-central-1
     S3_BUCKET_KEY: golden.tfstate
 
-    MODULE_DIR_BASE: ./aws/containers/ecs-dual-region-fargate/terraform/
-
 jobs:
     triage:
         runs-on: ubuntu-slim
@@ -46,10 +44,22 @@ jobs:
               uses: ./.github/actions/internal-triage-skip
 
     compare:
-        runs-on: ubuntu-latest
         needs:
             - triage
         if: needs.triage.outputs.should_skip == 'false'
+        runs-on: ubuntu-latest
+        strategy:
+            fail-fast: false # report drift for every state, not just the first that fails
+            matrix:
+                # Each state is planned independently. vpc/ is plannable as-is;
+                # infra/ and app/ read a sibling state via terraform_remote_state
+                # (and infra/ does live subnet lookups), which the golden fixtures
+                # under each state's test/fixtures/golden/ neutralise with a static
+                # snapshot so the plan is deterministic and offline.
+                module:
+                    - ecs-dual-region-fargate/terraform/vpc/
+                    - ecs-dual-region-fargate/terraform/infra/
+                    - ecs-dual-region-fargate/terraform/app/
         permissions:
             contents: write
             pull-requests: write
@@ -69,38 +79,16 @@ jobs:
                   aws-profile: ${{ env.AWS_PROFILE }}
                   aws-region: ${{ env.AWS_REGION }}
 
-            # The three states are planned independently. vpc/ is plannable as-is;
-            # infra/ and app/ read a sibling state via terraform_remote_state (and
-            # infra/ does live subnet lookups), which the golden fixtures under each
-            # state's test/fixtures/golden/ neutralise with a static snapshot so the
-            # plan is deterministic and offline. app/ is the most valuable of the
-            # three — it captures the Camunda ECS task/service configuration.
-            - name: Run Terraform Golden Plan Comparison - VPC
-              uses: ./.github/actions/internal-terraform-golden-plan
-              env:
-                  GH_TOKEN: ${{ github.token }}
-              with:
-                  module-dir: ${{ env.MODULE_DIR_BASE }}vpc/
-                  s3-bucket-region: ${{ env.S3_BUCKET_REGION }}
-                  s3-backend-bucket: ${{ env.S3_BACKEND_BUCKET }}
-                  s3-bucket-key: ${{ env.S3_BUCKET_KEY }}
+            - name: Export module_dir depending on scenario
+              id: set-module-dir
+              run: echo "MODULE_DIR=./aws/containers/${{ matrix.module }}" | tee -a "$GITHUB_ENV"
 
-            - name: Run Terraform Golden Plan Comparison - Infra
+            - name: Run Terraform Golden Plan Comparison
               uses: ./.github/actions/internal-terraform-golden-plan
               env:
                   GH_TOKEN: ${{ github.token }}
               with:
-                  module-dir: ${{ env.MODULE_DIR_BASE }}infra/
-                  s3-bucket-region: ${{ env.S3_BUCKET_REGION }}
-                  s3-backend-bucket: ${{ env.S3_BACKEND_BUCKET }}
-                  s3-bucket-key: ${{ env.S3_BUCKET_KEY }}
-
-            - name: Run Terraform Golden Plan Comparison - App
-              uses: ./.github/actions/internal-terraform-golden-plan
-              env:
-                  GH_TOKEN: ${{ github.token }}
-              with:
-                  module-dir: ${{ env.MODULE_DIR_BASE }}app/
+                  module-dir: ${{ env.MODULE_DIR }}
                   s3-bucket-region: ${{ env.S3_BUCKET_REGION }}
                   s3-backend-bucket: ${{ env.S3_BACKEND_BUCKET }}
                   s3-bucket-key: ${{ env.S3_BUCKET_KEY }}

--- a/aws/containers/ecs-dual-region-fargate/terraform/app/test/fixtures/golden/README.md
+++ b/aws/containers/ecs-dual-region-fargate/terraform/app/test/fixtures/golden/README.md
@@ -1,0 +1,18 @@
+# golden
+
+<!-- BEGIN_TF_DOCS -->
+## Modules
+
+No modules.
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [terraform_remote_state.infra](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
+## Inputs
+
+No inputs.
+## Outputs
+
+No outputs.
+<!-- END_TF_DOCS -->

--- a/aws/containers/ecs-dual-region-fargate/terraform/app/test/fixtures/golden/fixture_infra_override.tf
+++ b/aws/containers/ecs-dual-region-fargate/terraform/app/test/fixtures/golden/fixture_infra_override.tf
@@ -1,0 +1,97 @@
+# Golden-plan fixture (Terraform override file, copied into the module root by
+# the `regenerate-golden-file` recipe and removed afterwards).
+#
+# The app/ state cannot be planned standalone because it reads the sibling
+# infra/ state via data.terraform_remote_state.infra over an S3 backend that
+# does not exist during golden generation. Here we:
+#   1. disable that read (count = 0) so no backend is contacted, and
+#   2. replace local.infra with a static, deterministic snapshot of the infra
+#      outputs the app consumes.
+# This makes the app plan fully offline and reproducible while still exercising
+# the real Camunda ECS resources (task definitions, services, env vars) — which
+# is the drift we want the golden file to catch.
+#
+# Values are placeholders; ARNs use account 000000000000 and are redacted from
+# the committed golden JSON by the recipe. secondary_storage_type = "rdbms"
+# matches the module default (Aurora Global; OpenSearch outputs are null).
+
+data "terraform_remote_state" "infra" {
+  count = 0
+}
+
+locals {
+  infra = {
+    # Region & naming
+    region_0               = "eu-west-2"
+    region_1               = "eu-west-3"
+    cluster_name           = "camunda"
+    secondary_storage_type = "rdbms"
+
+    # VPC (re-exported from vpc state)
+    vpc_region_0_id              = "vpc-00000000000000000"
+    vpc_region_1_id              = "vpc-11111111111111111"
+    vpc_region_0_private_subnets = ["subnet-000000000000000a0", "subnet-000000000000000b0", "subnet-000000000000000c0"]
+    vpc_region_1_private_subnets = ["subnet-000000000000000a1", "subnet-000000000000000b1", "subnet-000000000000000c1"]
+
+    # ECS clusters
+    ecs_cluster_region_0_id = "arn:aws:ecs:eu-west-2:000000000000:cluster/camunda-r0"
+    ecs_cluster_region_1_id = "arn:aws:ecs:eu-west-3:000000000000:cluster/camunda-r1"
+
+    # Load balancers
+    region_0_alb_endpoint                     = "camunda-r0-alb.eu-west-2.elb.amazonaws.com"
+    region_1_alb_endpoint                     = "camunda-r1-alb.eu-west-3.elb.amazonaws.com"
+    alb_listener_http_webapp_region_0_arn     = "arn:aws:elasticloadbalancing:eu-west-2:000000000000:listener/app/camunda-r0/0000000000000000/0000000000000000"
+    alb_listener_http_webapp_region_1_arn     = "arn:aws:elasticloadbalancing:eu-west-3:000000000000:listener/app/camunda-r1/1111111111111111/1111111111111111"
+    alb_listener_http_management_region_0_arn = "arn:aws:elasticloadbalancing:eu-west-2:000000000000:listener/app/camunda-r0/0000000000000000/0000000000000001"
+    alb_listener_http_management_region_1_arn = "arn:aws:elasticloadbalancing:eu-west-3:000000000000:listener/app/camunda-r1/1111111111111111/1111111111111112"
+    nlb_grpc_region_0_arn                     = "arn:aws:elasticloadbalancing:eu-west-2:000000000000:loadbalancer/net/camunda-r0-grpc/0000000000000000"
+    nlb_grpc_region_1_arn                     = "arn:aws:elasticloadbalancing:eu-west-3:000000000000:loadbalancer/net/camunda-r1-grpc/1111111111111111"
+    nlb_raft_region_0_arn                     = "arn:aws:elasticloadbalancing:eu-west-2:000000000000:loadbalancer/net/camunda-r0-raft/0000000000000000"
+    nlb_raft_region_1_arn                     = "arn:aws:elasticloadbalancing:eu-west-3:000000000000:loadbalancer/net/camunda-r1-raft/1111111111111111"
+    region_0_nlb_raft_endpoint                = "camunda-r0-raft.elb.eu-west-2.amazonaws.com"
+    region_1_nlb_raft_endpoint                = "camunda-r1-raft.elb.eu-west-3.amazonaws.com"
+    region_0_nlb_grpc_endpoint                = "camunda-r0-grpc.elb.eu-west-2.amazonaws.com"
+    region_1_nlb_grpc_endpoint                = "camunda-r1-grpc.elb.eu-west-3.amazonaws.com"
+
+    # Security groups
+    sg_camunda_ports_region_0_id  = "sg-0000000000000000a"
+    sg_camunda_ports_region_1_id  = "sg-0000000000000001a"
+    sg_package_80_443_region_0_id = "sg-0000000000000000b"
+    sg_package_80_443_region_1_id = "sg-0000000000000001b"
+    sg_efs_region_0_id            = "sg-0000000000000000c"
+    sg_efs_region_1_id            = "sg-0000000000000001c"
+
+    # IAM
+    ecs_task_execution_role_region_0_arn = "arn:aws:iam::000000000000:role/camunda-r0-task-execution"
+    ecs_task_execution_role_region_1_arn = "arn:aws:iam::000000000000:role/camunda-r1-task-execution"
+    rds_db_connect_policy_region_0_arn   = "arn:aws:iam::000000000000:policy/camunda-r0-rds-connect"
+    rds_db_connect_policy_region_1_arn   = "arn:aws:iam::000000000000:policy/camunda-r1-rds-connect"
+    s3_backup_access_policy_region_0_arn = "arn:aws:iam::000000000000:policy/camunda-r0-s3-backup"
+
+    # Secrets
+    admin_user_password                     = "golden-placeholder-admin-password"
+    admin_user_password_secret_region_0_arn = "arn:aws:secretsmanager:eu-west-2:000000000000:secret:camunda-r0-admin-000000"
+    admin_user_password_secret_region_1_arn = "arn:aws:secretsmanager:eu-west-3:000000000000:secret:camunda-r1-admin-111111"
+    connectors_password_secret_region_0_arn = "arn:aws:secretsmanager:eu-west-2:000000000000:secret:camunda-r0-connectors-000000"
+    connectors_password_secret_region_1_arn = "arn:aws:secretsmanager:eu-west-3:000000000000:secret:camunda-r1-connectors-111111"
+    registry_credentials_region_0_arn       = ""
+    registry_credentials_region_1_arn       = ""
+
+    # Aurora (rdbms mode)
+    aurora_global_writer_endpoint       = "camunda-global.cluster-r00000000000.eu-west-2.rds.amazonaws.com"
+    aurora_primary_cluster_endpoint     = "camunda-primary.cluster-r00000000000.eu-west-2.rds.amazonaws.com"
+    aurora_primary_cluster_identifier   = "camunda-primary"
+    aurora_secondary_cluster_identifier = "camunda-secondary"
+    aurora_secondary_cluster_endpoint   = "camunda-secondary.cluster-r11111111111.eu-west-3.rds.amazonaws.com"
+
+    # OpenSearch (null in rdbms mode)
+    opensearch_region_0_endpoint = null
+    opensearch_region_1_endpoint = null
+
+    # S3 backup / database
+    backup_bucket_region_0_name = "camunda-backup-eu-west-2"
+    s3_force_destroy            = true
+    db_name                     = "camunda"
+    db_admin_username           = "camunda"
+  }
+}

--- a/aws/containers/ecs-dual-region-fargate/terraform/app/test/golden/golden.tfvars
+++ b/aws/containers/ecs-dual-region-fargate/terraform/app/test/golden/golden.tfvars
@@ -1,0 +1,11 @@
+# use this file for vars without default values
+# for the golden file generation
+
+aws_profile = null # uses default AWS credential chain (env vars, default profile, instance profile)
+
+# The app state normally reads the sibling infra state over an S3 backend. For
+# golden generation that read is neutralised by test/fixtures/golden/fixture_infra_override.tf
+# (a static snapshot of the infra outputs), so these backend coordinates are
+# never actually contacted — they only satisfy the required-variable check.
+terraform_backend_bucket     = "golden-not-used"
+terraform_backend_key_prefix = "golden-not-used/"

--- a/aws/containers/ecs-dual-region-fargate/terraform/app/test/golden/tfplan-golden.json
+++ b/aws/containers/ecs-dual-region-fargate/terraform/app/test/golden/tfplan-golden.json
@@ -1,0 +1,3552 @@
+{
+  "child_modules": {
+    "module.connectors_region_0": {
+      "resources": {
+        "module.connectors_region_0.aws_ecs_service.connectors": {
+          "identity": {
+            "account_id": null,
+            "cluster": null,
+            "name": null,
+            "region": null
+          },
+          "identity_schema_version": 0,
+          "mode": "managed",
+          "name": "connectors",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 1,
+          "sensitive_values": {
+            "alarms": [],
+            "capacity_provider_strategy": [],
+            "deployment_circuit_breaker": [
+              {}
+            ],
+            "deployment_configuration": [],
+            "deployment_controller": [],
+            "load_balancer": [
+              {
+                "advanced_configuration": []
+              }
+            ],
+            "network_configuration": [
+              {
+                "security_groups": [
+                  false,
+                  false
+                ],
+                "subnets": [
+                  false,
+                  false,
+                  false
+                ]
+              }
+            ],
+            "ordered_placement_strategy": [],
+            "placement_constraints": [],
+            "service_connect_configuration": [
+              {
+                "access_log_configuration": [],
+                "log_configuration": [],
+                "service": []
+              }
+            ],
+            "service_registries": [],
+            "tags_all": {},
+            "timeouts": {},
+            "triggers": {},
+            "volume_configuration": [],
+            "vpc_lattice_configurations": []
+          },
+          "type": "aws_ecs_service",
+          "values": {
+            "alarms": [],
+            "capacity_provider_strategy": [],
+            "cluster": "ARN_REDACTED",
+            "deployment_circuit_breaker": [
+              {
+                "enable": true,
+                "rollback": false
+              }
+            ],
+            "deployment_controller": [],
+            "deployment_maximum_percent": 200,
+            "deployment_minimum_healthy_percent": 50,
+            "desired_count": 1,
+            "enable_ecs_managed_tags": false,
+            "enable_execute_command": false,
+            "force_delete": null,
+            "force_new_deployment": false,
+            "health_check_grace_period_seconds": 300,
+            "launch_type": "FARGATE",
+            "load_balancer": [
+              {
+                "advanced_configuration": [],
+                "container_name": "connectors",
+                "container_port": 8080,
+                "elb_name": ""
+              }
+            ],
+            "name": "camunda-r0-oc-connectors",
+            "network_configuration": [
+              {
+                "assign_public_ip": false,
+                "security_groups": [
+                  "sg-0000000000000000a",
+                  "sg-0000000000000000b"
+                ],
+                "subnets": [
+                  "subnet-000000000000000a0",
+                  "subnet-000000000000000b0",
+                  "subnet-000000000000000c0"
+                ]
+              }
+            ],
+            "ordered_placement_strategy": [],
+            "placement_constraints": [],
+            "propagate_tags": null,
+            "region": "eu-west-2",
+            "scheduling_strategy": "REPLICA",
+            "service_connect_configuration": [
+              {
+                "access_log_configuration": [],
+                "enabled": true,
+                "log_configuration": [],
+                "service": []
+              }
+            ],
+            "service_registries": [],
+            "sigint_rollback": null,
+            "tags": null,
+            "timeouts": {
+              "create": "30m",
+              "delete": "15m",
+              "update": "30m"
+            },
+            "volume_configuration": [],
+            "vpc_lattice_configurations": [],
+            "wait_for_steady_state": true
+          }
+        },
+        "module.connectors_region_0.aws_ecs_task_definition.connectors": {
+          "identity": {
+            "account_id": null,
+            "family": null,
+            "region": null,
+            "revision": null
+          },
+          "identity_schema_version": 0,
+          "mode": "managed",
+          "name": "connectors",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 1,
+          "sensitive_values": {
+            "ephemeral_storage": [],
+            "placement_constraints": [],
+            "proxy_configuration": [],
+            "requires_compatibilities": [
+              false
+            ],
+            "runtime_platform": [
+              {}
+            ],
+            "tags_all": {},
+            "volume": []
+          },
+          "type": "aws_ecs_task_definition",
+          "values": {
+            "container_definitions": "[{\"cpu\":2048,\"environment\":[{\"name\":\"CAMUNDA_CLIENT_AUTH_METHOD\",\"value\":\"basic\"},{\"name\":\"CAMUNDA_CLIENT_AUTH_USERNAME\",\"value\":\"connectors\"},{\"name\":\"CAMUNDA_CLIENT_GRPCADDRESS\",\"value\":\"http://orchestration-cluster-grpc:26500\"},{\"name\":\"CAMUNDA_CLIENT_MODE\",\"value\":\"self-managed\"},{\"name\":\"CAMUNDA_CLIENT_RESTADDRESS\",\"value\":\"http://orchestration-cluster-rest:8080\"},{\"name\":\"CAMUNDA_DATA_SECONDARYSTORAGE_AUTOCONFIGURECAMUNDAEXPORTER\",\"value\":\"false\"},{\"name\":\"CAMUNDA_DATA_SECONDARYSTORAGE_RDBMS_AUTODDL\",\"value\":\"true\"},{\"name\":\"CAMUNDA_DATA_SECONDARYSTORAGE_RDBMS_URL\",\"value\":\"jdbc:aws-wrapper:postgresql://camunda-global.cluster-r00000000000.eu-west-2.rds.amazonaws.com:5432/camunda?wrapperPlugins=iam,failover\\u0026globalClusterInstanceHostPatterns=?.r00000000000.eu-west-2.rds.amazonaws.com,?.r11111111111.eu-west-3.rds.amazonaws.com\"},{\"name\":\"CAMUNDA_DATA_SECONDARYSTORAGE_RDBMS_USERNAME\",\"value\":\"camunda\"},{\"name\":\"CAMUNDA_DATA_SECONDARYSTORAGE_TYPE\",\"value\":\"rdbms\"},{\"name\":\"SERVER_SERVLET_CONTEXT_PATH\",\"value\":\"/connectors\"},{\"name\":\"SPRING_DATASOURCE_DRIVER_CLASS_NAME\",\"value\":\"software.amazon.jdbc.Driver\"},{\"name\":\"SPRING_PROFILES_ACTIVE\",\"value\":\"connectors\"}],\"essential\":true,\"healthCheck\":{\"command\":[\"CMD-SHELL\",\"wget -qO- http://localhost:8080/connectors/actuator/health/readiness || exit 1\"],\"interval\":30,\"retries\":3,\"startPeriod\":120,\"timeout\":5},\"image\":\"camunda/connectors-bundle:8.10-SNAPSHOT\",\"logConfiguration\":{\"logDriver\":\"awslogs\",\"options\":{\"awslogs-group\":\"/ecs/camunda-r0-oc-camunda\",\"awslogs-multiline-pattern\":\"^\\\\d{4}-\\\\d{2}-\\\\d{2}T\\\\d{2}:\\\\d{2}:\\\\d{2}\\\\.\\\\d{3}Z\",\"awslogs-region\":\"eu-west-2\",\"awslogs-stream-prefix\":\"connectors\"}},\"memory\":4096,\"name\":\"connectors\",\"portMappings\":[{\"containerPort\":8080,\"hostPort\":8080,\"protocol\":\"tcp\"}],\"secrets\":[{\"name\":\"CAMUNDA_CLIENT_AUTH_PASSWORD\",\"valueFrom\":\"ARN_REDACTED",
+            "cpu": "2048",
+            "ephemeral_storage": [],
+            "execution_role_arn": "ARN_REDACTED",
+            "family": "camunda-r0-oc-connectors",
+            "ipc_mode": null,
+            "memory": "4096",
+            "network_mode": "awsvpc",
+            "pid_mode": null,
+            "placement_constraints": [],
+            "proxy_configuration": [],
+            "region": "eu-west-2",
+            "requires_compatibilities": [
+              "FARGATE"
+            ],
+            "runtime_platform": [
+              {
+                "cpu_architecture": "X86_64",
+                "operating_system_family": "LINUX"
+              }
+            ],
+            "skip_destroy": false,
+            "tags": null,
+            "track_latest": false,
+            "volume": []
+          }
+        },
+        "module.connectors_region_0.aws_iam_policy.connectors_logs_policy": {
+          "identity": {
+            "arn": null
+          },
+          "identity_schema_version": 0,
+          "mode": "managed",
+          "name": "connectors_logs_policy",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "tags": {},
+            "tags_all": {}
+          },
+          "type": "aws_iam_policy",
+          "values": {
+            "delay_after_policy_creation_in_ms": null,
+            "description": null,
+            "name": "camunda-r0-oc-connectors-logs-policy",
+            "path": "/",
+            "policy": "{\"Statement\":[{\"Action\":[\"logs:CreateLogStream\",\"logs:DescribeLogGroups\",\"logs:DescribeLogStreams\",\"logs:PutLogEvents\"],\"Effect\":\"Allow\",\"Resource\":[\"ARN_REDACTED",
+            "tags": {
+              "Name": "camunda-r0-oc-connectors-logs-policy"
+            },
+            "tags_all": {
+              "Name": "camunda-r0-oc-connectors-logs-policy"
+            }
+          }
+        },
+        "module.connectors_region_0.aws_iam_policy.ecs_exec_policy": {
+          "identity": {
+            "arn": null
+          },
+          "identity_schema_version": 0,
+          "mode": "managed",
+          "name": "ecs_exec_policy",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "tags": {},
+            "tags_all": {}
+          },
+          "type": "aws_iam_policy",
+          "values": {
+            "delay_after_policy_creation_in_ms": null,
+            "description": null,
+            "name": "camunda-r0-oc-connectors-exec-policy",
+            "path": "/",
+            "policy": "{\"Statement\":[{\"Action\":[\"ssmmessages:CreateControlChannel\",\"ssmmessages:CreateDataChannel\",\"ssmmessages:OpenControlChannel\",\"ssmmessages:OpenDataChannel\"],\"Condition\":{\"StringEquals\":{\"aws:RequestedRegion\":\"eu-west-2\"}},\"Effect\":\"Allow\",\"Resource\":\"*\",\"Sid\":\"AllowSSMMessaging\"}],\"Version\":\"2012-10-17\"}",
+            "tags": {
+              "Name": "camunda-r0-oc-connectors-exec-policy"
+            },
+            "tags_all": {
+              "Name": "camunda-r0-oc-connectors-exec-policy"
+            }
+          }
+        },
+        "module.connectors_region_0.aws_iam_role.ecs_task_role": {
+          "identity": {
+            "account_id": null,
+            "name": null
+          },
+          "identity_schema_version": 0,
+          "mode": "managed",
+          "name": "ecs_task_role",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "inline_policy": [],
+            "managed_policy_arns": [],
+            "tags": {},
+            "tags_all": {}
+          },
+          "type": "aws_iam_role",
+          "values": {
+            "assume_role_policy": "{\"Statement\":[{\"Action\":\"sts:AssumeRole\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"ecs-tasks.amazonaws.com\"}}],\"Version\":\"2012-10-17\"}",
+            "description": null,
+            "force_detach_policies": false,
+            "max_session_duration": 3600,
+            "name": "camunda-r0-oc-connectors-task-role",
+            "path": "/",
+            "permissions_boundary": null,
+            "tags": {
+              "Name": "camunda-r0-oc-connectors-task-role"
+            },
+            "tags_all": {
+              "Name": "camunda-r0-oc-connectors-task-role"
+            }
+          }
+        },
+        "module.connectors_region_0.aws_iam_role_policy_attachment.connectors_logs_policy_attachment": {
+          "identity": {
+            "account_id": null,
+            "policy_arn": null,
+            "role": null
+          },
+          "identity_schema_version": 0,
+          "mode": "managed",
+          "name": "connectors_logs_policy_attachment",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {},
+          "type": "aws_iam_role_policy_attachment",
+          "values": {
+            "role": "camunda-r0-oc-connectors-task-role"
+          }
+        },
+        "module.connectors_region_0.aws_iam_role_policy_attachment.ecs_exec_policy_attachment": {
+          "identity": {
+            "account_id": null,
+            "policy_arn": null,
+            "role": null
+          },
+          "identity_schema_version": 0,
+          "mode": "managed",
+          "name": "ecs_exec_policy_attachment",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {},
+          "type": "aws_iam_role_policy_attachment",
+          "values": {
+            "role": "camunda-r0-oc-connectors-task-role"
+          }
+        },
+        "module.connectors_region_0.aws_iam_role_policy_attachment.task_role_policy_attachment[0]": {
+          "identity": {
+            "account_id": null,
+            "policy_arn": null,
+            "role": null
+          },
+          "identity_schema_version": 0,
+          "index": 0,
+          "mode": "managed",
+          "name": "task_role_policy_attachment",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {},
+          "type": "aws_iam_role_policy_attachment",
+          "values": {
+            "policy_arn": "ARN_REDACTED",
+            "role": "camunda-r0-oc-connectors-task-role"
+          }
+        },
+        "module.connectors_region_0.aws_lb_listener_rule.http_webapp[0]": {
+          "identity": {
+            "arn": null
+          },
+          "identity_schema_version": 0,
+          "index": 0,
+          "mode": "managed",
+          "name": "http_webapp",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "action": [
+              {
+                "authenticate_cognito": [],
+                "authenticate_oidc": [],
+                "fixed_response": [],
+                "forward": [],
+                "jwt_validation": [],
+                "redirect": []
+              }
+            ],
+            "condition": [
+              {
+                "host_header": [],
+                "http_header": [],
+                "http_request_method": [],
+                "path_pattern": [
+                  {
+                    "regex_values": [],
+                    "values": [
+                      false
+                    ]
+                  }
+                ],
+                "query_string": [],
+                "source_ip": []
+              }
+            ],
+            "tags_all": {},
+            "transform": []
+          },
+          "type": "aws_lb_listener_rule",
+          "values": {
+            "action": [
+              {
+                "authenticate_cognito": [],
+                "authenticate_oidc": [],
+                "fixed_response": [],
+                "forward": [],
+                "jwt_validation": [],
+                "redirect": [],
+                "type": "forward"
+              }
+            ],
+            "condition": [
+              {
+                "host_header": [],
+                "http_header": [],
+                "http_request_method": [],
+                "path_pattern": [
+                  {
+                    "regex_values": [],
+                    "values": [
+                      "/connectors*"
+                    ]
+                  }
+                ],
+                "query_string": [],
+                "source_ip": []
+              }
+            ],
+            "listener_arn": "ARN_REDACTED",
+            "priority": 50,
+            "region": "eu-west-2",
+            "tags": null,
+            "transform": []
+          }
+        },
+        "module.connectors_region_0.aws_lb_target_group.main": {
+          "identity": {
+            "arn": null
+          },
+          "identity_schema_version": 0,
+          "mode": "managed",
+          "name": "main",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "health_check": [
+              {}
+            ],
+            "load_balancer_arns": [],
+            "stickiness": [
+              {}
+            ],
+            "tags_all": {},
+            "target_failover": [],
+            "target_group_health": [],
+            "target_health_state": []
+          },
+          "type": "aws_lb_target_group",
+          "values": {
+            "deregistration_delay": "30",
+            "health_check": [
+              {
+                "enabled": true,
+                "healthy_threshold": 2,
+                "interval": 30,
+                "path": "/connectors/actuator/health/readiness",
+                "port": "8080",
+                "protocol": "HTTP",
+                "timeout": 5,
+                "unhealthy_threshold": 2
+              }
+            ],
+            "lambda_multi_value_headers_enabled": false,
+            "name": "camunda-r0-oc-con-tg-8080",
+            "port": 8080,
+            "protocol": "HTTP",
+            "proxy_protocol_v2": false,
+            "region": "eu-west-2",
+            "slow_start": 0,
+            "stickiness": [
+              {
+                "cookie_duration": 43200,
+                "cookie_name": null,
+                "enabled": true,
+                "type": "lb_cookie"
+              }
+            ],
+            "tags": null,
+            "target_control_port": null,
+            "target_type": "ip",
+            "vpc_id": "vpc-00000000000000000"
+          }
+        }
+      }
+    },
+    "module.connectors_region_1": {
+      "resources": {
+        "module.connectors_region_1.aws_ecs_service.connectors": {
+          "identity": {
+            "account_id": null,
+            "cluster": null,
+            "name": null,
+            "region": null
+          },
+          "identity_schema_version": 0,
+          "mode": "managed",
+          "name": "connectors",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 1,
+          "sensitive_values": {
+            "alarms": [],
+            "capacity_provider_strategy": [],
+            "deployment_circuit_breaker": [
+              {}
+            ],
+            "deployment_configuration": [],
+            "deployment_controller": [],
+            "load_balancer": [
+              {
+                "advanced_configuration": []
+              }
+            ],
+            "network_configuration": [
+              {
+                "security_groups": [
+                  false,
+                  false
+                ],
+                "subnets": [
+                  false,
+                  false,
+                  false
+                ]
+              }
+            ],
+            "ordered_placement_strategy": [],
+            "placement_constraints": [],
+            "service_connect_configuration": [
+              {
+                "access_log_configuration": [],
+                "log_configuration": [],
+                "service": []
+              }
+            ],
+            "service_registries": [],
+            "tags_all": {},
+            "timeouts": {},
+            "triggers": {},
+            "volume_configuration": [],
+            "vpc_lattice_configurations": []
+          },
+          "type": "aws_ecs_service",
+          "values": {
+            "alarms": [],
+            "capacity_provider_strategy": [],
+            "cluster": "ARN_REDACTED",
+            "deployment_circuit_breaker": [
+              {
+                "enable": true,
+                "rollback": false
+              }
+            ],
+            "deployment_controller": [],
+            "deployment_maximum_percent": 200,
+            "deployment_minimum_healthy_percent": 50,
+            "desired_count": 1,
+            "enable_ecs_managed_tags": false,
+            "enable_execute_command": false,
+            "force_delete": null,
+            "force_new_deployment": false,
+            "health_check_grace_period_seconds": 300,
+            "launch_type": "FARGATE",
+            "load_balancer": [
+              {
+                "advanced_configuration": [],
+                "container_name": "connectors",
+                "container_port": 8080,
+                "elb_name": ""
+              }
+            ],
+            "name": "camunda-r1-oc-connectors",
+            "network_configuration": [
+              {
+                "assign_public_ip": false,
+                "security_groups": [
+                  "sg-0000000000000001a",
+                  "sg-0000000000000001b"
+                ],
+                "subnets": [
+                  "subnet-000000000000000a1",
+                  "subnet-000000000000000b1",
+                  "subnet-000000000000000c1"
+                ]
+              }
+            ],
+            "ordered_placement_strategy": [],
+            "placement_constraints": [],
+            "propagate_tags": null,
+            "region": "eu-west-3",
+            "scheduling_strategy": "REPLICA",
+            "service_connect_configuration": [
+              {
+                "access_log_configuration": [],
+                "enabled": true,
+                "log_configuration": [],
+                "service": []
+              }
+            ],
+            "service_registries": [],
+            "sigint_rollback": null,
+            "tags": null,
+            "timeouts": {
+              "create": "30m",
+              "delete": "15m",
+              "update": "30m"
+            },
+            "volume_configuration": [],
+            "vpc_lattice_configurations": [],
+            "wait_for_steady_state": true
+          }
+        },
+        "module.connectors_region_1.aws_ecs_task_definition.connectors": {
+          "identity": {
+            "account_id": null,
+            "family": null,
+            "region": null,
+            "revision": null
+          },
+          "identity_schema_version": 0,
+          "mode": "managed",
+          "name": "connectors",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 1,
+          "sensitive_values": {
+            "ephemeral_storage": [],
+            "placement_constraints": [],
+            "proxy_configuration": [],
+            "requires_compatibilities": [
+              false
+            ],
+            "runtime_platform": [
+              {}
+            ],
+            "tags_all": {},
+            "volume": []
+          },
+          "type": "aws_ecs_task_definition",
+          "values": {
+            "container_definitions": "[{\"cpu\":2048,\"environment\":[{\"name\":\"CAMUNDA_CLIENT_AUTH_METHOD\",\"value\":\"basic\"},{\"name\":\"CAMUNDA_CLIENT_AUTH_USERNAME\",\"value\":\"connectors\"},{\"name\":\"CAMUNDA_CLIENT_GRPCADDRESS\",\"value\":\"http://orchestration-cluster-grpc:26500\"},{\"name\":\"CAMUNDA_CLIENT_MODE\",\"value\":\"self-managed\"},{\"name\":\"CAMUNDA_CLIENT_RESTADDRESS\",\"value\":\"http://orchestration-cluster-rest:8080\"},{\"name\":\"CAMUNDA_DATA_SECONDARYSTORAGE_AUTOCONFIGURECAMUNDAEXPORTER\",\"value\":\"false\"},{\"name\":\"CAMUNDA_DATA_SECONDARYSTORAGE_RDBMS_AUTODDL\",\"value\":\"true\"},{\"name\":\"CAMUNDA_DATA_SECONDARYSTORAGE_RDBMS_URL\",\"value\":\"jdbc:aws-wrapper:postgresql://camunda-global.cluster-r00000000000.eu-west-2.rds.amazonaws.com:5432/camunda?wrapperPlugins=iam,failover\\u0026globalClusterInstanceHostPatterns=?.r00000000000.eu-west-2.rds.amazonaws.com,?.r11111111111.eu-west-3.rds.amazonaws.com\"},{\"name\":\"CAMUNDA_DATA_SECONDARYSTORAGE_RDBMS_USERNAME\",\"value\":\"camunda\"},{\"name\":\"CAMUNDA_DATA_SECONDARYSTORAGE_TYPE\",\"value\":\"rdbms\"},{\"name\":\"SERVER_SERVLET_CONTEXT_PATH\",\"value\":\"/connectors\"},{\"name\":\"SPRING_DATASOURCE_DRIVER_CLASS_NAME\",\"value\":\"software.amazon.jdbc.Driver\"},{\"name\":\"SPRING_PROFILES_ACTIVE\",\"value\":\"connectors\"}],\"essential\":true,\"healthCheck\":{\"command\":[\"CMD-SHELL\",\"wget -qO- http://localhost:8080/connectors/actuator/health/readiness || exit 1\"],\"interval\":30,\"retries\":3,\"startPeriod\":120,\"timeout\":5},\"image\":\"camunda/connectors-bundle:8.10-SNAPSHOT\",\"logConfiguration\":{\"logDriver\":\"awslogs\",\"options\":{\"awslogs-group\":\"/ecs/camunda-r1-oc-camunda\",\"awslogs-multiline-pattern\":\"^\\\\d{4}-\\\\d{2}-\\\\d{2}T\\\\d{2}:\\\\d{2}:\\\\d{2}\\\\.\\\\d{3}Z\",\"awslogs-region\":\"eu-west-3\",\"awslogs-stream-prefix\":\"connectors\"}},\"memory\":4096,\"name\":\"connectors\",\"portMappings\":[{\"containerPort\":8080,\"hostPort\":8080,\"protocol\":\"tcp\"}],\"secrets\":[{\"name\":\"CAMUNDA_CLIENT_AUTH_PASSWORD\",\"valueFrom\":\"ARN_REDACTED",
+            "cpu": "2048",
+            "ephemeral_storage": [],
+            "execution_role_arn": "ARN_REDACTED",
+            "family": "camunda-r1-oc-connectors",
+            "ipc_mode": null,
+            "memory": "4096",
+            "network_mode": "awsvpc",
+            "pid_mode": null,
+            "placement_constraints": [],
+            "proxy_configuration": [],
+            "region": "eu-west-3",
+            "requires_compatibilities": [
+              "FARGATE"
+            ],
+            "runtime_platform": [
+              {
+                "cpu_architecture": "X86_64",
+                "operating_system_family": "LINUX"
+              }
+            ],
+            "skip_destroy": false,
+            "tags": null,
+            "track_latest": false,
+            "volume": []
+          }
+        },
+        "module.connectors_region_1.aws_iam_policy.connectors_logs_policy": {
+          "identity": {
+            "arn": null
+          },
+          "identity_schema_version": 0,
+          "mode": "managed",
+          "name": "connectors_logs_policy",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "tags": {},
+            "tags_all": {}
+          },
+          "type": "aws_iam_policy",
+          "values": {
+            "delay_after_policy_creation_in_ms": null,
+            "description": null,
+            "name": "camunda-r1-oc-connectors-logs-policy",
+            "path": "/",
+            "policy": "{\"Statement\":[{\"Action\":[\"logs:CreateLogStream\",\"logs:DescribeLogGroups\",\"logs:DescribeLogStreams\",\"logs:PutLogEvents\"],\"Effect\":\"Allow\",\"Resource\":[\"ARN_REDACTED",
+            "tags": {
+              "Name": "camunda-r1-oc-connectors-logs-policy"
+            },
+            "tags_all": {
+              "Name": "camunda-r1-oc-connectors-logs-policy"
+            }
+          }
+        },
+        "module.connectors_region_1.aws_iam_policy.ecs_exec_policy": {
+          "identity": {
+            "arn": null
+          },
+          "identity_schema_version": 0,
+          "mode": "managed",
+          "name": "ecs_exec_policy",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "tags": {},
+            "tags_all": {}
+          },
+          "type": "aws_iam_policy",
+          "values": {
+            "delay_after_policy_creation_in_ms": null,
+            "description": null,
+            "name": "camunda-r1-oc-connectors-exec-policy",
+            "path": "/",
+            "policy": "{\"Statement\":[{\"Action\":[\"ssmmessages:CreateControlChannel\",\"ssmmessages:CreateDataChannel\",\"ssmmessages:OpenControlChannel\",\"ssmmessages:OpenDataChannel\"],\"Condition\":{\"StringEquals\":{\"aws:RequestedRegion\":\"eu-west-3\"}},\"Effect\":\"Allow\",\"Resource\":\"*\",\"Sid\":\"AllowSSMMessaging\"}],\"Version\":\"2012-10-17\"}",
+            "tags": {
+              "Name": "camunda-r1-oc-connectors-exec-policy"
+            },
+            "tags_all": {
+              "Name": "camunda-r1-oc-connectors-exec-policy"
+            }
+          }
+        },
+        "module.connectors_region_1.aws_iam_role.ecs_task_role": {
+          "identity": {
+            "account_id": null,
+            "name": null
+          },
+          "identity_schema_version": 0,
+          "mode": "managed",
+          "name": "ecs_task_role",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "inline_policy": [],
+            "managed_policy_arns": [],
+            "tags": {},
+            "tags_all": {}
+          },
+          "type": "aws_iam_role",
+          "values": {
+            "assume_role_policy": "{\"Statement\":[{\"Action\":\"sts:AssumeRole\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"ecs-tasks.amazonaws.com\"}}],\"Version\":\"2012-10-17\"}",
+            "description": null,
+            "force_detach_policies": false,
+            "max_session_duration": 3600,
+            "name": "camunda-r1-oc-connectors-task-role",
+            "path": "/",
+            "permissions_boundary": null,
+            "tags": {
+              "Name": "camunda-r1-oc-connectors-task-role"
+            },
+            "tags_all": {
+              "Name": "camunda-r1-oc-connectors-task-role"
+            }
+          }
+        },
+        "module.connectors_region_1.aws_iam_role_policy_attachment.connectors_logs_policy_attachment": {
+          "identity": {
+            "account_id": null,
+            "policy_arn": null,
+            "role": null
+          },
+          "identity_schema_version": 0,
+          "mode": "managed",
+          "name": "connectors_logs_policy_attachment",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {},
+          "type": "aws_iam_role_policy_attachment",
+          "values": {
+            "role": "camunda-r1-oc-connectors-task-role"
+          }
+        },
+        "module.connectors_region_1.aws_iam_role_policy_attachment.ecs_exec_policy_attachment": {
+          "identity": {
+            "account_id": null,
+            "policy_arn": null,
+            "role": null
+          },
+          "identity_schema_version": 0,
+          "mode": "managed",
+          "name": "ecs_exec_policy_attachment",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {},
+          "type": "aws_iam_role_policy_attachment",
+          "values": {
+            "role": "camunda-r1-oc-connectors-task-role"
+          }
+        },
+        "module.connectors_region_1.aws_iam_role_policy_attachment.task_role_policy_attachment[0]": {
+          "identity": {
+            "account_id": null,
+            "policy_arn": null,
+            "role": null
+          },
+          "identity_schema_version": 0,
+          "index": 0,
+          "mode": "managed",
+          "name": "task_role_policy_attachment",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {},
+          "type": "aws_iam_role_policy_attachment",
+          "values": {
+            "policy_arn": "ARN_REDACTED",
+            "role": "camunda-r1-oc-connectors-task-role"
+          }
+        },
+        "module.connectors_region_1.aws_lb_listener_rule.http_webapp[0]": {
+          "identity": {
+            "arn": null
+          },
+          "identity_schema_version": 0,
+          "index": 0,
+          "mode": "managed",
+          "name": "http_webapp",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "action": [
+              {
+                "authenticate_cognito": [],
+                "authenticate_oidc": [],
+                "fixed_response": [],
+                "forward": [],
+                "jwt_validation": [],
+                "redirect": []
+              }
+            ],
+            "condition": [
+              {
+                "host_header": [],
+                "http_header": [],
+                "http_request_method": [],
+                "path_pattern": [
+                  {
+                    "regex_values": [],
+                    "values": [
+                      false
+                    ]
+                  }
+                ],
+                "query_string": [],
+                "source_ip": []
+              }
+            ],
+            "tags_all": {},
+            "transform": []
+          },
+          "type": "aws_lb_listener_rule",
+          "values": {
+            "action": [
+              {
+                "authenticate_cognito": [],
+                "authenticate_oidc": [],
+                "fixed_response": [],
+                "forward": [],
+                "jwt_validation": [],
+                "redirect": [],
+                "type": "forward"
+              }
+            ],
+            "condition": [
+              {
+                "host_header": [],
+                "http_header": [],
+                "http_request_method": [],
+                "path_pattern": [
+                  {
+                    "regex_values": [],
+                    "values": [
+                      "/connectors*"
+                    ]
+                  }
+                ],
+                "query_string": [],
+                "source_ip": []
+              }
+            ],
+            "listener_arn": "ARN_REDACTED",
+            "priority": 50,
+            "region": "eu-west-3",
+            "tags": null,
+            "transform": []
+          }
+        },
+        "module.connectors_region_1.aws_lb_target_group.main": {
+          "identity": {
+            "arn": null
+          },
+          "identity_schema_version": 0,
+          "mode": "managed",
+          "name": "main",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "health_check": [
+              {}
+            ],
+            "load_balancer_arns": [],
+            "stickiness": [
+              {}
+            ],
+            "tags_all": {},
+            "target_failover": [],
+            "target_group_health": [],
+            "target_health_state": []
+          },
+          "type": "aws_lb_target_group",
+          "values": {
+            "deregistration_delay": "30",
+            "health_check": [
+              {
+                "enabled": true,
+                "healthy_threshold": 2,
+                "interval": 30,
+                "path": "/connectors/actuator/health/readiness",
+                "port": "8080",
+                "protocol": "HTTP",
+                "timeout": 5,
+                "unhealthy_threshold": 2
+              }
+            ],
+            "lambda_multi_value_headers_enabled": false,
+            "name": "camunda-r1-oc-con-tg-8080",
+            "port": 8080,
+            "protocol": "HTTP",
+            "proxy_protocol_v2": false,
+            "region": "eu-west-3",
+            "slow_start": 0,
+            "stickiness": [
+              {
+                "cookie_duration": 43200,
+                "cookie_name": null,
+                "enabled": true,
+                "type": "lb_cookie"
+              }
+            ],
+            "tags": null,
+            "target_control_port": null,
+            "target_type": "ip",
+            "vpc_id": "vpc-11111111111111111"
+          }
+        }
+      }
+    },
+    "module.orchestration_cluster_region_0": {
+      "resources": {
+        "module.orchestration_cluster_region_0.aws_cloudwatch_log_group.orchestration_cluster_log_group": {
+          "identity": {
+            "account_id": null,
+            "name": null,
+            "region": null
+          },
+          "identity_schema_version": 0,
+          "mode": "managed",
+          "name": "orchestration_cluster_log_group",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "tags": {},
+            "tags_all": {}
+          },
+          "type": "aws_cloudwatch_log_group",
+          "values": {
+            "kms_key_id": null,
+            "name": "/ecs/camunda-r0-oc-camunda",
+            "region": "eu-west-2",
+            "retention_in_days": 30,
+            "skip_destroy": false,
+            "tags": {
+              "Name": "camunda-r0-oc-oc-log-group"
+            },
+            "tags_all": {
+              "Name": "camunda-r0-oc-oc-log-group"
+            }
+          }
+        },
+        "module.orchestration_cluster_region_0.aws_cloudwatch_log_stream.orchestration_cluster_log_stream": {
+          "identity": {
+            "account_id": null,
+            "log_group_name": null,
+            "name": null,
+            "region": null
+          },
+          "identity_schema_version": 0,
+          "mode": "managed",
+          "name": "orchestration_cluster_log_stream",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {},
+          "type": "aws_cloudwatch_log_stream",
+          "values": {
+            "log_group_name": "/ecs/camunda-r0-oc-camunda",
+            "name": "camunda-r0-oc-orchestration-cluster-log-stream",
+            "region": "eu-west-2"
+          }
+        },
+        "module.orchestration_cluster_region_0.aws_ecs_service.orchestration_cluster": {
+          "identity": {
+            "account_id": null,
+            "cluster": null,
+            "name": null,
+            "region": null
+          },
+          "identity_schema_version": 0,
+          "mode": "managed",
+          "name": "orchestration_cluster",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 1,
+          "sensitive_values": {
+            "alarms": [],
+            "capacity_provider_strategy": [],
+            "deployment_circuit_breaker": [
+              {}
+            ],
+            "deployment_configuration": [],
+            "deployment_controller": [],
+            "load_balancer": [
+              {
+                "advanced_configuration": []
+              },
+              {
+                "advanced_configuration": []
+              },
+              {
+                "advanced_configuration": []
+              }
+            ],
+            "network_configuration": [
+              {
+                "security_groups": [
+                  false,
+                  false,
+                  false
+                ],
+                "subnets": [
+                  false,
+                  false,
+                  false
+                ]
+              }
+            ],
+            "ordered_placement_strategy": [],
+            "placement_constraints": [],
+            "service_connect_configuration": [
+              {
+                "access_log_configuration": [],
+                "log_configuration": [],
+                "service": [
+                  {
+                    "client_alias": [
+                      {
+                        "test_traffic_rules": []
+                      }
+                    ],
+                    "timeout": [],
+                    "tls": []
+                  },
+                  {
+                    "client_alias": [
+                      {
+                        "test_traffic_rules": []
+                      }
+                    ],
+                    "timeout": [],
+                    "tls": []
+                  },
+                  {
+                    "client_alias": [
+                      {
+                        "test_traffic_rules": []
+                      }
+                    ],
+                    "timeout": [],
+                    "tls": []
+                  }
+                ]
+              }
+            ],
+            "service_registries": [
+              {}
+            ],
+            "tags_all": {},
+            "timeouts": {},
+            "triggers": {},
+            "volume_configuration": [],
+            "vpc_lattice_configurations": []
+          },
+          "type": "aws_ecs_service",
+          "values": {
+            "alarms": [],
+            "capacity_provider_strategy": [],
+            "cluster": "ARN_REDACTED",
+            "deployment_circuit_breaker": [
+              {
+                "enable": false,
+                "rollback": false
+              }
+            ],
+            "deployment_controller": [],
+            "deployment_maximum_percent": 100,
+            "deployment_minimum_healthy_percent": 66,
+            "desired_count": 4,
+            "enable_ecs_managed_tags": false,
+            "enable_execute_command": true,
+            "force_delete": null,
+            "force_new_deployment": false,
+            "health_check_grace_period_seconds": 1200,
+            "launch_type": "FARGATE",
+            "load_balancer": [
+              {
+                "advanced_configuration": [],
+                "container_name": "orchestration-cluster",
+                "container_port": 26500,
+                "elb_name": ""
+              },
+              {
+                "advanced_configuration": [],
+                "container_name": "orchestration-cluster",
+                "container_port": 26502,
+                "elb_name": ""
+              },
+              {
+                "advanced_configuration": [],
+                "container_name": "orchestration-cluster",
+                "container_port": 8080,
+                "elb_name": ""
+              }
+            ],
+            "name": "camunda-r0-oc-orchestration-cluster",
+            "network_configuration": [
+              {
+                "assign_public_ip": false,
+                "security_groups": [
+                  "sg-0000000000000000a",
+                  "sg-0000000000000000b",
+                  "sg-0000000000000000c"
+                ],
+                "subnets": [
+                  "subnet-000000000000000a0",
+                  "subnet-000000000000000b0",
+                  "subnet-000000000000000c0"
+                ]
+              }
+            ],
+            "ordered_placement_strategy": [],
+            "placement_constraints": [],
+            "propagate_tags": null,
+            "region": "eu-west-2",
+            "scheduling_strategy": "REPLICA",
+            "service_connect_configuration": [
+              {
+                "access_log_configuration": [],
+                "enabled": true,
+                "log_configuration": [],
+                "service": [
+                  {
+                    "client_alias": [
+                      {
+                        "dns_name": "orchestration-cluster-grpc",
+                        "port": 26500,
+                        "test_traffic_rules": []
+                      }
+                    ],
+                    "discovery_name": "orchestration-cluster-grpc",
+                    "ingress_port_override": null,
+                    "port_name": "grpc",
+                    "timeout": [],
+                    "tls": []
+                  },
+                  {
+                    "client_alias": [
+                      {
+                        "dns_name": "orchestration-cluster-sc",
+                        "port": 26502,
+                        "test_traffic_rules": []
+                      }
+                    ],
+                    "discovery_name": "orchestration-cluster-sc",
+                    "ingress_port_override": null,
+                    "port_name": "internal-api",
+                    "timeout": [],
+                    "tls": []
+                  },
+                  {
+                    "client_alias": [
+                      {
+                        "dns_name": "orchestration-cluster-rest",
+                        "port": 8080,
+                        "test_traffic_rules": []
+                      }
+                    ],
+                    "discovery_name": "orchestration-cluster-rest",
+                    "ingress_port_override": null,
+                    "port_name": "rest",
+                    "timeout": [],
+                    "tls": []
+                  }
+                ]
+              }
+            ],
+            "service_registries": [
+              {
+                "container_name": null,
+                "container_port": null,
+                "port": null
+              }
+            ],
+            "sigint_rollback": null,
+            "tags": null,
+            "timeouts": {
+              "create": "30m",
+              "delete": "15m",
+              "update": "30m"
+            },
+            "volume_configuration": [],
+            "vpc_lattice_configurations": [],
+            "wait_for_steady_state": true
+          }
+        },
+        "module.orchestration_cluster_region_0.aws_ecs_task_definition.orchestration_cluster": {
+          "identity": {
+            "account_id": null,
+            "family": null,
+            "region": null,
+            "revision": null
+          },
+          "identity_schema_version": 0,
+          "mode": "managed",
+          "name": "orchestration_cluster",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 1,
+          "sensitive_values": {
+            "ephemeral_storage": [],
+            "placement_constraints": [],
+            "proxy_configuration": [],
+            "requires_compatibilities": [
+              false
+            ],
+            "runtime_platform": [
+              {}
+            ],
+            "tags_all": {},
+            "volume": [
+              {
+                "docker_volume_configuration": [],
+                "efs_volume_configuration": [
+                  {
+                    "authorization_config": [
+                      {}
+                    ]
+                  }
+                ],
+                "fsx_windows_file_server_volume_configuration": [],
+                "s3files_volume_configuration": []
+              }
+            ]
+          },
+          "type": "aws_ecs_task_definition",
+          "values": {
+            "cpu": "4096",
+            "ephemeral_storage": [],
+            "execution_role_arn": "ARN_REDACTED",
+            "family": "camunda-r0-oc-orchestration-cluster",
+            "ipc_mode": null,
+            "memory": "8192",
+            "network_mode": "awsvpc",
+            "pid_mode": null,
+            "placement_constraints": [],
+            "proxy_configuration": [],
+            "region": "eu-west-2",
+            "requires_compatibilities": [
+              "FARGATE"
+            ],
+            "runtime_platform": [
+              {
+                "cpu_architecture": "X86_64",
+                "operating_system_family": "LINUX"
+              }
+            ],
+            "skip_destroy": false,
+            "tags": null,
+            "track_latest": false,
+            "volume": [
+              {
+                "docker_volume_configuration": [],
+                "efs_volume_configuration": [
+                  {
+                    "authorization_config": [
+                      {
+                        "iam": "ENABLED"
+                      }
+                    ],
+                    "root_directory": "/",
+                    "transit_encryption": "ENABLED",
+                    "transit_encryption_port": 0
+                  }
+                ],
+                "fsx_windows_file_server_volume_configuration": [],
+                "host_path": "",
+                "name": "camunda-volume",
+                "s3files_volume_configuration": []
+              }
+            ]
+          }
+        },
+        "module.orchestration_cluster_region_0.aws_efs_access_point.camunda_data": {
+          "mode": "managed",
+          "name": "camunda_data",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "posix_user": [
+              {}
+            ],
+            "root_directory": [
+              {
+                "creation_info": [
+                  {}
+                ]
+              }
+            ],
+            "tags": {},
+            "tags_all": {}
+          },
+          "type": "aws_efs_access_point",
+          "values": {
+            "posix_user": [
+              {
+                "gid": 1000,
+                "secondary_gids": null,
+                "uid": 1000
+              }
+            ],
+            "region": "eu-west-2",
+            "root_directory": [
+              {
+                "creation_info": [
+                  {
+                    "owner_gid": 1000,
+                    "owner_uid": 1000,
+                    "permissions": "755"
+                  }
+                ],
+                "path": "/usr/local/camunda/data"
+              }
+            ],
+            "tags": {
+              "Name": "camunda-r0-oc-camunda-data-access-point"
+            },
+            "tags_all": {
+              "Name": "camunda-r0-oc-camunda-data-access-point"
+            }
+          }
+        },
+        "module.orchestration_cluster_region_0.aws_efs_file_system.efs": {
+          "mode": "managed",
+          "name": "efs",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "lifecycle_policy": [],
+            "protection": [],
+            "size_in_bytes": [],
+            "tags_all": {}
+          },
+          "type": "aws_efs_file_system",
+          "values": {
+            "creation_token": "camunda-r0-oc-efs",
+            "encrypted": true,
+            "lifecycle_policy": [],
+            "performance_mode": "generalPurpose",
+            "provisioned_throughput_in_mibps": null,
+            "region": "eu-west-2",
+            "tags": null,
+            "throughput_mode": "elastic"
+          }
+        },
+        "module.orchestration_cluster_region_0.aws_efs_mount_target.efs_mounts[0]": {
+          "index": 0,
+          "mode": "managed",
+          "name": "efs_mounts",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "security_groups": [
+              false
+            ]
+          },
+          "type": "aws_efs_mount_target",
+          "values": {
+            "region": "eu-west-2",
+            "security_groups": [
+              "sg-0000000000000000c"
+            ],
+            "subnet_id": "subnet-000000000000000a0",
+            "timeouts": null
+          }
+        },
+        "module.orchestration_cluster_region_0.aws_efs_mount_target.efs_mounts[1]": {
+          "index": 1,
+          "mode": "managed",
+          "name": "efs_mounts",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "security_groups": [
+              false
+            ]
+          },
+          "type": "aws_efs_mount_target",
+          "values": {
+            "region": "eu-west-2",
+            "security_groups": [
+              "sg-0000000000000000c"
+            ],
+            "subnet_id": "subnet-000000000000000b0",
+            "timeouts": null
+          }
+        },
+        "module.orchestration_cluster_region_0.aws_efs_mount_target.efs_mounts[2]": {
+          "index": 2,
+          "mode": "managed",
+          "name": "efs_mounts",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "security_groups": [
+              false
+            ]
+          },
+          "type": "aws_efs_mount_target",
+          "values": {
+            "region": "eu-west-2",
+            "security_groups": [
+              "sg-0000000000000000c"
+            ],
+            "subnet_id": "subnet-000000000000000c0",
+            "timeouts": null
+          }
+        },
+        "module.orchestration_cluster_region_0.aws_iam_policy.ecs_exec_policy": {
+          "identity": {
+            "arn": null
+          },
+          "identity_schema_version": 0,
+          "mode": "managed",
+          "name": "ecs_exec_policy",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "tags": {},
+            "tags_all": {}
+          },
+          "type": "aws_iam_policy",
+          "values": {
+            "delay_after_policy_creation_in_ms": null,
+            "description": null,
+            "name": "camunda-r0-oc-orchestration-exec-policy",
+            "path": "/",
+            "policy": "{\"Statement\":[{\"Action\":[\"ssmmessages:CreateControlChannel\",\"ssmmessages:CreateDataChannel\",\"ssmmessages:OpenControlChannel\",\"ssmmessages:OpenDataChannel\"],\"Condition\":{\"StringEquals\":{\"aws:RequestedRegion\":\"eu-west-2\"}},\"Effect\":\"Allow\",\"Resource\":\"*\",\"Sid\":\"AllowSSMMessaging\"}],\"Version\":\"2012-10-17\"}",
+            "tags": {
+              "Name": "camunda-r0-oc-orchestration-exec-policy"
+            },
+            "tags_all": {
+              "Name": "camunda-r0-oc-orchestration-exec-policy"
+            }
+          }
+        },
+        "module.orchestration_cluster_region_0.aws_iam_policy.efs_sc_access": {
+          "identity": {
+            "arn": null
+          },
+          "identity_schema_version": 0,
+          "mode": "managed",
+          "name": "efs_sc_access",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "tags_all": {}
+          },
+          "type": "aws_iam_policy",
+          "values": {
+            "delay_after_policy_creation_in_ms": null,
+            "description": null,
+            "name": "camunda-r0-oc-efs-sc-access",
+            "path": "/",
+            "tags": null
+          }
+        },
+        "module.orchestration_cluster_region_0.aws_iam_policy.orchestration_cluster_logs_policy": {
+          "identity": {
+            "arn": null
+          },
+          "identity_schema_version": 0,
+          "mode": "managed",
+          "name": "orchestration_cluster_logs_policy",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "tags_all": {}
+          },
+          "type": "aws_iam_policy",
+          "values": {
+            "delay_after_policy_creation_in_ms": null,
+            "description": null,
+            "name": "camunda-r0-oc-orchestration-cluster-logs-policy",
+            "path": "/",
+            "tags": null
+          }
+        },
+        "module.orchestration_cluster_region_0.aws_iam_policy.s3_access": {
+          "identity": {
+            "arn": null
+          },
+          "identity_schema_version": 0,
+          "mode": "managed",
+          "name": "s3_access",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "tags_all": {}
+          },
+          "type": "aws_iam_policy",
+          "values": {
+            "delay_after_policy_creation_in_ms": null,
+            "description": null,
+            "name": "camunda-r0-oc-s3-access-policy",
+            "path": "/",
+            "tags": null
+          }
+        },
+        "module.orchestration_cluster_region_0.aws_iam_role.ecs_task_role": {
+          "identity": {
+            "account_id": null,
+            "name": null
+          },
+          "identity_schema_version": 0,
+          "mode": "managed",
+          "name": "ecs_task_role",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "inline_policy": [],
+            "managed_policy_arns": [],
+            "tags": {},
+            "tags_all": {}
+          },
+          "type": "aws_iam_role",
+          "values": {
+            "assume_role_policy": "{\"Statement\":[{\"Action\":\"sts:AssumeRole\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"ecs-tasks.amazonaws.com\"}}],\"Version\":\"2012-10-17\"}",
+            "description": null,
+            "force_detach_policies": false,
+            "max_session_duration": 3600,
+            "name": "camunda-r0-oc-orchestration-task-role",
+            "path": "/",
+            "permissions_boundary": null,
+            "tags": {
+              "Name": "camunda-r0-oc-orchestration-task-role"
+            },
+            "tags_all": {
+              "Name": "camunda-r0-oc-orchestration-task-role"
+            }
+          }
+        },
+        "module.orchestration_cluster_region_0.aws_iam_role_policy_attachment.ecs_exec_policy_attachment": {
+          "identity": {
+            "account_id": null,
+            "policy_arn": null,
+            "role": null
+          },
+          "identity_schema_version": 0,
+          "mode": "managed",
+          "name": "ecs_exec_policy_attachment",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {},
+          "type": "aws_iam_role_policy_attachment",
+          "values": {
+            "role": "camunda-r0-oc-orchestration-task-role"
+          }
+        },
+        "module.orchestration_cluster_region_0.aws_iam_role_policy_attachment.ecs_task_efs_policy": {
+          "identity": {
+            "account_id": null,
+            "policy_arn": null,
+            "role": null
+          },
+          "identity_schema_version": 0,
+          "mode": "managed",
+          "name": "ecs_task_efs_policy",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {},
+          "type": "aws_iam_role_policy_attachment",
+          "values": {
+            "role": "camunda-r0-oc-orchestration-task-role"
+          }
+        },
+        "module.orchestration_cluster_region_0.aws_iam_role_policy_attachment.ecs_task_s3_policy": {
+          "identity": {
+            "account_id": null,
+            "policy_arn": null,
+            "role": null
+          },
+          "identity_schema_version": 0,
+          "mode": "managed",
+          "name": "ecs_task_s3_policy",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {},
+          "type": "aws_iam_role_policy_attachment",
+          "values": {
+            "role": "camunda-r0-oc-orchestration-task-role"
+          }
+        },
+        "module.orchestration_cluster_region_0.aws_iam_role_policy_attachment.orchestration_cluster_logs_policy_attachment": {
+          "identity": {
+            "account_id": null,
+            "policy_arn": null,
+            "role": null
+          },
+          "identity_schema_version": 0,
+          "mode": "managed",
+          "name": "orchestration_cluster_logs_policy_attachment",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {},
+          "type": "aws_iam_role_policy_attachment",
+          "values": {
+            "role": "camunda-r0-oc-orchestration-task-role"
+          }
+        },
+        "module.orchestration_cluster_region_0.aws_iam_role_policy_attachment.task_role_policy_attachment[0]": {
+          "identity": {
+            "account_id": null,
+            "policy_arn": null,
+            "role": null
+          },
+          "identity_schema_version": 0,
+          "index": 0,
+          "mode": "managed",
+          "name": "task_role_policy_attachment",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {},
+          "type": "aws_iam_role_policy_attachment",
+          "values": {
+            "policy_arn": "ARN_REDACTED",
+            "role": "camunda-r0-oc-orchestration-task-role"
+          }
+        },
+        "module.orchestration_cluster_region_0.aws_iam_role_policy_attachment.task_role_policy_attachment[1]": {
+          "identity": {
+            "account_id": null,
+            "policy_arn": null,
+            "role": null
+          },
+          "identity_schema_version": 0,
+          "index": 1,
+          "mode": "managed",
+          "name": "task_role_policy_attachment",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {},
+          "type": "aws_iam_role_policy_attachment",
+          "values": {
+            "policy_arn": "ARN_REDACTED",
+            "role": "camunda-r0-oc-orchestration-task-role"
+          }
+        },
+        "module.orchestration_cluster_region_0.aws_kms_alias.s3": {
+          "identity": {
+            "account_id": null,
+            "name": null,
+            "region": null
+          },
+          "identity_schema_version": 0,
+          "mode": "managed",
+          "name": "s3",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {},
+          "type": "aws_kms_alias",
+          "values": {
+            "name": "alias/camunda-r0-oc-s3-encryption",
+            "region": "eu-west-2"
+          }
+        },
+        "module.orchestration_cluster_region_0.aws_kms_key.s3": {
+          "identity": {
+            "account_id": null,
+            "id": null,
+            "region": null
+          },
+          "identity_schema_version": 0,
+          "mode": "managed",
+          "name": "s3",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "tags_all": {}
+          },
+          "type": "aws_kms_key",
+          "values": {
+            "bypass_policy_lockout_safety_check": false,
+            "custom_key_store_id": null,
+            "customer_master_key_spec": "SYMMETRIC_DEFAULT",
+            "deletion_window_in_days": 10,
+            "description": "KMS key for camunda-r0-oc S3 bucket encryption",
+            "enable_key_rotation": true,
+            "is_enabled": true,
+            "key_usage": "ENCRYPT_DECRYPT",
+            "region": "eu-west-2",
+            "tags": null,
+            "timeouts": null,
+            "xks_key_id": null
+          }
+        },
+        "module.orchestration_cluster_region_0.aws_lb_listener.grpc_26500[0]": {
+          "identity": {
+            "arn": null
+          },
+          "identity_schema_version": 0,
+          "index": 0,
+          "mode": "managed",
+          "name": "grpc_26500",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "default_action": [
+              {
+                "authenticate_cognito": [],
+                "authenticate_oidc": [],
+                "fixed_response": [],
+                "forward": [],
+                "jwt_validation": [],
+                "redirect": []
+              }
+            ],
+            "mutual_authentication": [],
+            "tags_all": {}
+          },
+          "type": "aws_lb_listener",
+          "values": {
+            "alpn_policy": null,
+            "certificate_arn": null,
+            "default_action": [
+              {
+                "authenticate_cognito": [],
+                "authenticate_oidc": [],
+                "fixed_response": [],
+                "forward": [],
+                "jwt_validation": [],
+                "redirect": [],
+                "type": "forward"
+              }
+            ],
+            "load_balancer_arn": "ARN_REDACTED",
+            "port": 26500,
+            "protocol": "TCP",
+            "region": "eu-west-2",
+            "tags": null,
+            "timeouts": null
+          }
+        },
+        "module.orchestration_cluster_region_0.aws_lb_listener.raft_26502[0]": {
+          "identity": {
+            "arn": null
+          },
+          "identity_schema_version": 0,
+          "index": 0,
+          "mode": "managed",
+          "name": "raft_26502",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "default_action": [
+              {
+                "authenticate_cognito": [],
+                "authenticate_oidc": [],
+                "fixed_response": [],
+                "forward": [],
+                "jwt_validation": [],
+                "redirect": []
+              }
+            ],
+            "mutual_authentication": [],
+            "tags_all": {}
+          },
+          "type": "aws_lb_listener",
+          "values": {
+            "alpn_policy": null,
+            "certificate_arn": null,
+            "default_action": [
+              {
+                "authenticate_cognito": [],
+                "authenticate_oidc": [],
+                "fixed_response": [],
+                "forward": [],
+                "jwt_validation": [],
+                "redirect": [],
+                "type": "forward"
+              }
+            ],
+            "load_balancer_arn": "ARN_REDACTED",
+            "port": 26502,
+            "protocol": "TCP",
+            "region": "eu-west-2",
+            "tags": null,
+            "timeouts": null
+          }
+        },
+        "module.orchestration_cluster_region_0.aws_lb_listener_rule.http_webapp[0]": {
+          "identity": {
+            "arn": null
+          },
+          "identity_schema_version": 0,
+          "index": 0,
+          "mode": "managed",
+          "name": "http_webapp",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "action": [
+              {
+                "authenticate_cognito": [],
+                "authenticate_oidc": [],
+                "fixed_response": [],
+                "forward": [],
+                "jwt_validation": [],
+                "redirect": []
+              }
+            ],
+            "condition": [
+              {
+                "host_header": [],
+                "http_header": [],
+                "http_request_method": [],
+                "path_pattern": [
+                  {
+                    "regex_values": [],
+                    "values": [
+                      false
+                    ]
+                  }
+                ],
+                "query_string": [],
+                "source_ip": []
+              }
+            ],
+            "tags_all": {},
+            "transform": []
+          },
+          "type": "aws_lb_listener_rule",
+          "values": {
+            "action": [
+              {
+                "authenticate_cognito": [],
+                "authenticate_oidc": [],
+                "fixed_response": [],
+                "forward": [],
+                "jwt_validation": [],
+                "redirect": [],
+                "type": "forward"
+              }
+            ],
+            "condition": [
+              {
+                "host_header": [],
+                "http_header": [],
+                "http_request_method": [],
+                "path_pattern": [
+                  {
+                    "regex_values": [],
+                    "values": [
+                      "/*"
+                    ]
+                  }
+                ],
+                "query_string": [],
+                "source_ip": []
+              }
+            ],
+            "listener_arn": "ARN_REDACTED",
+            "priority": 100,
+            "region": "eu-west-2",
+            "tags": null,
+            "transform": []
+          }
+        },
+        "module.orchestration_cluster_region_0.aws_lb_target_group.main": {
+          "identity": {
+            "arn": null
+          },
+          "identity_schema_version": 0,
+          "mode": "managed",
+          "name": "main",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "health_check": [
+              {}
+            ],
+            "load_balancer_arns": [],
+            "stickiness": [
+              {}
+            ],
+            "tags_all": {},
+            "target_failover": [],
+            "target_group_health": [],
+            "target_health_state": []
+          },
+          "type": "aws_lb_target_group",
+          "values": {
+            "deregistration_delay": "30",
+            "health_check": [
+              {
+                "enabled": true,
+                "healthy_threshold": 2,
+                "interval": 30,
+                "path": "/actuator/health/readiness",
+                "port": "9600",
+                "protocol": "HTTP",
+                "timeout": 5,
+                "unhealthy_threshold": 2
+              }
+            ],
+            "lambda_multi_value_headers_enabled": false,
+            "name": "camunda-r0-oc-orc-tg-8080",
+            "port": 8080,
+            "protocol": "HTTP",
+            "proxy_protocol_v2": false,
+            "region": "eu-west-2",
+            "slow_start": 0,
+            "stickiness": [
+              {
+                "cookie_duration": 43200,
+                "cookie_name": null,
+                "enabled": true,
+                "type": "lb_cookie"
+              }
+            ],
+            "tags": null,
+            "target_control_port": null,
+            "target_type": "ip",
+            "vpc_id": "vpc-00000000000000000"
+          }
+        },
+        "module.orchestration_cluster_region_0.aws_lb_target_group.main_26500": {
+          "identity": {
+            "arn": null
+          },
+          "identity_schema_version": 0,
+          "mode": "managed",
+          "name": "main_26500",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "health_check": [
+              {}
+            ],
+            "load_balancer_arns": [],
+            "stickiness": [],
+            "tags_all": {},
+            "target_failover": [],
+            "target_group_health": [],
+            "target_health_state": []
+          },
+          "type": "aws_lb_target_group",
+          "values": {
+            "deregistration_delay": "30",
+            "health_check": [
+              {
+                "enabled": true,
+                "healthy_threshold": 2,
+                "interval": 30,
+                "path": "/actuator/health/readiness",
+                "port": "9600",
+                "protocol": "HTTP",
+                "timeout": 5,
+                "unhealthy_threshold": 2
+              }
+            ],
+            "lambda_multi_value_headers_enabled": false,
+            "name": "camunda-r0-oc-orc-tg-26500",
+            "port": 26500,
+            "protocol": "TCP",
+            "proxy_protocol_v2": false,
+            "region": "eu-west-2",
+            "slow_start": 0,
+            "tags": null,
+            "target_control_port": null,
+            "target_type": "ip",
+            "vpc_id": "vpc-00000000000000000"
+          }
+        },
+        "module.orchestration_cluster_region_0.aws_lb_target_group.main_9600": {
+          "identity": {
+            "arn": null
+          },
+          "identity_schema_version": 0,
+          "mode": "managed",
+          "name": "main_9600",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "health_check": [
+              {}
+            ],
+            "load_balancer_arns": [],
+            "stickiness": [],
+            "tags_all": {},
+            "target_failover": [],
+            "target_group_health": [],
+            "target_health_state": []
+          },
+          "type": "aws_lb_target_group",
+          "values": {
+            "deregistration_delay": "30",
+            "health_check": [
+              {
+                "enabled": true,
+                "healthy_threshold": 2,
+                "interval": 30,
+                "path": "/actuator/health/readiness",
+                "port": "9600",
+                "protocol": "HTTP",
+                "timeout": 5,
+                "unhealthy_threshold": 2
+              }
+            ],
+            "lambda_multi_value_headers_enabled": false,
+            "name": "camunda-r0-oc-orc-tg-9600",
+            "port": 9600,
+            "protocol": "HTTP",
+            "proxy_protocol_v2": false,
+            "region": "eu-west-2",
+            "slow_start": 0,
+            "tags": null,
+            "target_control_port": null,
+            "target_type": "ip",
+            "vpc_id": "vpc-00000000000000000"
+          }
+        },
+        "module.orchestration_cluster_region_0.aws_lb_target_group.raft_26502[0]": {
+          "identity": {
+            "arn": null
+          },
+          "identity_schema_version": 0,
+          "index": 0,
+          "mode": "managed",
+          "name": "raft_26502",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "health_check": [
+              {}
+            ],
+            "load_balancer_arns": [],
+            "stickiness": [],
+            "tags_all": {},
+            "target_failover": [],
+            "target_group_health": [],
+            "target_health_state": []
+          },
+          "type": "aws_lb_target_group",
+          "values": {
+            "deregistration_delay": "30",
+            "health_check": [
+              {
+                "enabled": true,
+                "healthy_threshold": 2,
+                "interval": 30,
+                "path": "/actuator/health/readiness",
+                "port": "9600",
+                "protocol": "HTTP",
+                "timeout": 5,
+                "unhealthy_threshold": 2
+              }
+            ],
+            "lambda_multi_value_headers_enabled": false,
+            "name": "camunda-r0-oc-orc-tg-26502",
+            "port": 26502,
+            "protocol": "TCP",
+            "proxy_protocol_v2": false,
+            "region": "eu-west-2",
+            "slow_start": 0,
+            "tags": null,
+            "target_control_port": null,
+            "target_type": "ip",
+            "vpc_id": "vpc-00000000000000000"
+          }
+        },
+        "module.orchestration_cluster_region_0.aws_s3_bucket.main": {
+          "identity": {
+            "account_id": null,
+            "bucket": null,
+            "region": null
+          },
+          "identity_schema_version": 0,
+          "mode": "managed",
+          "name": "main",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "cors_rule": [],
+            "grant": [],
+            "lifecycle_rule": [],
+            "logging": [],
+            "object_lock_configuration": [],
+            "replication_configuration": [],
+            "server_side_encryption_configuration": [],
+            "tags_all": {},
+            "versioning": [],
+            "website": []
+          },
+          "type": "aws_s3_bucket",
+          "values": {
+            "bucket": "camunda-r0-oc-bucket",
+            "force_destroy": true,
+            "region": "eu-west-2",
+            "tags": null,
+            "timeouts": null
+          }
+        },
+        "module.orchestration_cluster_region_0.aws_s3_bucket_public_access_block.main": {
+          "identity": {
+            "account_id": null,
+            "bucket": null,
+            "region": null
+          },
+          "identity_schema_version": 0,
+          "mode": "managed",
+          "name": "main",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {},
+          "type": "aws_s3_bucket_public_access_block",
+          "values": {
+            "block_public_acls": true,
+            "block_public_policy": true,
+            "ignore_public_acls": true,
+            "region": "eu-west-2",
+            "restrict_public_buckets": true,
+            "skip_destroy": null
+          }
+        },
+        "module.orchestration_cluster_region_0.aws_s3_bucket_server_side_encryption_configuration.main": {
+          "identity": {
+            "account_id": null,
+            "bucket": null,
+            "region": null
+          },
+          "identity_schema_version": 1,
+          "mode": "managed",
+          "name": "main",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "rule": [
+              {
+                "apply_server_side_encryption_by_default": [
+                  {}
+                ],
+                "blocked_encryption_types": []
+              }
+            ]
+          },
+          "type": "aws_s3_bucket_server_side_encryption_configuration",
+          "values": {
+            "expected_bucket_owner": null,
+            "region": "eu-west-2",
+            "rule": [
+              {
+                "apply_server_side_encryption_by_default": [
+                  {
+                    "sse_algorithm": "aws:kms"
+                  }
+                ],
+                "bucket_key_enabled": true
+              }
+            ]
+          }
+        },
+        "module.orchestration_cluster_region_0.aws_service_discovery_http_namespace.service_connect": {
+          "mode": "managed",
+          "name": "service_connect",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "tags_all": {}
+          },
+          "type": "aws_service_discovery_http_namespace",
+          "values": {
+            "description": "Service Connect namespace for ECS services",
+            "name": "camunda-r0-oc-sc",
+            "region": "eu-west-2",
+            "tags": null
+          }
+        },
+        "module.orchestration_cluster_region_0.aws_service_discovery_private_dns_namespace.namespace": {
+          "mode": "managed",
+          "name": "namespace",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "tags_all": {}
+          },
+          "type": "aws_service_discovery_private_dns_namespace",
+          "values": {
+            "description": "Namespace for ECS services",
+            "name": "camunda-r0-oc.service.local",
+            "region": "eu-west-2",
+            "tags": null,
+            "vpc": "vpc-00000000000000000"
+          }
+        },
+        "module.orchestration_cluster_region_0.aws_service_discovery_service.discovery": {
+          "mode": "managed",
+          "name": "discovery",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "dns_config": [
+              {
+                "dns_records": [
+                  {}
+                ]
+              }
+            ],
+            "health_check_config": [],
+            "health_check_custom_config": [],
+            "tags_all": {}
+          },
+          "type": "aws_service_discovery_service",
+          "values": {
+            "description": null,
+            "dns_config": [
+              {
+                "dns_records": [
+                  {
+                    "ttl": 10,
+                    "type": "A"
+                  }
+                ],
+                "routing_policy": "MULTIVALUE"
+              }
+            ],
+            "force_destroy": false,
+            "health_check_config": [],
+            "health_check_custom_config": [],
+            "name": "orchestration-cluster",
+            "region": "eu-west-2",
+            "tags": null
+          }
+        }
+      }
+    },
+    "module.orchestration_cluster_region_1": {
+      "resources": {
+        "module.orchestration_cluster_region_1.aws_cloudwatch_log_group.orchestration_cluster_log_group": {
+          "identity": {
+            "account_id": null,
+            "name": null,
+            "region": null
+          },
+          "identity_schema_version": 0,
+          "mode": "managed",
+          "name": "orchestration_cluster_log_group",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "tags": {},
+            "tags_all": {}
+          },
+          "type": "aws_cloudwatch_log_group",
+          "values": {
+            "kms_key_id": null,
+            "name": "/ecs/camunda-r1-oc-camunda",
+            "region": "eu-west-3",
+            "retention_in_days": 30,
+            "skip_destroy": false,
+            "tags": {
+              "Name": "camunda-r1-oc-oc-log-group"
+            },
+            "tags_all": {
+              "Name": "camunda-r1-oc-oc-log-group"
+            }
+          }
+        },
+        "module.orchestration_cluster_region_1.aws_cloudwatch_log_stream.orchestration_cluster_log_stream": {
+          "identity": {
+            "account_id": null,
+            "log_group_name": null,
+            "name": null,
+            "region": null
+          },
+          "identity_schema_version": 0,
+          "mode": "managed",
+          "name": "orchestration_cluster_log_stream",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {},
+          "type": "aws_cloudwatch_log_stream",
+          "values": {
+            "log_group_name": "/ecs/camunda-r1-oc-camunda",
+            "name": "camunda-r1-oc-orchestration-cluster-log-stream",
+            "region": "eu-west-3"
+          }
+        },
+        "module.orchestration_cluster_region_1.aws_ecs_service.orchestration_cluster": {
+          "identity": {
+            "account_id": null,
+            "cluster": null,
+            "name": null,
+            "region": null
+          },
+          "identity_schema_version": 0,
+          "mode": "managed",
+          "name": "orchestration_cluster",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 1,
+          "sensitive_values": {
+            "alarms": [],
+            "capacity_provider_strategy": [],
+            "deployment_circuit_breaker": [
+              {}
+            ],
+            "deployment_configuration": [],
+            "deployment_controller": [],
+            "load_balancer": [
+              {
+                "advanced_configuration": []
+              },
+              {
+                "advanced_configuration": []
+              },
+              {
+                "advanced_configuration": []
+              }
+            ],
+            "network_configuration": [
+              {
+                "security_groups": [
+                  false,
+                  false,
+                  false
+                ],
+                "subnets": [
+                  false,
+                  false,
+                  false
+                ]
+              }
+            ],
+            "ordered_placement_strategy": [],
+            "placement_constraints": [],
+            "service_connect_configuration": [
+              {
+                "access_log_configuration": [],
+                "log_configuration": [],
+                "service": [
+                  {
+                    "client_alias": [
+                      {
+                        "test_traffic_rules": []
+                      }
+                    ],
+                    "timeout": [],
+                    "tls": []
+                  },
+                  {
+                    "client_alias": [
+                      {
+                        "test_traffic_rules": []
+                      }
+                    ],
+                    "timeout": [],
+                    "tls": []
+                  },
+                  {
+                    "client_alias": [
+                      {
+                        "test_traffic_rules": []
+                      }
+                    ],
+                    "timeout": [],
+                    "tls": []
+                  }
+                ]
+              }
+            ],
+            "service_registries": [
+              {}
+            ],
+            "tags_all": {},
+            "timeouts": {},
+            "triggers": {},
+            "volume_configuration": [],
+            "vpc_lattice_configurations": []
+          },
+          "type": "aws_ecs_service",
+          "values": {
+            "alarms": [],
+            "capacity_provider_strategy": [],
+            "cluster": "ARN_REDACTED",
+            "deployment_circuit_breaker": [
+              {
+                "enable": false,
+                "rollback": false
+              }
+            ],
+            "deployment_controller": [],
+            "deployment_maximum_percent": 100,
+            "deployment_minimum_healthy_percent": 66,
+            "desired_count": 4,
+            "enable_ecs_managed_tags": false,
+            "enable_execute_command": true,
+            "force_delete": null,
+            "force_new_deployment": false,
+            "health_check_grace_period_seconds": 1200,
+            "launch_type": "FARGATE",
+            "load_balancer": [
+              {
+                "advanced_configuration": [],
+                "container_name": "orchestration-cluster",
+                "container_port": 26500,
+                "elb_name": ""
+              },
+              {
+                "advanced_configuration": [],
+                "container_name": "orchestration-cluster",
+                "container_port": 26502,
+                "elb_name": ""
+              },
+              {
+                "advanced_configuration": [],
+                "container_name": "orchestration-cluster",
+                "container_port": 8080,
+                "elb_name": ""
+              }
+            ],
+            "name": "camunda-r1-oc-orchestration-cluster",
+            "network_configuration": [
+              {
+                "assign_public_ip": false,
+                "security_groups": [
+                  "sg-0000000000000001a",
+                  "sg-0000000000000001b",
+                  "sg-0000000000000001c"
+                ],
+                "subnets": [
+                  "subnet-000000000000000a1",
+                  "subnet-000000000000000b1",
+                  "subnet-000000000000000c1"
+                ]
+              }
+            ],
+            "ordered_placement_strategy": [],
+            "placement_constraints": [],
+            "propagate_tags": null,
+            "region": "eu-west-3",
+            "scheduling_strategy": "REPLICA",
+            "service_connect_configuration": [
+              {
+                "access_log_configuration": [],
+                "enabled": true,
+                "log_configuration": [],
+                "service": [
+                  {
+                    "client_alias": [
+                      {
+                        "dns_name": "orchestration-cluster-grpc",
+                        "port": 26500,
+                        "test_traffic_rules": []
+                      }
+                    ],
+                    "discovery_name": "orchestration-cluster-grpc",
+                    "ingress_port_override": null,
+                    "port_name": "grpc",
+                    "timeout": [],
+                    "tls": []
+                  },
+                  {
+                    "client_alias": [
+                      {
+                        "dns_name": "orchestration-cluster-sc",
+                        "port": 26502,
+                        "test_traffic_rules": []
+                      }
+                    ],
+                    "discovery_name": "orchestration-cluster-sc",
+                    "ingress_port_override": null,
+                    "port_name": "internal-api",
+                    "timeout": [],
+                    "tls": []
+                  },
+                  {
+                    "client_alias": [
+                      {
+                        "dns_name": "orchestration-cluster-rest",
+                        "port": 8080,
+                        "test_traffic_rules": []
+                      }
+                    ],
+                    "discovery_name": "orchestration-cluster-rest",
+                    "ingress_port_override": null,
+                    "port_name": "rest",
+                    "timeout": [],
+                    "tls": []
+                  }
+                ]
+              }
+            ],
+            "service_registries": [
+              {
+                "container_name": null,
+                "container_port": null,
+                "port": null
+              }
+            ],
+            "sigint_rollback": null,
+            "tags": null,
+            "timeouts": {
+              "create": "30m",
+              "delete": "15m",
+              "update": "30m"
+            },
+            "volume_configuration": [],
+            "vpc_lattice_configurations": [],
+            "wait_for_steady_state": true
+          }
+        },
+        "module.orchestration_cluster_region_1.aws_ecs_task_definition.orchestration_cluster": {
+          "identity": {
+            "account_id": null,
+            "family": null,
+            "region": null,
+            "revision": null
+          },
+          "identity_schema_version": 0,
+          "mode": "managed",
+          "name": "orchestration_cluster",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 1,
+          "sensitive_values": {
+            "ephemeral_storage": [],
+            "placement_constraints": [],
+            "proxy_configuration": [],
+            "requires_compatibilities": [
+              false
+            ],
+            "runtime_platform": [
+              {}
+            ],
+            "tags_all": {},
+            "volume": [
+              {
+                "docker_volume_configuration": [],
+                "efs_volume_configuration": [
+                  {
+                    "authorization_config": [
+                      {}
+                    ]
+                  }
+                ],
+                "fsx_windows_file_server_volume_configuration": [],
+                "s3files_volume_configuration": []
+              }
+            ]
+          },
+          "type": "aws_ecs_task_definition",
+          "values": {
+            "cpu": "4096",
+            "ephemeral_storage": [],
+            "execution_role_arn": "ARN_REDACTED",
+            "family": "camunda-r1-oc-orchestration-cluster",
+            "ipc_mode": null,
+            "memory": "8192",
+            "network_mode": "awsvpc",
+            "pid_mode": null,
+            "placement_constraints": [],
+            "proxy_configuration": [],
+            "region": "eu-west-3",
+            "requires_compatibilities": [
+              "FARGATE"
+            ],
+            "runtime_platform": [
+              {
+                "cpu_architecture": "X86_64",
+                "operating_system_family": "LINUX"
+              }
+            ],
+            "skip_destroy": false,
+            "tags": null,
+            "track_latest": false,
+            "volume": [
+              {
+                "docker_volume_configuration": [],
+                "efs_volume_configuration": [
+                  {
+                    "authorization_config": [
+                      {
+                        "iam": "ENABLED"
+                      }
+                    ],
+                    "root_directory": "/",
+                    "transit_encryption": "ENABLED",
+                    "transit_encryption_port": 0
+                  }
+                ],
+                "fsx_windows_file_server_volume_configuration": [],
+                "host_path": "",
+                "name": "camunda-volume",
+                "s3files_volume_configuration": []
+              }
+            ]
+          }
+        },
+        "module.orchestration_cluster_region_1.aws_efs_access_point.camunda_data": {
+          "mode": "managed",
+          "name": "camunda_data",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "posix_user": [
+              {}
+            ],
+            "root_directory": [
+              {
+                "creation_info": [
+                  {}
+                ]
+              }
+            ],
+            "tags": {},
+            "tags_all": {}
+          },
+          "type": "aws_efs_access_point",
+          "values": {
+            "posix_user": [
+              {
+                "gid": 1000,
+                "secondary_gids": null,
+                "uid": 1000
+              }
+            ],
+            "region": "eu-west-3",
+            "root_directory": [
+              {
+                "creation_info": [
+                  {
+                    "owner_gid": 1000,
+                    "owner_uid": 1000,
+                    "permissions": "755"
+                  }
+                ],
+                "path": "/usr/local/camunda/data"
+              }
+            ],
+            "tags": {
+              "Name": "camunda-r1-oc-camunda-data-access-point"
+            },
+            "tags_all": {
+              "Name": "camunda-r1-oc-camunda-data-access-point"
+            }
+          }
+        },
+        "module.orchestration_cluster_region_1.aws_efs_file_system.efs": {
+          "mode": "managed",
+          "name": "efs",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "lifecycle_policy": [],
+            "protection": [],
+            "size_in_bytes": [],
+            "tags_all": {}
+          },
+          "type": "aws_efs_file_system",
+          "values": {
+            "creation_token": "camunda-r1-oc-efs",
+            "encrypted": true,
+            "lifecycle_policy": [],
+            "performance_mode": "generalPurpose",
+            "provisioned_throughput_in_mibps": null,
+            "region": "eu-west-3",
+            "tags": null,
+            "throughput_mode": "elastic"
+          }
+        },
+        "module.orchestration_cluster_region_1.aws_efs_mount_target.efs_mounts[0]": {
+          "index": 0,
+          "mode": "managed",
+          "name": "efs_mounts",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "security_groups": [
+              false
+            ]
+          },
+          "type": "aws_efs_mount_target",
+          "values": {
+            "region": "eu-west-3",
+            "security_groups": [
+              "sg-0000000000000001c"
+            ],
+            "subnet_id": "subnet-000000000000000a1",
+            "timeouts": null
+          }
+        },
+        "module.orchestration_cluster_region_1.aws_efs_mount_target.efs_mounts[1]": {
+          "index": 1,
+          "mode": "managed",
+          "name": "efs_mounts",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "security_groups": [
+              false
+            ]
+          },
+          "type": "aws_efs_mount_target",
+          "values": {
+            "region": "eu-west-3",
+            "security_groups": [
+              "sg-0000000000000001c"
+            ],
+            "subnet_id": "subnet-000000000000000b1",
+            "timeouts": null
+          }
+        },
+        "module.orchestration_cluster_region_1.aws_efs_mount_target.efs_mounts[2]": {
+          "index": 2,
+          "mode": "managed",
+          "name": "efs_mounts",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "security_groups": [
+              false
+            ]
+          },
+          "type": "aws_efs_mount_target",
+          "values": {
+            "region": "eu-west-3",
+            "security_groups": [
+              "sg-0000000000000001c"
+            ],
+            "subnet_id": "subnet-000000000000000c1",
+            "timeouts": null
+          }
+        },
+        "module.orchestration_cluster_region_1.aws_iam_policy.ecs_exec_policy": {
+          "identity": {
+            "arn": null
+          },
+          "identity_schema_version": 0,
+          "mode": "managed",
+          "name": "ecs_exec_policy",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "tags": {},
+            "tags_all": {}
+          },
+          "type": "aws_iam_policy",
+          "values": {
+            "delay_after_policy_creation_in_ms": null,
+            "description": null,
+            "name": "camunda-r1-oc-orchestration-exec-policy",
+            "path": "/",
+            "policy": "{\"Statement\":[{\"Action\":[\"ssmmessages:CreateControlChannel\",\"ssmmessages:CreateDataChannel\",\"ssmmessages:OpenControlChannel\",\"ssmmessages:OpenDataChannel\"],\"Condition\":{\"StringEquals\":{\"aws:RequestedRegion\":\"eu-west-3\"}},\"Effect\":\"Allow\",\"Resource\":\"*\",\"Sid\":\"AllowSSMMessaging\"}],\"Version\":\"2012-10-17\"}",
+            "tags": {
+              "Name": "camunda-r1-oc-orchestration-exec-policy"
+            },
+            "tags_all": {
+              "Name": "camunda-r1-oc-orchestration-exec-policy"
+            }
+          }
+        },
+        "module.orchestration_cluster_region_1.aws_iam_policy.efs_sc_access": {
+          "identity": {
+            "arn": null
+          },
+          "identity_schema_version": 0,
+          "mode": "managed",
+          "name": "efs_sc_access",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "tags_all": {}
+          },
+          "type": "aws_iam_policy",
+          "values": {
+            "delay_after_policy_creation_in_ms": null,
+            "description": null,
+            "name": "camunda-r1-oc-efs-sc-access",
+            "path": "/",
+            "tags": null
+          }
+        },
+        "module.orchestration_cluster_region_1.aws_iam_policy.orchestration_cluster_logs_policy": {
+          "identity": {
+            "arn": null
+          },
+          "identity_schema_version": 0,
+          "mode": "managed",
+          "name": "orchestration_cluster_logs_policy",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "tags_all": {}
+          },
+          "type": "aws_iam_policy",
+          "values": {
+            "delay_after_policy_creation_in_ms": null,
+            "description": null,
+            "name": "camunda-r1-oc-orchestration-cluster-logs-policy",
+            "path": "/",
+            "tags": null
+          }
+        },
+        "module.orchestration_cluster_region_1.aws_iam_policy.s3_access": {
+          "identity": {
+            "arn": null
+          },
+          "identity_schema_version": 0,
+          "mode": "managed",
+          "name": "s3_access",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "tags_all": {}
+          },
+          "type": "aws_iam_policy",
+          "values": {
+            "delay_after_policy_creation_in_ms": null,
+            "description": null,
+            "name": "camunda-r1-oc-s3-access-policy",
+            "path": "/",
+            "tags": null
+          }
+        },
+        "module.orchestration_cluster_region_1.aws_iam_role.ecs_task_role": {
+          "identity": {
+            "account_id": null,
+            "name": null
+          },
+          "identity_schema_version": 0,
+          "mode": "managed",
+          "name": "ecs_task_role",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "inline_policy": [],
+            "managed_policy_arns": [],
+            "tags": {},
+            "tags_all": {}
+          },
+          "type": "aws_iam_role",
+          "values": {
+            "assume_role_policy": "{\"Statement\":[{\"Action\":\"sts:AssumeRole\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"ecs-tasks.amazonaws.com\"}}],\"Version\":\"2012-10-17\"}",
+            "description": null,
+            "force_detach_policies": false,
+            "max_session_duration": 3600,
+            "name": "camunda-r1-oc-orchestration-task-role",
+            "path": "/",
+            "permissions_boundary": null,
+            "tags": {
+              "Name": "camunda-r1-oc-orchestration-task-role"
+            },
+            "tags_all": {
+              "Name": "camunda-r1-oc-orchestration-task-role"
+            }
+          }
+        },
+        "module.orchestration_cluster_region_1.aws_iam_role_policy_attachment.ecs_exec_policy_attachment": {
+          "identity": {
+            "account_id": null,
+            "policy_arn": null,
+            "role": null
+          },
+          "identity_schema_version": 0,
+          "mode": "managed",
+          "name": "ecs_exec_policy_attachment",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {},
+          "type": "aws_iam_role_policy_attachment",
+          "values": {
+            "role": "camunda-r1-oc-orchestration-task-role"
+          }
+        },
+        "module.orchestration_cluster_region_1.aws_iam_role_policy_attachment.ecs_task_efs_policy": {
+          "identity": {
+            "account_id": null,
+            "policy_arn": null,
+            "role": null
+          },
+          "identity_schema_version": 0,
+          "mode": "managed",
+          "name": "ecs_task_efs_policy",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {},
+          "type": "aws_iam_role_policy_attachment",
+          "values": {
+            "role": "camunda-r1-oc-orchestration-task-role"
+          }
+        },
+        "module.orchestration_cluster_region_1.aws_iam_role_policy_attachment.ecs_task_s3_policy": {
+          "identity": {
+            "account_id": null,
+            "policy_arn": null,
+            "role": null
+          },
+          "identity_schema_version": 0,
+          "mode": "managed",
+          "name": "ecs_task_s3_policy",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {},
+          "type": "aws_iam_role_policy_attachment",
+          "values": {
+            "role": "camunda-r1-oc-orchestration-task-role"
+          }
+        },
+        "module.orchestration_cluster_region_1.aws_iam_role_policy_attachment.orchestration_cluster_logs_policy_attachment": {
+          "identity": {
+            "account_id": null,
+            "policy_arn": null,
+            "role": null
+          },
+          "identity_schema_version": 0,
+          "mode": "managed",
+          "name": "orchestration_cluster_logs_policy_attachment",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {},
+          "type": "aws_iam_role_policy_attachment",
+          "values": {
+            "role": "camunda-r1-oc-orchestration-task-role"
+          }
+        },
+        "module.orchestration_cluster_region_1.aws_iam_role_policy_attachment.task_role_policy_attachment[0]": {
+          "identity": {
+            "account_id": null,
+            "policy_arn": null,
+            "role": null
+          },
+          "identity_schema_version": 0,
+          "index": 0,
+          "mode": "managed",
+          "name": "task_role_policy_attachment",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {},
+          "type": "aws_iam_role_policy_attachment",
+          "values": {
+            "policy_arn": "ARN_REDACTED",
+            "role": "camunda-r1-oc-orchestration-task-role"
+          }
+        },
+        "module.orchestration_cluster_region_1.aws_iam_role_policy_attachment.task_role_policy_attachment[1]": {
+          "identity": {
+            "account_id": null,
+            "policy_arn": null,
+            "role": null
+          },
+          "identity_schema_version": 0,
+          "index": 1,
+          "mode": "managed",
+          "name": "task_role_policy_attachment",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {},
+          "type": "aws_iam_role_policy_attachment",
+          "values": {
+            "policy_arn": "ARN_REDACTED",
+            "role": "camunda-r1-oc-orchestration-task-role"
+          }
+        },
+        "module.orchestration_cluster_region_1.aws_kms_alias.s3": {
+          "identity": {
+            "account_id": null,
+            "name": null,
+            "region": null
+          },
+          "identity_schema_version": 0,
+          "mode": "managed",
+          "name": "s3",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {},
+          "type": "aws_kms_alias",
+          "values": {
+            "name": "alias/camunda-r1-oc-s3-encryption",
+            "region": "eu-west-3"
+          }
+        },
+        "module.orchestration_cluster_region_1.aws_kms_key.s3": {
+          "identity": {
+            "account_id": null,
+            "id": null,
+            "region": null
+          },
+          "identity_schema_version": 0,
+          "mode": "managed",
+          "name": "s3",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "tags_all": {}
+          },
+          "type": "aws_kms_key",
+          "values": {
+            "bypass_policy_lockout_safety_check": false,
+            "custom_key_store_id": null,
+            "customer_master_key_spec": "SYMMETRIC_DEFAULT",
+            "deletion_window_in_days": 10,
+            "description": "KMS key for camunda-r1-oc S3 bucket encryption",
+            "enable_key_rotation": true,
+            "is_enabled": true,
+            "key_usage": "ENCRYPT_DECRYPT",
+            "region": "eu-west-3",
+            "tags": null,
+            "timeouts": null,
+            "xks_key_id": null
+          }
+        },
+        "module.orchestration_cluster_region_1.aws_lb_listener.grpc_26500[0]": {
+          "identity": {
+            "arn": null
+          },
+          "identity_schema_version": 0,
+          "index": 0,
+          "mode": "managed",
+          "name": "grpc_26500",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "default_action": [
+              {
+                "authenticate_cognito": [],
+                "authenticate_oidc": [],
+                "fixed_response": [],
+                "forward": [],
+                "jwt_validation": [],
+                "redirect": []
+              }
+            ],
+            "mutual_authentication": [],
+            "tags_all": {}
+          },
+          "type": "aws_lb_listener",
+          "values": {
+            "alpn_policy": null,
+            "certificate_arn": null,
+            "default_action": [
+              {
+                "authenticate_cognito": [],
+                "authenticate_oidc": [],
+                "fixed_response": [],
+                "forward": [],
+                "jwt_validation": [],
+                "redirect": [],
+                "type": "forward"
+              }
+            ],
+            "load_balancer_arn": "ARN_REDACTED",
+            "port": 26500,
+            "protocol": "TCP",
+            "region": "eu-west-3",
+            "tags": null,
+            "timeouts": null
+          }
+        },
+        "module.orchestration_cluster_region_1.aws_lb_listener.raft_26502[0]": {
+          "identity": {
+            "arn": null
+          },
+          "identity_schema_version": 0,
+          "index": 0,
+          "mode": "managed",
+          "name": "raft_26502",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "default_action": [
+              {
+                "authenticate_cognito": [],
+                "authenticate_oidc": [],
+                "fixed_response": [],
+                "forward": [],
+                "jwt_validation": [],
+                "redirect": []
+              }
+            ],
+            "mutual_authentication": [],
+            "tags_all": {}
+          },
+          "type": "aws_lb_listener",
+          "values": {
+            "alpn_policy": null,
+            "certificate_arn": null,
+            "default_action": [
+              {
+                "authenticate_cognito": [],
+                "authenticate_oidc": [],
+                "fixed_response": [],
+                "forward": [],
+                "jwt_validation": [],
+                "redirect": [],
+                "type": "forward"
+              }
+            ],
+            "load_balancer_arn": "ARN_REDACTED",
+            "port": 26502,
+            "protocol": "TCP",
+            "region": "eu-west-3",
+            "tags": null,
+            "timeouts": null
+          }
+        },
+        "module.orchestration_cluster_region_1.aws_lb_listener_rule.http_webapp[0]": {
+          "identity": {
+            "arn": null
+          },
+          "identity_schema_version": 0,
+          "index": 0,
+          "mode": "managed",
+          "name": "http_webapp",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "action": [
+              {
+                "authenticate_cognito": [],
+                "authenticate_oidc": [],
+                "fixed_response": [],
+                "forward": [],
+                "jwt_validation": [],
+                "redirect": []
+              }
+            ],
+            "condition": [
+              {
+                "host_header": [],
+                "http_header": [],
+                "http_request_method": [],
+                "path_pattern": [
+                  {
+                    "regex_values": [],
+                    "values": [
+                      false
+                    ]
+                  }
+                ],
+                "query_string": [],
+                "source_ip": []
+              }
+            ],
+            "tags_all": {},
+            "transform": []
+          },
+          "type": "aws_lb_listener_rule",
+          "values": {
+            "action": [
+              {
+                "authenticate_cognito": [],
+                "authenticate_oidc": [],
+                "fixed_response": [],
+                "forward": [],
+                "jwt_validation": [],
+                "redirect": [],
+                "type": "forward"
+              }
+            ],
+            "condition": [
+              {
+                "host_header": [],
+                "http_header": [],
+                "http_request_method": [],
+                "path_pattern": [
+                  {
+                    "regex_values": [],
+                    "values": [
+                      "/*"
+                    ]
+                  }
+                ],
+                "query_string": [],
+                "source_ip": []
+              }
+            ],
+            "listener_arn": "ARN_REDACTED",
+            "priority": 100,
+            "region": "eu-west-3",
+            "tags": null,
+            "transform": []
+          }
+        },
+        "module.orchestration_cluster_region_1.aws_lb_target_group.main": {
+          "identity": {
+            "arn": null
+          },
+          "identity_schema_version": 0,
+          "mode": "managed",
+          "name": "main",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "health_check": [
+              {}
+            ],
+            "load_balancer_arns": [],
+            "stickiness": [
+              {}
+            ],
+            "tags_all": {},
+            "target_failover": [],
+            "target_group_health": [],
+            "target_health_state": []
+          },
+          "type": "aws_lb_target_group",
+          "values": {
+            "deregistration_delay": "30",
+            "health_check": [
+              {
+                "enabled": true,
+                "healthy_threshold": 2,
+                "interval": 30,
+                "path": "/actuator/health/readiness",
+                "port": "9600",
+                "protocol": "HTTP",
+                "timeout": 5,
+                "unhealthy_threshold": 2
+              }
+            ],
+            "lambda_multi_value_headers_enabled": false,
+            "name": "camunda-r1-oc-orc-tg-8080",
+            "port": 8080,
+            "protocol": "HTTP",
+            "proxy_protocol_v2": false,
+            "region": "eu-west-3",
+            "slow_start": 0,
+            "stickiness": [
+              {
+                "cookie_duration": 43200,
+                "cookie_name": null,
+                "enabled": true,
+                "type": "lb_cookie"
+              }
+            ],
+            "tags": null,
+            "target_control_port": null,
+            "target_type": "ip",
+            "vpc_id": "vpc-11111111111111111"
+          }
+        },
+        "module.orchestration_cluster_region_1.aws_lb_target_group.main_26500": {
+          "identity": {
+            "arn": null
+          },
+          "identity_schema_version": 0,
+          "mode": "managed",
+          "name": "main_26500",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "health_check": [
+              {}
+            ],
+            "load_balancer_arns": [],
+            "stickiness": [],
+            "tags_all": {},
+            "target_failover": [],
+            "target_group_health": [],
+            "target_health_state": []
+          },
+          "type": "aws_lb_target_group",
+          "values": {
+            "deregistration_delay": "30",
+            "health_check": [
+              {
+                "enabled": true,
+                "healthy_threshold": 2,
+                "interval": 30,
+                "path": "/actuator/health/readiness",
+                "port": "9600",
+                "protocol": "HTTP",
+                "timeout": 5,
+                "unhealthy_threshold": 2
+              }
+            ],
+            "lambda_multi_value_headers_enabled": false,
+            "name": "camunda-r1-oc-orc-tg-26500",
+            "port": 26500,
+            "protocol": "TCP",
+            "proxy_protocol_v2": false,
+            "region": "eu-west-3",
+            "slow_start": 0,
+            "tags": null,
+            "target_control_port": null,
+            "target_type": "ip",
+            "vpc_id": "vpc-11111111111111111"
+          }
+        },
+        "module.orchestration_cluster_region_1.aws_lb_target_group.main_9600": {
+          "identity": {
+            "arn": null
+          },
+          "identity_schema_version": 0,
+          "mode": "managed",
+          "name": "main_9600",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "health_check": [
+              {}
+            ],
+            "load_balancer_arns": [],
+            "stickiness": [],
+            "tags_all": {},
+            "target_failover": [],
+            "target_group_health": [],
+            "target_health_state": []
+          },
+          "type": "aws_lb_target_group",
+          "values": {
+            "deregistration_delay": "30",
+            "health_check": [
+              {
+                "enabled": true,
+                "healthy_threshold": 2,
+                "interval": 30,
+                "path": "/actuator/health/readiness",
+                "port": "9600",
+                "protocol": "HTTP",
+                "timeout": 5,
+                "unhealthy_threshold": 2
+              }
+            ],
+            "lambda_multi_value_headers_enabled": false,
+            "name": "camunda-r1-oc-orc-tg-9600",
+            "port": 9600,
+            "protocol": "HTTP",
+            "proxy_protocol_v2": false,
+            "region": "eu-west-3",
+            "slow_start": 0,
+            "tags": null,
+            "target_control_port": null,
+            "target_type": "ip",
+            "vpc_id": "vpc-11111111111111111"
+          }
+        },
+        "module.orchestration_cluster_region_1.aws_lb_target_group.raft_26502[0]": {
+          "identity": {
+            "arn": null
+          },
+          "identity_schema_version": 0,
+          "index": 0,
+          "mode": "managed",
+          "name": "raft_26502",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "health_check": [
+              {}
+            ],
+            "load_balancer_arns": [],
+            "stickiness": [],
+            "tags_all": {},
+            "target_failover": [],
+            "target_group_health": [],
+            "target_health_state": []
+          },
+          "type": "aws_lb_target_group",
+          "values": {
+            "deregistration_delay": "30",
+            "health_check": [
+              {
+                "enabled": true,
+                "healthy_threshold": 2,
+                "interval": 30,
+                "path": "/actuator/health/readiness",
+                "port": "9600",
+                "protocol": "HTTP",
+                "timeout": 5,
+                "unhealthy_threshold": 2
+              }
+            ],
+            "lambda_multi_value_headers_enabled": false,
+            "name": "camunda-r1-oc-orc-tg-26502",
+            "port": 26502,
+            "protocol": "TCP",
+            "proxy_protocol_v2": false,
+            "region": "eu-west-3",
+            "slow_start": 0,
+            "tags": null,
+            "target_control_port": null,
+            "target_type": "ip",
+            "vpc_id": "vpc-11111111111111111"
+          }
+        },
+        "module.orchestration_cluster_region_1.aws_s3_bucket.main": {
+          "identity": {
+            "account_id": null,
+            "bucket": null,
+            "region": null
+          },
+          "identity_schema_version": 0,
+          "mode": "managed",
+          "name": "main",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "cors_rule": [],
+            "grant": [],
+            "lifecycle_rule": [],
+            "logging": [],
+            "object_lock_configuration": [],
+            "replication_configuration": [],
+            "server_side_encryption_configuration": [],
+            "tags_all": {},
+            "versioning": [],
+            "website": []
+          },
+          "type": "aws_s3_bucket",
+          "values": {
+            "bucket": "camunda-r1-oc-bucket",
+            "force_destroy": true,
+            "region": "eu-west-3",
+            "tags": null,
+            "timeouts": null
+          }
+        },
+        "module.orchestration_cluster_region_1.aws_s3_bucket_public_access_block.main": {
+          "identity": {
+            "account_id": null,
+            "bucket": null,
+            "region": null
+          },
+          "identity_schema_version": 0,
+          "mode": "managed",
+          "name": "main",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {},
+          "type": "aws_s3_bucket_public_access_block",
+          "values": {
+            "block_public_acls": true,
+            "block_public_policy": true,
+            "ignore_public_acls": true,
+            "region": "eu-west-3",
+            "restrict_public_buckets": true,
+            "skip_destroy": null
+          }
+        },
+        "module.orchestration_cluster_region_1.aws_s3_bucket_server_side_encryption_configuration.main": {
+          "identity": {
+            "account_id": null,
+            "bucket": null,
+            "region": null
+          },
+          "identity_schema_version": 1,
+          "mode": "managed",
+          "name": "main",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "rule": [
+              {
+                "apply_server_side_encryption_by_default": [
+                  {}
+                ],
+                "blocked_encryption_types": []
+              }
+            ]
+          },
+          "type": "aws_s3_bucket_server_side_encryption_configuration",
+          "values": {
+            "expected_bucket_owner": null,
+            "region": "eu-west-3",
+            "rule": [
+              {
+                "apply_server_side_encryption_by_default": [
+                  {
+                    "sse_algorithm": "aws:kms"
+                  }
+                ],
+                "bucket_key_enabled": true
+              }
+            ]
+          }
+        },
+        "module.orchestration_cluster_region_1.aws_service_discovery_http_namespace.service_connect": {
+          "mode": "managed",
+          "name": "service_connect",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "tags_all": {}
+          },
+          "type": "aws_service_discovery_http_namespace",
+          "values": {
+            "description": "Service Connect namespace for ECS services",
+            "name": "camunda-r1-oc-sc",
+            "region": "eu-west-3",
+            "tags": null
+          }
+        },
+        "module.orchestration_cluster_region_1.aws_service_discovery_private_dns_namespace.namespace": {
+          "mode": "managed",
+          "name": "namespace",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "tags_all": {}
+          },
+          "type": "aws_service_discovery_private_dns_namespace",
+          "values": {
+            "description": "Namespace for ECS services",
+            "name": "camunda-r1-oc.service.local",
+            "region": "eu-west-3",
+            "tags": null,
+            "vpc": "vpc-11111111111111111"
+          }
+        },
+        "module.orchestration_cluster_region_1.aws_service_discovery_service.discovery": {
+          "mode": "managed",
+          "name": "discovery",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "dns_config": [
+              {
+                "dns_records": [
+                  {}
+                ]
+              }
+            ],
+            "health_check_config": [],
+            "health_check_custom_config": [],
+            "tags_all": {}
+          },
+          "type": "aws_service_discovery_service",
+          "values": {
+            "description": null,
+            "dns_config": [
+              {
+                "dns_records": [
+                  {
+                    "ttl": 10,
+                    "type": "A"
+                  }
+                ],
+                "routing_policy": "MULTIVALUE"
+              }
+            ],
+            "force_destroy": false,
+            "health_check_config": [],
+            "health_check_custom_config": [],
+            "name": "orchestration-cluster",
+            "region": "eu-west-3",
+            "tags": null
+          }
+        }
+      }
+    }
+  }
+}

--- a/aws/containers/ecs-dual-region-fargate/terraform/infra/test/fixtures/golden/README.md
+++ b/aws/containers/ecs-dual-region-fargate/terraform/infra/test/fixtures/golden/README.md
@@ -1,0 +1,20 @@
+# golden
+
+<!-- BEGIN_TF_DOCS -->
+## Modules
+
+No modules.
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [aws_subnet.region_0_private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet) | data source |
+| [aws_subnet.region_1_private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet) | data source |
+| [terraform_remote_state.vpc](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
+## Inputs
+
+No inputs.
+## Outputs
+
+No outputs.
+<!-- END_TF_DOCS -->

--- a/aws/containers/ecs-dual-region-fargate/terraform/infra/test/fixtures/golden/fixture_vpc_override.tf
+++ b/aws/containers/ecs-dual-region-fargate/terraform/infra/test/fixtures/golden/fixture_vpc_override.tf
@@ -1,0 +1,52 @@
+# Golden-plan fixture (Terraform override file, copied into the module root by
+# the `regenerate-golden-file` recipe and removed afterwards).
+#
+# The infra/ state cannot be planned standalone because it:
+#   1. reads the sibling vpc/ state via data.terraform_remote_state.vpc over an
+#      S3 backend that does not exist during golden generation, and
+#   2. performs live data.aws_subnet lookups on the subnet IDs from that state
+#      (to derive the private-subnet AZs for Aurora).
+#
+# Here we disable both reads (count = 0) and inject a static, deterministic
+# snapshot of the vpc outputs (local.vpc) and the derived AZ lists
+# (region_{0,1}_azs). Everything else — KMS keys, IAM, Aurora Global, ALB/NLB,
+# security groups, secrets — is planned for real, which is the drift we want the
+# golden file to catch. data.aws_caller_identity stays live; the account ID it
+# yields appears only inside ARNs, which the recipe redacts.
+#
+# Values are placeholders; subnet/VPC IDs are syntactically valid but fake.
+
+data "terraform_remote_state" "vpc" {
+  count = 0
+}
+
+data "aws_subnet" "region_0_private" {
+  count = 0
+}
+
+data "aws_subnet" "region_1_private" {
+  count = 0
+}
+
+locals {
+  vpc = {
+    region_0_vpc_id             = "vpc-00000000000000000"
+    region_0_vpc_cidr           = "10.192.0.0/16"
+    region_0_private_subnet_ids = ["subnet-000000000000000a0", "subnet-000000000000000b0", "subnet-000000000000000c0"]
+    region_0_public_subnet_ids  = ["subnet-000000000000000d0", "subnet-000000000000000e0", "subnet-000000000000000f0"]
+
+    region_1_vpc_id             = "vpc-11111111111111111"
+    region_1_vpc_cidr           = "10.202.0.0/16"
+    region_1_private_subnet_ids = ["subnet-000000000000000a1", "subnet-000000000000000b1", "subnet-000000000000000c1"]
+    region_1_public_subnet_ids  = ["subnet-000000000000000d1", "subnet-000000000000000e1", "subnet-000000000000000f1"]
+  }
+
+  # data.aws_subnet.region_{0,1}_private are disabled with count = 0 above because
+  # the fake subnet IDs cannot be looked up live. Their only consumer today is the
+  # region_*_azs locals, so we re-inject region_0_azs directly (aurora-global.tf reads
+  # it as primary_availability_zones). region_1_azs is intentionally NOT set: the module
+  # defines it but no resource consumes it. If a future change consumes these data sources
+  # in a new way (e.g. region_1_azs for the secondary cluster, or subnet CIDRs), add the
+  # corresponding static value here — otherwise it resolves to empty only in the golden plan.
+  region_0_azs = ["eu-west-2a", "eu-west-2b", "eu-west-2c"]
+}

--- a/aws/containers/ecs-dual-region-fargate/terraform/infra/test/golden/golden.tfvars
+++ b/aws/containers/ecs-dual-region-fargate/terraform/infra/test/golden/golden.tfvars
@@ -1,0 +1,12 @@
+# use this file for vars without default values
+# for the golden file generation
+
+aws_profile  = null # uses default AWS credential chain (env vars, default profile, instance profile)
+cluster_name = "camunda"
+
+# The infra state normally reads the sibling vpc state over an S3 backend. For
+# golden generation that read is neutralised by test/fixtures/golden/fixture_vpc_override.tf
+# (a static snapshot of the vpc outputs), so these backend coordinates are never
+# actually contacted — they only satisfy the required-variable check.
+terraform_backend_bucket     = "golden-not-used"
+terraform_backend_key_prefix = "golden-not-used/"

--- a/aws/containers/ecs-dual-region-fargate/terraform/infra/test/golden/tfplan-golden.json
+++ b/aws/containers/ecs-dual-region-fargate/terraform/infra/test/golden/tfplan-golden.json
@@ -1,0 +1,3449 @@
+{
+  "resources": {
+    "aws_cloudwatch_log_group.db_seed[0]": {
+      "identity": {
+        "account_id": null,
+        "name": null,
+        "region": null
+      },
+      "identity_schema_version": 0,
+      "index": 0,
+      "mode": "managed",
+      "name": "db_seed",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "schema_version": 0,
+      "sensitive_values": {
+        "tags_all": {}
+      },
+      "type": "aws_cloudwatch_log_group",
+      "values": {
+        "kms_key_id": null,
+        "name": "/ecs/camunda-r0-db-seed",
+        "region": "eu-west-2",
+        "retention_in_days": 7,
+        "skip_destroy": false,
+        "tags": null
+      }
+    },
+    "aws_ecs_cluster.region_0": {
+      "mode": "managed",
+      "name": "region_0",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "schema_version": 0,
+      "sensitive_values": {
+        "configuration": [],
+        "service_connect_defaults": [],
+        "setting": [
+          {}
+        ],
+        "tags_all": {}
+      },
+      "type": "aws_ecs_cluster",
+      "values": {
+        "configuration": [],
+        "name": "camunda-r0-cluster",
+        "region": "eu-west-2",
+        "service_connect_defaults": [],
+        "setting": [
+          {
+            "name": "containerInsights",
+            "value": "enabled"
+          }
+        ],
+        "tags": null
+      }
+    },
+    "aws_ecs_cluster.region_1": {
+      "mode": "managed",
+      "name": "region_1",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "schema_version": 0,
+      "sensitive_values": {
+        "configuration": [],
+        "service_connect_defaults": [],
+        "setting": [
+          {}
+        ],
+        "tags_all": {}
+      },
+      "type": "aws_ecs_cluster",
+      "values": {
+        "configuration": [],
+        "name": "camunda-r1-cluster",
+        "region": "eu-west-3",
+        "service_connect_defaults": [],
+        "setting": [
+          {
+            "name": "containerInsights",
+            "value": "enabled"
+          }
+        ],
+        "tags": null
+      }
+    },
+    "aws_ecs_task_definition.db_seed[0]": {
+      "identity": {
+        "account_id": null,
+        "family": null,
+        "region": null,
+        "revision": null
+      },
+      "identity_schema_version": 0,
+      "index": 0,
+      "mode": "managed",
+      "name": "db_seed",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "schema_version": 1,
+      "sensitive_values": {
+        "container_definitions": true,
+        "ephemeral_storage": [],
+        "placement_constraints": [],
+        "proxy_configuration": [],
+        "requires_compatibilities": [
+          false
+        ],
+        "runtime_platform": [],
+        "tags_all": {},
+        "volume": []
+      },
+      "type": "aws_ecs_task_definition",
+      "values": {
+        "cpu": "256",
+        "ephemeral_storage": [],
+        "family": "camunda-r0-db-seed",
+        "ipc_mode": null,
+        "memory": "512",
+        "network_mode": "awsvpc",
+        "pid_mode": null,
+        "placement_constraints": [],
+        "proxy_configuration": [],
+        "region": "eu-west-2",
+        "requires_compatibilities": [
+          "FARGATE"
+        ],
+        "runtime_platform": [],
+        "skip_destroy": false,
+        "tags": null,
+        "task_role_arn": null,
+        "track_latest": false,
+        "volume": []
+      }
+    },
+    "aws_iam_policy.ecs_task_secrets_region_0": {
+      "identity": {
+        "arn": null
+      },
+      "identity_schema_version": 0,
+      "mode": "managed",
+      "name": "ecs_task_secrets_region_0",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "schema_version": 0,
+      "sensitive_values": {
+        "tags_all": {}
+      },
+      "type": "aws_iam_policy",
+      "values": {
+        "delay_after_policy_creation_in_ms": null,
+        "description": "Allow ECS task execution role to read Secrets Manager values",
+        "name": "camunda-r0-ecs-task-secrets",
+        "path": "/",
+        "tags": null
+      }
+    },
+    "aws_iam_policy.ecs_task_secrets_region_1": {
+      "identity": {
+        "arn": null
+      },
+      "identity_schema_version": 0,
+      "mode": "managed",
+      "name": "ecs_task_secrets_region_1",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "schema_version": 0,
+      "sensitive_values": {
+        "tags_all": {}
+      },
+      "type": "aws_iam_policy",
+      "values": {
+        "delay_after_policy_creation_in_ms": null,
+        "description": "Allow ECS task execution role to read Secrets Manager values",
+        "name": "camunda-r1-ecs-task-secrets",
+        "path": "/",
+        "tags": null
+      }
+    },
+    "aws_iam_policy.rds_db_connect_region_0[0]": {
+      "identity": {
+        "arn": null
+      },
+      "identity_schema_version": 0,
+      "index": 0,
+      "mode": "managed",
+      "name": "rds_db_connect_region_0",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "schema_version": 0,
+      "sensitive_values": {
+        "tags_all": {}
+      },
+      "type": "aws_iam_policy",
+      "values": {
+        "delay_after_policy_creation_in_ms": null,
+        "description": "Allow ECS tasks to connect to Aurora PostgreSQL as IAM DB user 'camunda'",
+        "name": "camunda-r0-rds-db-connect-camunda",
+        "path": "/",
+        "tags": null
+      }
+    },
+    "aws_iam_policy.rds_db_connect_region_1[0]": {
+      "identity": {
+        "arn": null
+      },
+      "identity_schema_version": 0,
+      "index": 0,
+      "mode": "managed",
+      "name": "rds_db_connect_region_1",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "schema_version": 0,
+      "sensitive_values": {
+        "tags_all": {}
+      },
+      "type": "aws_iam_policy",
+      "values": {
+        "delay_after_policy_creation_in_ms": null,
+        "description": "Allow ECS tasks to connect to Aurora PostgreSQL as IAM DB user 'camunda'",
+        "name": "camunda-r1-rds-db-connect-camunda",
+        "path": "/",
+        "tags": null
+      }
+    },
+    "aws_iam_policy.s3_backup_access_region_0": {
+      "identity": {
+        "arn": null
+      },
+      "identity_schema_version": 0,
+      "mode": "managed",
+      "name": "s3_backup_access_region_0",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "schema_version": 0,
+      "sensitive_values": {
+        "tags_all": {}
+      },
+      "type": "aws_iam_policy",
+      "values": {
+        "delay_after_policy_creation_in_ms": null,
+        "description": "S3 backup bucket access for region 0",
+        "name": "camunda-r0-s3-backup-access",
+        "path": "/",
+        "tags": null
+      }
+    },
+    "aws_iam_role.ecs_task_execution_region_0": {
+      "identity": {
+        "account_id": null,
+        "name": null
+      },
+      "identity_schema_version": 0,
+      "mode": "managed",
+      "name": "ecs_task_execution_region_0",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "schema_version": 0,
+      "sensitive_values": {
+        "inline_policy": [],
+        "managed_policy_arns": [],
+        "tags": {},
+        "tags_all": {}
+      },
+      "type": "aws_iam_role",
+      "values": {
+        "assume_role_policy": "{\"Statement\":[{\"Action\":\"sts:AssumeRole\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"ecs-tasks.amazonaws.com\"}}],\"Version\":\"2012-10-17\"}",
+        "description": null,
+        "force_detach_policies": false,
+        "max_session_duration": 3600,
+        "name": "camunda-r0-ecs-task-execution-role",
+        "path": "/",
+        "permissions_boundary": null,
+        "tags": {
+          "Name": "camunda-r0-ecs-task-execution-role"
+        },
+        "tags_all": {
+          "Name": "camunda-r0-ecs-task-execution-role"
+        }
+      }
+    },
+    "aws_iam_role.ecs_task_execution_region_1": {
+      "identity": {
+        "account_id": null,
+        "name": null
+      },
+      "identity_schema_version": 0,
+      "mode": "managed",
+      "name": "ecs_task_execution_region_1",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "schema_version": 0,
+      "sensitive_values": {
+        "inline_policy": [],
+        "managed_policy_arns": [],
+        "tags": {},
+        "tags_all": {}
+      },
+      "type": "aws_iam_role",
+      "values": {
+        "assume_role_policy": "{\"Statement\":[{\"Action\":\"sts:AssumeRole\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"ecs-tasks.amazonaws.com\"}}],\"Version\":\"2012-10-17\"}",
+        "description": null,
+        "force_detach_policies": false,
+        "max_session_duration": 3600,
+        "name": "camunda-r1-ecs-task-execution-role",
+        "path": "/",
+        "permissions_boundary": null,
+        "tags": {
+          "Name": "camunda-r1-ecs-task-execution-role"
+        },
+        "tags_all": {
+          "Name": "camunda-r1-ecs-task-execution-role"
+        }
+      }
+    },
+    "aws_iam_role_policy_attachment.ecs_task_execution_region_0": {
+      "identity": {
+        "account_id": null,
+        "policy_arn": null,
+        "role": null
+      },
+      "identity_schema_version": 0,
+      "mode": "managed",
+      "name": "ecs_task_execution_region_0",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "schema_version": 0,
+      "sensitive_values": {},
+      "type": "aws_iam_role_policy_attachment",
+      "values": {
+        "policy_arn": "ARN_REDACTED",
+        "role": "camunda-r0-ecs-task-execution-role"
+      }
+    },
+    "aws_iam_role_policy_attachment.ecs_task_execution_region_1": {
+      "identity": {
+        "account_id": null,
+        "policy_arn": null,
+        "role": null
+      },
+      "identity_schema_version": 0,
+      "mode": "managed",
+      "name": "ecs_task_execution_region_1",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "schema_version": 0,
+      "sensitive_values": {},
+      "type": "aws_iam_role_policy_attachment",
+      "values": {
+        "policy_arn": "ARN_REDACTED",
+        "role": "camunda-r1-ecs-task-execution-role"
+      }
+    },
+    "aws_iam_role_policy_attachment.ecs_task_secrets_region_0": {
+      "identity": {
+        "account_id": null,
+        "policy_arn": null,
+        "role": null
+      },
+      "identity_schema_version": 0,
+      "mode": "managed",
+      "name": "ecs_task_secrets_region_0",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "schema_version": 0,
+      "sensitive_values": {},
+      "type": "aws_iam_role_policy_attachment",
+      "values": {
+        "role": "camunda-r0-ecs-task-execution-role"
+      }
+    },
+    "aws_iam_role_policy_attachment.ecs_task_secrets_region_1": {
+      "identity": {
+        "account_id": null,
+        "policy_arn": null,
+        "role": null
+      },
+      "identity_schema_version": 0,
+      "mode": "managed",
+      "name": "ecs_task_secrets_region_1",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "schema_version": 0,
+      "sensitive_values": {},
+      "type": "aws_iam_role_policy_attachment",
+      "values": {
+        "role": "camunda-r1-ecs-task-execution-role"
+      }
+    },
+    "aws_kms_alias.s3_region_0": {
+      "identity": {
+        "account_id": null,
+        "name": null,
+        "region": null
+      },
+      "identity_schema_version": 0,
+      "mode": "managed",
+      "name": "s3_region_0",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "schema_version": 0,
+      "sensitive_values": {},
+      "type": "aws_kms_alias",
+      "values": {
+        "name": "alias/camunda-r0-s3-key",
+        "region": "eu-west-2"
+      }
+    },
+    "aws_kms_alias.secrets_region_0[0]": {
+      "identity": {
+        "account_id": null,
+        "name": null,
+        "region": null
+      },
+      "identity_schema_version": 0,
+      "index": 0,
+      "mode": "managed",
+      "name": "secrets_region_0",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "schema_version": 0,
+      "sensitive_values": {},
+      "type": "aws_kms_alias",
+      "values": {
+        "name": "alias/camunda-r0-secrets",
+        "region": "eu-west-2"
+      }
+    },
+    "aws_kms_alias.secrets_region_1[0]": {
+      "identity": {
+        "account_id": null,
+        "name": null,
+        "region": null
+      },
+      "identity_schema_version": 0,
+      "index": 0,
+      "mode": "managed",
+      "name": "secrets_region_1",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "schema_version": 0,
+      "sensitive_values": {},
+      "type": "aws_kms_alias",
+      "values": {
+        "name": "alias/camunda-r1-secrets",
+        "region": "eu-west-3"
+      }
+    },
+    "aws_kms_key.s3_region_0": {
+      "identity": {
+        "account_id": null,
+        "id": null,
+        "region": null
+      },
+      "identity_schema_version": 0,
+      "mode": "managed",
+      "name": "s3_region_0",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "schema_version": 0,
+      "sensitive_values": {
+        "tags": {},
+        "tags_all": {}
+      },
+      "type": "aws_kms_key",
+      "values": {
+        "bypass_policy_lockout_safety_check": false,
+        "custom_key_store_id": null,
+        "customer_master_key_spec": "SYMMETRIC_DEFAULT",
+        "deletion_window_in_days": 7,
+        "description": "KMS key for camunda-r0 S3 bucket encryption",
+        "enable_key_rotation": true,
+        "is_enabled": true,
+        "key_usage": "ENCRYPT_DECRYPT",
+        "region": "eu-west-2",
+        "tags": {
+          "Name": "camunda-r0-s3-kms-key"
+        },
+        "tags_all": {
+          "Name": "camunda-r0-s3-kms-key"
+        },
+        "timeouts": null,
+        "xks_key_id": null
+      }
+    },
+    "aws_kms_key.secrets_region_0[0]": {
+      "identity": {
+        "account_id": null,
+        "id": null,
+        "region": null
+      },
+      "identity_schema_version": 0,
+      "index": 0,
+      "mode": "managed",
+      "name": "secrets_region_0",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "schema_version": 0,
+      "sensitive_values": {
+        "tags_all": {}
+      },
+      "type": "aws_kms_key",
+      "values": {
+        "bypass_policy_lockout_safety_check": false,
+        "custom_key_store_id": null,
+        "customer_master_key_spec": "SYMMETRIC_DEFAULT",
+        "deletion_window_in_days": 7,
+        "description": "CMK for Secrets Manager secrets (camunda-r0)",
+        "enable_key_rotation": true,
+        "is_enabled": true,
+        "key_usage": "ENCRYPT_DECRYPT",
+        "policy": "{\"Statement\":[{\"Action\":\"kms:*\",\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"ARN_REDACTED",
+        "region": "eu-west-2",
+        "tags": null,
+        "timeouts": null,
+        "xks_key_id": null
+      }
+    },
+    "aws_kms_key.secrets_region_1[0]": {
+      "identity": {
+        "account_id": null,
+        "id": null,
+        "region": null
+      },
+      "identity_schema_version": 0,
+      "index": 0,
+      "mode": "managed",
+      "name": "secrets_region_1",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "schema_version": 0,
+      "sensitive_values": {
+        "tags_all": {}
+      },
+      "type": "aws_kms_key",
+      "values": {
+        "bypass_policy_lockout_safety_check": false,
+        "custom_key_store_id": null,
+        "customer_master_key_spec": "SYMMETRIC_DEFAULT",
+        "deletion_window_in_days": 7,
+        "description": "CMK for Secrets Manager secrets (camunda-r1)",
+        "enable_key_rotation": true,
+        "is_enabled": true,
+        "key_usage": "ENCRYPT_DECRYPT",
+        "policy": "{\"Statement\":[{\"Action\":\"kms:*\",\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"ARN_REDACTED",
+        "region": "eu-west-3",
+        "tags": null,
+        "timeouts": null,
+        "xks_key_id": null
+      }
+    },
+    "aws_lb.alb_region_0": {
+      "identity": {
+        "arn": null
+      },
+      "identity_schema_version": 0,
+      "mode": "managed",
+      "name": "alb_region_0",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "schema_version": 0,
+      "sensitive_values": {
+        "access_logs": [],
+        "connection_logs": [],
+        "health_check_logs": [],
+        "minimum_load_balancer_capacity": [],
+        "security_groups": [],
+        "subnet_mapping": [],
+        "subnets": [
+          false,
+          false,
+          false
+        ],
+        "tags_all": {}
+      },
+      "type": "aws_lb",
+      "values": {
+        "access_logs": [],
+        "client_keep_alive": 3600,
+        "connection_logs": [],
+        "customer_owned_ipv4_pool": null,
+        "desync_mitigation_mode": "defensive",
+        "dns_record_client_routing_policy": null,
+        "drop_invalid_header_fields": false,
+        "enable_cross_zone_load_balancing": null,
+        "enable_deletion_protection": false,
+        "enable_http2": true,
+        "enable_tls_version_and_cipher_suite_headers": false,
+        "enable_waf_fail_open": false,
+        "enable_xff_client_port": false,
+        "enable_zonal_shift": false,
+        "health_check_logs": [],
+        "idle_timeout": 60,
+        "internal": false,
+        "load_balancer_type": "application",
+        "minimum_load_balancer_capacity": [],
+        "name": "camunda-r0-alb",
+        "preserve_host_header": false,
+        "region": "eu-west-2",
+        "subnets": [
+          "subnet-000000000000000d0",
+          "subnet-000000000000000e0",
+          "subnet-000000000000000f0"
+        ],
+        "tags": null,
+        "timeouts": null,
+        "xff_header_processing_mode": "append"
+      }
+    },
+    "aws_lb.alb_region_1": {
+      "identity": {
+        "arn": null
+      },
+      "identity_schema_version": 0,
+      "mode": "managed",
+      "name": "alb_region_1",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "schema_version": 0,
+      "sensitive_values": {
+        "access_logs": [],
+        "connection_logs": [],
+        "health_check_logs": [],
+        "minimum_load_balancer_capacity": [],
+        "security_groups": [],
+        "subnet_mapping": [],
+        "subnets": [
+          false,
+          false,
+          false
+        ],
+        "tags_all": {}
+      },
+      "type": "aws_lb",
+      "values": {
+        "access_logs": [],
+        "client_keep_alive": 3600,
+        "connection_logs": [],
+        "customer_owned_ipv4_pool": null,
+        "desync_mitigation_mode": "defensive",
+        "dns_record_client_routing_policy": null,
+        "drop_invalid_header_fields": false,
+        "enable_cross_zone_load_balancing": null,
+        "enable_deletion_protection": false,
+        "enable_http2": true,
+        "enable_tls_version_and_cipher_suite_headers": false,
+        "enable_waf_fail_open": false,
+        "enable_xff_client_port": false,
+        "enable_zonal_shift": false,
+        "health_check_logs": [],
+        "idle_timeout": 60,
+        "internal": false,
+        "load_balancer_type": "application",
+        "minimum_load_balancer_capacity": [],
+        "name": "camunda-r1-alb",
+        "preserve_host_header": false,
+        "region": "eu-west-3",
+        "subnets": [
+          "subnet-000000000000000d1",
+          "subnet-000000000000000e1",
+          "subnet-000000000000000f1"
+        ],
+        "tags": null,
+        "timeouts": null,
+        "xff_header_processing_mode": "append"
+      }
+    },
+    "aws_lb.nlb_grpc_region_0": {
+      "identity": {
+        "arn": null
+      },
+      "identity_schema_version": 0,
+      "mode": "managed",
+      "name": "nlb_grpc_region_0",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "schema_version": 0,
+      "sensitive_values": {
+        "access_logs": [],
+        "connection_logs": [],
+        "health_check_logs": [],
+        "minimum_load_balancer_capacity": [],
+        "security_groups": [],
+        "subnet_mapping": [],
+        "subnets": [
+          false,
+          false,
+          false
+        ],
+        "tags_all": {}
+      },
+      "type": "aws_lb",
+      "values": {
+        "access_logs": [],
+        "client_keep_alive": null,
+        "connection_logs": [],
+        "customer_owned_ipv4_pool": null,
+        "desync_mitigation_mode": null,
+        "dns_record_client_routing_policy": "any_availability_zone",
+        "drop_invalid_header_fields": null,
+        "enable_cross_zone_load_balancing": false,
+        "enable_deletion_protection": false,
+        "enable_http2": null,
+        "enable_tls_version_and_cipher_suite_headers": null,
+        "enable_waf_fail_open": null,
+        "enable_xff_client_port": null,
+        "enable_zonal_shift": false,
+        "health_check_logs": [],
+        "idle_timeout": null,
+        "internal": false,
+        "load_balancer_type": "network",
+        "minimum_load_balancer_capacity": [],
+        "name": "camunda-r0-nlb-grpc",
+        "preserve_host_header": null,
+        "region": "eu-west-2",
+        "subnets": [
+          "subnet-000000000000000d0",
+          "subnet-000000000000000e0",
+          "subnet-000000000000000f0"
+        ],
+        "tags": null,
+        "timeouts": null,
+        "xff_header_processing_mode": null
+      }
+    },
+    "aws_lb.nlb_grpc_region_1": {
+      "identity": {
+        "arn": null
+      },
+      "identity_schema_version": 0,
+      "mode": "managed",
+      "name": "nlb_grpc_region_1",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "schema_version": 0,
+      "sensitive_values": {
+        "access_logs": [],
+        "connection_logs": [],
+        "health_check_logs": [],
+        "minimum_load_balancer_capacity": [],
+        "security_groups": [],
+        "subnet_mapping": [],
+        "subnets": [
+          false,
+          false,
+          false
+        ],
+        "tags_all": {}
+      },
+      "type": "aws_lb",
+      "values": {
+        "access_logs": [],
+        "client_keep_alive": null,
+        "connection_logs": [],
+        "customer_owned_ipv4_pool": null,
+        "desync_mitigation_mode": null,
+        "dns_record_client_routing_policy": "any_availability_zone",
+        "drop_invalid_header_fields": null,
+        "enable_cross_zone_load_balancing": false,
+        "enable_deletion_protection": false,
+        "enable_http2": null,
+        "enable_tls_version_and_cipher_suite_headers": null,
+        "enable_waf_fail_open": null,
+        "enable_xff_client_port": null,
+        "enable_zonal_shift": false,
+        "health_check_logs": [],
+        "idle_timeout": null,
+        "internal": false,
+        "load_balancer_type": "network",
+        "minimum_load_balancer_capacity": [],
+        "name": "camunda-r1-nlb-grpc",
+        "preserve_host_header": null,
+        "region": "eu-west-3",
+        "subnets": [
+          "subnet-000000000000000d1",
+          "subnet-000000000000000e1",
+          "subnet-000000000000000f1"
+        ],
+        "tags": null,
+        "timeouts": null,
+        "xff_header_processing_mode": null
+      }
+    },
+    "aws_lb.nlb_raft_region_0": {
+      "identity": {
+        "arn": null
+      },
+      "identity_schema_version": 0,
+      "mode": "managed",
+      "name": "nlb_raft_region_0",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "schema_version": 0,
+      "sensitive_values": {
+        "access_logs": [],
+        "connection_logs": [],
+        "health_check_logs": [],
+        "minimum_load_balancer_capacity": [],
+        "security_groups": [],
+        "subnet_mapping": [],
+        "subnets": [
+          false,
+          false,
+          false
+        ],
+        "tags_all": {}
+      },
+      "type": "aws_lb",
+      "values": {
+        "access_logs": [],
+        "client_keep_alive": null,
+        "connection_logs": [],
+        "customer_owned_ipv4_pool": null,
+        "desync_mitigation_mode": null,
+        "dns_record_client_routing_policy": "any_availability_zone",
+        "drop_invalid_header_fields": null,
+        "enable_cross_zone_load_balancing": false,
+        "enable_deletion_protection": false,
+        "enable_http2": null,
+        "enable_tls_version_and_cipher_suite_headers": null,
+        "enable_waf_fail_open": null,
+        "enable_xff_client_port": null,
+        "enable_zonal_shift": false,
+        "health_check_logs": [],
+        "idle_timeout": null,
+        "internal": true,
+        "load_balancer_type": "network",
+        "minimum_load_balancer_capacity": [],
+        "name": "camunda-r0-nlb-raft",
+        "preserve_host_header": null,
+        "region": "eu-west-2",
+        "subnets": [
+          "subnet-000000000000000a0",
+          "subnet-000000000000000b0",
+          "subnet-000000000000000c0"
+        ],
+        "tags": null,
+        "timeouts": null,
+        "xff_header_processing_mode": null
+      }
+    },
+    "aws_lb.nlb_raft_region_1": {
+      "identity": {
+        "arn": null
+      },
+      "identity_schema_version": 0,
+      "mode": "managed",
+      "name": "nlb_raft_region_1",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "schema_version": 0,
+      "sensitive_values": {
+        "access_logs": [],
+        "connection_logs": [],
+        "health_check_logs": [],
+        "minimum_load_balancer_capacity": [],
+        "security_groups": [],
+        "subnet_mapping": [],
+        "subnets": [
+          false,
+          false,
+          false
+        ],
+        "tags_all": {}
+      },
+      "type": "aws_lb",
+      "values": {
+        "access_logs": [],
+        "client_keep_alive": null,
+        "connection_logs": [],
+        "customer_owned_ipv4_pool": null,
+        "desync_mitigation_mode": null,
+        "dns_record_client_routing_policy": "any_availability_zone",
+        "drop_invalid_header_fields": null,
+        "enable_cross_zone_load_balancing": false,
+        "enable_deletion_protection": false,
+        "enable_http2": null,
+        "enable_tls_version_and_cipher_suite_headers": null,
+        "enable_waf_fail_open": null,
+        "enable_xff_client_port": null,
+        "enable_zonal_shift": false,
+        "health_check_logs": [],
+        "idle_timeout": null,
+        "internal": true,
+        "load_balancer_type": "network",
+        "minimum_load_balancer_capacity": [],
+        "name": "camunda-r1-nlb-raft",
+        "preserve_host_header": null,
+        "region": "eu-west-3",
+        "subnets": [
+          "subnet-000000000000000a1",
+          "subnet-000000000000000b1",
+          "subnet-000000000000000c1"
+        ],
+        "tags": null,
+        "timeouts": null,
+        "xff_header_processing_mode": null
+      }
+    },
+    "aws_lb_listener.http_management_region_0": {
+      "identity": {
+        "arn": null
+      },
+      "identity_schema_version": 0,
+      "mode": "managed",
+      "name": "http_management_region_0",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "schema_version": 0,
+      "sensitive_values": {
+        "default_action": [
+          {
+            "authenticate_cognito": [],
+            "authenticate_oidc": [],
+            "fixed_response": [
+              {}
+            ],
+            "forward": [],
+            "jwt_validation": [],
+            "redirect": []
+          }
+        ],
+        "mutual_authentication": [],
+        "tags_all": {}
+      },
+      "type": "aws_lb_listener",
+      "values": {
+        "alpn_policy": null,
+        "certificate_arn": null,
+        "default_action": [
+          {
+            "authenticate_cognito": [],
+            "authenticate_oidc": [],
+            "fixed_response": [
+              {
+                "content_type": "text/plain",
+                "message_body": "",
+                "status_code": "200"
+              }
+            ],
+            "forward": [],
+            "jwt_validation": [],
+            "redirect": [],
+            "target_group_arn": null,
+            "type": "fixed-response"
+          }
+        ],
+        "port": 9600,
+        "protocol": "HTTP",
+        "region": "eu-west-2",
+        "tags": null,
+        "timeouts": null
+      }
+    },
+    "aws_lb_listener.http_management_region_1": {
+      "identity": {
+        "arn": null
+      },
+      "identity_schema_version": 0,
+      "mode": "managed",
+      "name": "http_management_region_1",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "schema_version": 0,
+      "sensitive_values": {
+        "default_action": [
+          {
+            "authenticate_cognito": [],
+            "authenticate_oidc": [],
+            "fixed_response": [
+              {}
+            ],
+            "forward": [],
+            "jwt_validation": [],
+            "redirect": []
+          }
+        ],
+        "mutual_authentication": [],
+        "tags_all": {}
+      },
+      "type": "aws_lb_listener",
+      "values": {
+        "alpn_policy": null,
+        "certificate_arn": null,
+        "default_action": [
+          {
+            "authenticate_cognito": [],
+            "authenticate_oidc": [],
+            "fixed_response": [
+              {
+                "content_type": "text/plain",
+                "message_body": "",
+                "status_code": "200"
+              }
+            ],
+            "forward": [],
+            "jwt_validation": [],
+            "redirect": [],
+            "target_group_arn": null,
+            "type": "fixed-response"
+          }
+        ],
+        "port": 9600,
+        "protocol": "HTTP",
+        "region": "eu-west-3",
+        "tags": null,
+        "timeouts": null
+      }
+    },
+    "aws_lb_listener.http_webapp_region_0": {
+      "identity": {
+        "arn": null
+      },
+      "identity_schema_version": 0,
+      "mode": "managed",
+      "name": "http_webapp_region_0",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "schema_version": 0,
+      "sensitive_values": {
+        "default_action": [
+          {
+            "authenticate_cognito": [],
+            "authenticate_oidc": [],
+            "fixed_response": [
+              {}
+            ],
+            "forward": [],
+            "jwt_validation": [],
+            "redirect": []
+          }
+        ],
+        "mutual_authentication": [],
+        "tags_all": {}
+      },
+      "type": "aws_lb_listener",
+      "values": {
+        "alpn_policy": null,
+        "certificate_arn": null,
+        "default_action": [
+          {
+            "authenticate_cognito": [],
+            "authenticate_oidc": [],
+            "fixed_response": [
+              {
+                "content_type": "text/plain",
+                "message_body": "",
+                "status_code": "200"
+              }
+            ],
+            "forward": [],
+            "jwt_validation": [],
+            "redirect": [],
+            "target_group_arn": null,
+            "type": "fixed-response"
+          }
+        ],
+        "port": 80,
+        "protocol": "HTTP",
+        "region": "eu-west-2",
+        "tags": null,
+        "timeouts": null
+      }
+    },
+    "aws_lb_listener.http_webapp_region_1": {
+      "identity": {
+        "arn": null
+      },
+      "identity_schema_version": 0,
+      "mode": "managed",
+      "name": "http_webapp_region_1",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "schema_version": 0,
+      "sensitive_values": {
+        "default_action": [
+          {
+            "authenticate_cognito": [],
+            "authenticate_oidc": [],
+            "fixed_response": [
+              {}
+            ],
+            "forward": [],
+            "jwt_validation": [],
+            "redirect": []
+          }
+        ],
+        "mutual_authentication": [],
+        "tags_all": {}
+      },
+      "type": "aws_lb_listener",
+      "values": {
+        "alpn_policy": null,
+        "certificate_arn": null,
+        "default_action": [
+          {
+            "authenticate_cognito": [],
+            "authenticate_oidc": [],
+            "fixed_response": [
+              {
+                "content_type": "text/plain",
+                "message_body": "",
+                "status_code": "200"
+              }
+            ],
+            "forward": [],
+            "jwt_validation": [],
+            "redirect": [],
+            "target_group_arn": null,
+            "type": "fixed-response"
+          }
+        ],
+        "port": 80,
+        "protocol": "HTTP",
+        "region": "eu-west-3",
+        "tags": null,
+        "timeouts": null
+      }
+    },
+    "aws_s3_bucket.backup_region_0": {
+      "identity": {
+        "account_id": null,
+        "bucket": null,
+        "region": null
+      },
+      "identity_schema_version": 0,
+      "mode": "managed",
+      "name": "backup_region_0",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "schema_version": 0,
+      "sensitive_values": {
+        "cors_rule": [],
+        "grant": [],
+        "lifecycle_rule": [],
+        "logging": [],
+        "object_lock_configuration": [],
+        "replication_configuration": [],
+        "server_side_encryption_configuration": [],
+        "tags_all": {},
+        "versioning": [],
+        "website": []
+      },
+      "type": "aws_s3_bucket",
+      "values": {
+        "force_destroy": true,
+        "region": "eu-west-2",
+        "tags": null,
+        "timeouts": null
+      }
+    },
+    "aws_s3_bucket_public_access_block.backup_region_0": {
+      "identity": {
+        "account_id": null,
+        "bucket": null,
+        "region": null
+      },
+      "identity_schema_version": 0,
+      "mode": "managed",
+      "name": "backup_region_0",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "schema_version": 0,
+      "sensitive_values": {},
+      "type": "aws_s3_bucket_public_access_block",
+      "values": {
+        "block_public_acls": true,
+        "block_public_policy": true,
+        "ignore_public_acls": true,
+        "region": "eu-west-2",
+        "restrict_public_buckets": true,
+        "skip_destroy": null
+      }
+    },
+    "aws_s3_bucket_server_side_encryption_configuration.backup_region_0": {
+      "identity": {
+        "account_id": null,
+        "bucket": null,
+        "region": null
+      },
+      "identity_schema_version": 1,
+      "mode": "managed",
+      "name": "backup_region_0",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "schema_version": 0,
+      "sensitive_values": {
+        "rule": [
+          {
+            "apply_server_side_encryption_by_default": [
+              {}
+            ],
+            "blocked_encryption_types": []
+          }
+        ]
+      },
+      "type": "aws_s3_bucket_server_side_encryption_configuration",
+      "values": {
+        "expected_bucket_owner": null,
+        "region": "eu-west-2",
+        "rule": [
+          {
+            "apply_server_side_encryption_by_default": [
+              {
+                "sse_algorithm": "aws:kms"
+              }
+            ],
+            "bucket_key_enabled": true
+          }
+        ]
+      }
+    },
+    "aws_s3_bucket_versioning.backup_region_0": {
+      "identity": {
+        "account_id": null,
+        "bucket": null,
+        "region": null
+      },
+      "identity_schema_version": 1,
+      "mode": "managed",
+      "name": "backup_region_0",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "schema_version": 0,
+      "sensitive_values": {
+        "versioning_configuration": [
+          {}
+        ]
+      },
+      "type": "aws_s3_bucket_versioning",
+      "values": {
+        "expected_bucket_owner": null,
+        "mfa": null,
+        "region": "eu-west-2",
+        "versioning_configuration": [
+          {
+            "status": "Enabled"
+          }
+        ]
+      }
+    },
+    "aws_secretsmanager_secret.admin_user_password_region_0": {
+      "identity": {
+        "arn": null
+      },
+      "identity_schema_version": 0,
+      "mode": "managed",
+      "name": "admin_user_password_region_0",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "schema_version": 0,
+      "sensitive_values": {
+        "replica": [],
+        "tags_all": {}
+      },
+      "type": "aws_secretsmanager_secret",
+      "values": {
+        "description": "Password for Camunda admin user (camunda-r0)",
+        "force_overwrite_replica_secret": false,
+        "name": "camunda-r0-oc-admin-user-password",
+        "recovery_window_in_days": 0,
+        "region": "eu-west-2",
+        "tags": null
+      }
+    },
+    "aws_secretsmanager_secret.admin_user_password_region_1": {
+      "identity": {
+        "arn": null
+      },
+      "identity_schema_version": 0,
+      "mode": "managed",
+      "name": "admin_user_password_region_1",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "schema_version": 0,
+      "sensitive_values": {
+        "replica": [],
+        "tags_all": {}
+      },
+      "type": "aws_secretsmanager_secret",
+      "values": {
+        "description": "Password for Camunda admin user (camunda-r1)",
+        "force_overwrite_replica_secret": false,
+        "name": "camunda-r1-oc-admin-user-password",
+        "recovery_window_in_days": 0,
+        "region": "eu-west-3",
+        "tags": null
+      }
+    },
+    "aws_secretsmanager_secret.connectors_password_region_0": {
+      "identity": {
+        "arn": null
+      },
+      "identity_schema_version": 0,
+      "mode": "managed",
+      "name": "connectors_password_region_0",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "schema_version": 0,
+      "sensitive_values": {
+        "replica": [],
+        "tags_all": {}
+      },
+      "type": "aws_secretsmanager_secret",
+      "values": {
+        "description": "Password for Connectors basic auth (camunda-r0)",
+        "force_overwrite_replica_secret": false,
+        "name": "camunda-r0-oc-connectors-password",
+        "recovery_window_in_days": 0,
+        "region": "eu-west-2",
+        "tags": null
+      }
+    },
+    "aws_secretsmanager_secret.connectors_password_region_1": {
+      "identity": {
+        "arn": null
+      },
+      "identity_schema_version": 0,
+      "mode": "managed",
+      "name": "connectors_password_region_1",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "schema_version": 0,
+      "sensitive_values": {
+        "replica": [],
+        "tags_all": {}
+      },
+      "type": "aws_secretsmanager_secret",
+      "values": {
+        "description": "Password for Connectors basic auth (camunda-r1)",
+        "force_overwrite_replica_secret": false,
+        "name": "camunda-r1-oc-connectors-password",
+        "recovery_window_in_days": 0,
+        "region": "eu-west-3",
+        "tags": null
+      }
+    },
+    "aws_secretsmanager_secret.db_admin_password_region_0": {
+      "identity": {
+        "arn": null
+      },
+      "identity_schema_version": 0,
+      "mode": "managed",
+      "name": "db_admin_password_region_0",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "schema_version": 0,
+      "sensitive_values": {
+        "replica": [],
+        "tags_all": {}
+      },
+      "type": "aws_secretsmanager_secret",
+      "values": {
+        "description": "Admin password for Aurora PostgreSQL (camunda-r0)",
+        "force_overwrite_replica_secret": false,
+        "name": "camunda-r0-db-admin-password",
+        "recovery_window_in_days": 0,
+        "region": "eu-west-2",
+        "tags": null
+      }
+    },
+    "aws_secretsmanager_secret_version.admin_user_password_region_0": {
+      "identity": {
+        "account_id": null,
+        "region": null,
+        "secret_id": null,
+        "version_id": null
+      },
+      "identity_schema_version": 0,
+      "mode": "managed",
+      "name": "admin_user_password_region_0",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "schema_version": 0,
+      "sensitive_values": {
+        "secret_binary": true,
+        "secret_string": true,
+        "secret_string_wo": true,
+        "version_stages": []
+      },
+      "type": "aws_secretsmanager_secret_version",
+      "values": {
+        "region": "eu-west-2",
+        "secret_binary": null,
+        "secret_string_wo": null,
+        "secret_string_wo_version": null
+      }
+    },
+    "aws_secretsmanager_secret_version.admin_user_password_region_1": {
+      "identity": {
+        "account_id": null,
+        "region": null,
+        "secret_id": null,
+        "version_id": null
+      },
+      "identity_schema_version": 0,
+      "mode": "managed",
+      "name": "admin_user_password_region_1",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "schema_version": 0,
+      "sensitive_values": {
+        "secret_binary": true,
+        "secret_string": true,
+        "secret_string_wo": true,
+        "version_stages": []
+      },
+      "type": "aws_secretsmanager_secret_version",
+      "values": {
+        "region": "eu-west-3",
+        "secret_binary": null,
+        "secret_string_wo": null,
+        "secret_string_wo_version": null
+      }
+    },
+    "aws_secretsmanager_secret_version.connectors_password_region_0": {
+      "identity": {
+        "account_id": null,
+        "region": null,
+        "secret_id": null,
+        "version_id": null
+      },
+      "identity_schema_version": 0,
+      "mode": "managed",
+      "name": "connectors_password_region_0",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "schema_version": 0,
+      "sensitive_values": {
+        "secret_binary": true,
+        "secret_string": true,
+        "secret_string_wo": true,
+        "version_stages": []
+      },
+      "type": "aws_secretsmanager_secret_version",
+      "values": {
+        "region": "eu-west-2",
+        "secret_binary": null,
+        "secret_string_wo": null,
+        "secret_string_wo_version": null
+      }
+    },
+    "aws_secretsmanager_secret_version.connectors_password_region_1": {
+      "identity": {
+        "account_id": null,
+        "region": null,
+        "secret_id": null,
+        "version_id": null
+      },
+      "identity_schema_version": 0,
+      "mode": "managed",
+      "name": "connectors_password_region_1",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "schema_version": 0,
+      "sensitive_values": {
+        "secret_binary": true,
+        "secret_string": true,
+        "secret_string_wo": true,
+        "version_stages": []
+      },
+      "type": "aws_secretsmanager_secret_version",
+      "values": {
+        "region": "eu-west-3",
+        "secret_binary": null,
+        "secret_string_wo": null,
+        "secret_string_wo_version": null
+      }
+    },
+    "aws_secretsmanager_secret_version.db_admin_password_region_0": {
+      "identity": {
+        "account_id": null,
+        "region": null,
+        "secret_id": null,
+        "version_id": null
+      },
+      "identity_schema_version": 0,
+      "mode": "managed",
+      "name": "db_admin_password_region_0",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "schema_version": 0,
+      "sensitive_values": {
+        "secret_binary": true,
+        "secret_string": true,
+        "secret_string_wo": true,
+        "version_stages": []
+      },
+      "type": "aws_secretsmanager_secret_version",
+      "values": {
+        "region": "eu-west-2",
+        "secret_binary": null,
+        "secret_string_wo": null,
+        "secret_string_wo_version": null
+      }
+    },
+    "aws_security_group.camunda_ports_region_0": {
+      "identity": {
+        "account_id": null,
+        "id": null,
+        "region": null
+      },
+      "identity_schema_version": 0,
+      "mode": "managed",
+      "name": "camunda_ports_region_0",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "schema_version": 1,
+      "sensitive_values": {
+        "egress": [
+          {
+            "cidr_blocks": [
+              false
+            ],
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "security_groups": []
+          },
+          {
+            "cidr_blocks": [
+              false
+            ],
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "security_groups": []
+          },
+          {
+            "cidr_blocks": [
+              false
+            ],
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "security_groups": []
+          },
+          {
+            "cidr_blocks": [
+              false
+            ],
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "security_groups": []
+          },
+          {
+            "cidr_blocks": [
+              false
+            ],
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "security_groups": []
+          },
+          {
+            "cidr_blocks": [
+              false
+            ],
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "security_groups": []
+          },
+          {
+            "cidr_blocks": [
+              false
+            ],
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "security_groups": []
+          },
+          {
+            "cidr_blocks": [
+              false
+            ],
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "security_groups": []
+          },
+          {
+            "cidr_blocks": [],
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "security_groups": []
+          }
+        ],
+        "ingress": [
+          {
+            "cidr_blocks": [
+              false
+            ],
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "security_groups": []
+          },
+          {
+            "cidr_blocks": [
+              false
+            ],
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "security_groups": []
+          },
+          {
+            "cidr_blocks": [
+              false
+            ],
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "security_groups": []
+          },
+          {
+            "cidr_blocks": [
+              false
+            ],
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "security_groups": []
+          },
+          {
+            "cidr_blocks": [
+              false
+            ],
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "security_groups": []
+          },
+          {
+            "cidr_blocks": [
+              false
+            ],
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "security_groups": []
+          },
+          {
+            "cidr_blocks": [
+              false
+            ],
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "security_groups": []
+          }
+        ],
+        "tags": {},
+        "tags_all": {}
+      },
+      "type": "aws_security_group",
+      "values": {
+        "description": "Allow necessary Camunda ports within VPC and cross-region",
+        "egress": [
+          {
+            "cidr_blocks": [
+              "10.192.0.0/16"
+            ],
+            "description": "Allow outbound on port 26500 to local VPC",
+            "from_port": 26500,
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "protocol": "tcp",
+            "security_groups": [],
+            "self": false,
+            "to_port": 26500
+          },
+          {
+            "cidr_blocks": [
+              "10.192.0.0/16"
+            ],
+            "description": "Allow outbound on port 26501 to local VPC",
+            "from_port": 26501,
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "protocol": "tcp",
+            "security_groups": [],
+            "self": false,
+            "to_port": 26501
+          },
+          {
+            "cidr_blocks": [
+              "10.192.0.0/16"
+            ],
+            "description": "Allow outbound on port 26502 to local VPC",
+            "from_port": 26502,
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "protocol": "tcp",
+            "security_groups": [],
+            "self": false,
+            "to_port": 26502
+          },
+          {
+            "cidr_blocks": [
+              "10.192.0.0/16"
+            ],
+            "description": "Allow outbound on port 5432 to local VPC",
+            "from_port": 5432,
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "protocol": "tcp",
+            "security_groups": [],
+            "self": false,
+            "to_port": 5432
+          },
+          {
+            "cidr_blocks": [
+              "10.192.0.0/16"
+            ],
+            "description": "Allow outbound on port 8080 to local VPC",
+            "from_port": 8080,
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "protocol": "tcp",
+            "security_groups": [],
+            "self": false,
+            "to_port": 8080
+          },
+          {
+            "cidr_blocks": [
+              "10.192.0.0/16"
+            ],
+            "description": "Allow outbound on port 9600 to local VPC",
+            "from_port": 9600,
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "protocol": "tcp",
+            "security_groups": [],
+            "self": false,
+            "to_port": 9600
+          },
+          {
+            "cidr_blocks": [
+              "10.202.0.0/16"
+            ],
+            "description": "Allow Aurora traffic to region 1",
+            "from_port": 5432,
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "protocol": "tcp",
+            "security_groups": [],
+            "self": false,
+            "to_port": 5432
+          },
+          {
+            "cidr_blocks": [
+              "10.202.0.0/16"
+            ],
+            "description": "Allow cross-region Zeebe cluster traffic to region 1",
+            "from_port": 26500,
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "protocol": "tcp",
+            "security_groups": [],
+            "self": false,
+            "to_port": 26502
+          },
+          {
+            "cidr_blocks": [],
+            "description": "Allow NFS traffic to EFS",
+            "from_port": 2049,
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "protocol": "tcp",
+            "self": false,
+            "to_port": 2049
+          }
+        ],
+        "ingress": [
+          {
+            "cidr_blocks": [
+              "10.192.0.0/16"
+            ],
+            "description": "Allow inbound on port 26500 from local VPC",
+            "from_port": 26500,
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "protocol": "tcp",
+            "security_groups": [],
+            "self": false,
+            "to_port": 26500
+          },
+          {
+            "cidr_blocks": [
+              "10.192.0.0/16"
+            ],
+            "description": "Allow inbound on port 26501 from local VPC",
+            "from_port": 26501,
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "protocol": "tcp",
+            "security_groups": [],
+            "self": false,
+            "to_port": 26501
+          },
+          {
+            "cidr_blocks": [
+              "10.192.0.0/16"
+            ],
+            "description": "Allow inbound on port 26502 from local VPC",
+            "from_port": 26502,
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "protocol": "tcp",
+            "security_groups": [],
+            "self": false,
+            "to_port": 26502
+          },
+          {
+            "cidr_blocks": [
+              "10.192.0.0/16"
+            ],
+            "description": "Allow inbound on port 5432 from local VPC",
+            "from_port": 5432,
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "protocol": "tcp",
+            "security_groups": [],
+            "self": false,
+            "to_port": 5432
+          },
+          {
+            "cidr_blocks": [
+              "10.192.0.0/16"
+            ],
+            "description": "Allow inbound on port 8080 from local VPC",
+            "from_port": 8080,
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "protocol": "tcp",
+            "security_groups": [],
+            "self": false,
+            "to_port": 8080
+          },
+          {
+            "cidr_blocks": [
+              "10.192.0.0/16"
+            ],
+            "description": "Allow inbound on port 9600 from local VPC",
+            "from_port": 9600,
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "protocol": "tcp",
+            "security_groups": [],
+            "self": false,
+            "to_port": 9600
+          },
+          {
+            "cidr_blocks": [
+              "10.202.0.0/16"
+            ],
+            "description": "Allow cross-region Zeebe cluster traffic from region 1",
+            "from_port": 26500,
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "protocol": "tcp",
+            "security_groups": [],
+            "self": false,
+            "to_port": 26502
+          }
+        ],
+        "name": "camunda-r0-camunda-ports",
+        "region": "eu-west-2",
+        "revoke_rules_on_delete": false,
+        "tags": {
+          "Name": "camunda-r0-camunda-ports"
+        },
+        "tags_all": {
+          "Name": "camunda-r0-camunda-ports"
+        },
+        "timeouts": null,
+        "vpc_id": "vpc-00000000000000000"
+      }
+    },
+    "aws_security_group.camunda_ports_region_1": {
+      "identity": {
+        "account_id": null,
+        "id": null,
+        "region": null
+      },
+      "identity_schema_version": 0,
+      "mode": "managed",
+      "name": "camunda_ports_region_1",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "schema_version": 1,
+      "sensitive_values": {
+        "egress": [
+          {
+            "cidr_blocks": [
+              false
+            ],
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "security_groups": []
+          },
+          {
+            "cidr_blocks": [
+              false
+            ],
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "security_groups": []
+          },
+          {
+            "cidr_blocks": [
+              false
+            ],
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "security_groups": []
+          },
+          {
+            "cidr_blocks": [
+              false
+            ],
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "security_groups": []
+          },
+          {
+            "cidr_blocks": [
+              false
+            ],
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "security_groups": []
+          },
+          {
+            "cidr_blocks": [
+              false
+            ],
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "security_groups": []
+          },
+          {
+            "cidr_blocks": [
+              false
+            ],
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "security_groups": []
+          },
+          {
+            "cidr_blocks": [
+              false
+            ],
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "security_groups": []
+          },
+          {
+            "cidr_blocks": [],
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "security_groups": []
+          }
+        ],
+        "ingress": [
+          {
+            "cidr_blocks": [
+              false
+            ],
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "security_groups": []
+          },
+          {
+            "cidr_blocks": [
+              false
+            ],
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "security_groups": []
+          },
+          {
+            "cidr_blocks": [
+              false
+            ],
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "security_groups": []
+          },
+          {
+            "cidr_blocks": [
+              false
+            ],
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "security_groups": []
+          },
+          {
+            "cidr_blocks": [
+              false
+            ],
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "security_groups": []
+          },
+          {
+            "cidr_blocks": [
+              false
+            ],
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "security_groups": []
+          },
+          {
+            "cidr_blocks": [
+              false
+            ],
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "security_groups": []
+          }
+        ],
+        "tags": {},
+        "tags_all": {}
+      },
+      "type": "aws_security_group",
+      "values": {
+        "description": "Allow necessary Camunda ports within VPC and cross-region",
+        "egress": [
+          {
+            "cidr_blocks": [
+              "10.192.0.0/16"
+            ],
+            "description": "Allow Aurora traffic to region 0 (Global DB writer)",
+            "from_port": 5432,
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "protocol": "tcp",
+            "security_groups": [],
+            "self": false,
+            "to_port": 5432
+          },
+          {
+            "cidr_blocks": [
+              "10.192.0.0/16"
+            ],
+            "description": "Allow cross-region Zeebe cluster traffic to region 0",
+            "from_port": 26500,
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "protocol": "tcp",
+            "security_groups": [],
+            "self": false,
+            "to_port": 26502
+          },
+          {
+            "cidr_blocks": [
+              "10.202.0.0/16"
+            ],
+            "description": "Allow outbound on port 26500 to local VPC",
+            "from_port": 26500,
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "protocol": "tcp",
+            "security_groups": [],
+            "self": false,
+            "to_port": 26500
+          },
+          {
+            "cidr_blocks": [
+              "10.202.0.0/16"
+            ],
+            "description": "Allow outbound on port 26501 to local VPC",
+            "from_port": 26501,
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "protocol": "tcp",
+            "security_groups": [],
+            "self": false,
+            "to_port": 26501
+          },
+          {
+            "cidr_blocks": [
+              "10.202.0.0/16"
+            ],
+            "description": "Allow outbound on port 26502 to local VPC",
+            "from_port": 26502,
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "protocol": "tcp",
+            "security_groups": [],
+            "self": false,
+            "to_port": 26502
+          },
+          {
+            "cidr_blocks": [
+              "10.202.0.0/16"
+            ],
+            "description": "Allow outbound on port 5432 to local VPC",
+            "from_port": 5432,
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "protocol": "tcp",
+            "security_groups": [],
+            "self": false,
+            "to_port": 5432
+          },
+          {
+            "cidr_blocks": [
+              "10.202.0.0/16"
+            ],
+            "description": "Allow outbound on port 8080 to local VPC",
+            "from_port": 8080,
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "protocol": "tcp",
+            "security_groups": [],
+            "self": false,
+            "to_port": 8080
+          },
+          {
+            "cidr_blocks": [
+              "10.202.0.0/16"
+            ],
+            "description": "Allow outbound on port 9600 to local VPC",
+            "from_port": 9600,
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "protocol": "tcp",
+            "security_groups": [],
+            "self": false,
+            "to_port": 9600
+          },
+          {
+            "cidr_blocks": [],
+            "description": "Allow NFS traffic to EFS",
+            "from_port": 2049,
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "protocol": "tcp",
+            "self": false,
+            "to_port": 2049
+          }
+        ],
+        "ingress": [
+          {
+            "cidr_blocks": [
+              "10.192.0.0/16"
+            ],
+            "description": "Allow cross-region Zeebe cluster traffic from region 0",
+            "from_port": 26500,
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "protocol": "tcp",
+            "security_groups": [],
+            "self": false,
+            "to_port": 26502
+          },
+          {
+            "cidr_blocks": [
+              "10.202.0.0/16"
+            ],
+            "description": "Allow inbound on port 26500 from local VPC",
+            "from_port": 26500,
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "protocol": "tcp",
+            "security_groups": [],
+            "self": false,
+            "to_port": 26500
+          },
+          {
+            "cidr_blocks": [
+              "10.202.0.0/16"
+            ],
+            "description": "Allow inbound on port 26501 from local VPC",
+            "from_port": 26501,
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "protocol": "tcp",
+            "security_groups": [],
+            "self": false,
+            "to_port": 26501
+          },
+          {
+            "cidr_blocks": [
+              "10.202.0.0/16"
+            ],
+            "description": "Allow inbound on port 26502 from local VPC",
+            "from_port": 26502,
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "protocol": "tcp",
+            "security_groups": [],
+            "self": false,
+            "to_port": 26502
+          },
+          {
+            "cidr_blocks": [
+              "10.202.0.0/16"
+            ],
+            "description": "Allow inbound on port 5432 from local VPC",
+            "from_port": 5432,
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "protocol": "tcp",
+            "security_groups": [],
+            "self": false,
+            "to_port": 5432
+          },
+          {
+            "cidr_blocks": [
+              "10.202.0.0/16"
+            ],
+            "description": "Allow inbound on port 8080 from local VPC",
+            "from_port": 8080,
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "protocol": "tcp",
+            "security_groups": [],
+            "self": false,
+            "to_port": 8080
+          },
+          {
+            "cidr_blocks": [
+              "10.202.0.0/16"
+            ],
+            "description": "Allow inbound on port 9600 from local VPC",
+            "from_port": 9600,
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "protocol": "tcp",
+            "security_groups": [],
+            "self": false,
+            "to_port": 9600
+          }
+        ],
+        "name": "camunda-r1-camunda-ports",
+        "region": "eu-west-3",
+        "revoke_rules_on_delete": false,
+        "tags": {
+          "Name": "camunda-r1-camunda-ports"
+        },
+        "tags_all": {
+          "Name": "camunda-r1-camunda-ports"
+        },
+        "timeouts": null,
+        "vpc_id": "vpc-11111111111111111"
+      }
+    },
+    "aws_security_group.efs_region_0": {
+      "identity": {
+        "account_id": null,
+        "id": null,
+        "region": null
+      },
+      "identity_schema_version": 0,
+      "mode": "managed",
+      "name": "efs_region_0",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "schema_version": 1,
+      "sensitive_values": {
+        "egress": [
+          {
+            "cidr_blocks": [
+              false
+            ],
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "security_groups": []
+          }
+        ],
+        "ingress": [
+          {
+            "cidr_blocks": [
+              false
+            ],
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "security_groups": []
+          }
+        ],
+        "tags": {},
+        "tags_all": {}
+      },
+      "type": "aws_security_group",
+      "values": {
+        "description": "Security group for EFS",
+        "egress": [
+          {
+            "cidr_blocks": [
+              "10.192.0.0/16"
+            ],
+            "description": "NFS outbound",
+            "from_port": 2049,
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "protocol": "tcp",
+            "security_groups": [],
+            "self": false,
+            "to_port": 2049
+          }
+        ],
+        "ingress": [
+          {
+            "cidr_blocks": [
+              "10.192.0.0/16"
+            ],
+            "description": "NFS from ECS tasks",
+            "from_port": 2049,
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "protocol": "tcp",
+            "security_groups": [],
+            "self": false,
+            "to_port": 2049
+          }
+        ],
+        "name": "camunda-r0-efs",
+        "region": "eu-west-2",
+        "revoke_rules_on_delete": false,
+        "tags": {
+          "Name": "camunda-r0-efs"
+        },
+        "tags_all": {
+          "Name": "camunda-r0-efs"
+        },
+        "timeouts": null,
+        "vpc_id": "vpc-00000000000000000"
+      }
+    },
+    "aws_security_group.efs_region_1": {
+      "identity": {
+        "account_id": null,
+        "id": null,
+        "region": null
+      },
+      "identity_schema_version": 0,
+      "mode": "managed",
+      "name": "efs_region_1",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "schema_version": 1,
+      "sensitive_values": {
+        "egress": [
+          {
+            "cidr_blocks": [
+              false
+            ],
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "security_groups": []
+          }
+        ],
+        "ingress": [
+          {
+            "cidr_blocks": [
+              false
+            ],
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "security_groups": []
+          }
+        ],
+        "tags": {},
+        "tags_all": {}
+      },
+      "type": "aws_security_group",
+      "values": {
+        "description": "Security group for EFS",
+        "egress": [
+          {
+            "cidr_blocks": [
+              "10.202.0.0/16"
+            ],
+            "description": "NFS outbound",
+            "from_port": 2049,
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "protocol": "tcp",
+            "security_groups": [],
+            "self": false,
+            "to_port": 2049
+          }
+        ],
+        "ingress": [
+          {
+            "cidr_blocks": [
+              "10.202.0.0/16"
+            ],
+            "description": "NFS from ECS tasks",
+            "from_port": 2049,
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "protocol": "tcp",
+            "security_groups": [],
+            "self": false,
+            "to_port": 2049
+          }
+        ],
+        "name": "camunda-r1-efs",
+        "region": "eu-west-3",
+        "revoke_rules_on_delete": false,
+        "tags": {
+          "Name": "camunda-r1-efs"
+        },
+        "tags_all": {
+          "Name": "camunda-r1-efs"
+        },
+        "timeouts": null,
+        "vpc_id": "vpc-11111111111111111"
+      }
+    },
+    "aws_security_group.package_80_443_region_0": {
+      "identity": {
+        "account_id": null,
+        "id": null,
+        "region": null
+      },
+      "identity_schema_version": 0,
+      "mode": "managed",
+      "name": "package_80_443_region_0",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "schema_version": 1,
+      "sensitive_values": {
+        "egress": [
+          {
+            "cidr_blocks": [
+              false
+            ],
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "security_groups": []
+          },
+          {
+            "cidr_blocks": [
+              false
+            ],
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "security_groups": []
+          }
+        ],
+        "ingress": [],
+        "tags": {},
+        "tags_all": {}
+      },
+      "type": "aws_security_group",
+      "values": {
+        "description": "Allow remote HTTP/HTTPS for package updates",
+        "egress": [
+          {
+            "cidr_blocks": [
+              "0.0.0.0/0"
+            ],
+            "description": "Allow outbound HTTP",
+            "from_port": 80,
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "protocol": "tcp",
+            "security_groups": [],
+            "self": false,
+            "to_port": 80
+          },
+          {
+            "cidr_blocks": [
+              "0.0.0.0/0"
+            ],
+            "description": "Allow outbound HTTPS",
+            "from_port": 443,
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "protocol": "tcp",
+            "security_groups": [],
+            "self": false,
+            "to_port": 443
+          }
+        ],
+        "name": "camunda-r0-package-80-443",
+        "region": "eu-west-2",
+        "revoke_rules_on_delete": false,
+        "tags": {
+          "Name": "camunda-r0-package-80-443"
+        },
+        "tags_all": {
+          "Name": "camunda-r0-package-80-443"
+        },
+        "timeouts": null,
+        "vpc_id": "vpc-00000000000000000"
+      }
+    },
+    "aws_security_group.package_80_443_region_1": {
+      "identity": {
+        "account_id": null,
+        "id": null,
+        "region": null
+      },
+      "identity_schema_version": 0,
+      "mode": "managed",
+      "name": "package_80_443_region_1",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "schema_version": 1,
+      "sensitive_values": {
+        "egress": [
+          {
+            "cidr_blocks": [
+              false
+            ],
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "security_groups": []
+          },
+          {
+            "cidr_blocks": [
+              false
+            ],
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "security_groups": []
+          }
+        ],
+        "ingress": [],
+        "tags": {},
+        "tags_all": {}
+      },
+      "type": "aws_security_group",
+      "values": {
+        "description": "Allow remote HTTP/HTTPS for package updates",
+        "egress": [
+          {
+            "cidr_blocks": [
+              "0.0.0.0/0"
+            ],
+            "description": "Allow outbound HTTP",
+            "from_port": 80,
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "protocol": "tcp",
+            "security_groups": [],
+            "self": false,
+            "to_port": 80
+          },
+          {
+            "cidr_blocks": [
+              "0.0.0.0/0"
+            ],
+            "description": "Allow outbound HTTPS",
+            "from_port": 443,
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "protocol": "tcp",
+            "security_groups": [],
+            "self": false,
+            "to_port": 443
+          }
+        ],
+        "name": "camunda-r1-package-80-443",
+        "region": "eu-west-3",
+        "revoke_rules_on_delete": false,
+        "tags": {
+          "Name": "camunda-r1-package-80-443"
+        },
+        "tags_all": {
+          "Name": "camunda-r1-package-80-443"
+        },
+        "timeouts": null,
+        "vpc_id": "vpc-11111111111111111"
+      }
+    },
+    "aws_security_group.remote_access_region_0": {
+      "identity": {
+        "account_id": null,
+        "id": null,
+        "region": null
+      },
+      "identity_schema_version": 0,
+      "mode": "managed",
+      "name": "remote_access_region_0",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "schema_version": 1,
+      "sensitive_values": {
+        "egress": [
+          {
+            "cidr_blocks": [
+              false
+            ],
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "security_groups": []
+          }
+        ],
+        "ingress": [
+          {
+            "cidr_blocks": [
+              false
+            ],
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "security_groups": []
+          },
+          {
+            "cidr_blocks": [
+              false
+            ],
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "security_groups": []
+          },
+          {
+            "cidr_blocks": [
+              false
+            ],
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "security_groups": []
+          },
+          {
+            "cidr_blocks": [
+              false
+            ],
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "security_groups": []
+          }
+        ],
+        "tags": {},
+        "tags_all": {}
+      },
+      "type": "aws_security_group",
+      "values": {
+        "description": "Allow remote access to LoadBalancers",
+        "egress": [
+          {
+            "cidr_blocks": [
+              "0.0.0.0/0"
+            ],
+            "description": "Allow outbound to remote CIDRs",
+            "from_port": 0,
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "protocol": "-1",
+            "security_groups": [],
+            "self": false,
+            "to_port": 0
+          }
+        ],
+        "ingress": [
+          {
+            "cidr_blocks": [
+              "0.0.0.0/0"
+            ],
+            "description": "Allow inbound HTTP",
+            "from_port": 80,
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "protocol": "tcp",
+            "security_groups": [],
+            "self": false,
+            "to_port": 80
+          },
+          {
+            "cidr_blocks": [
+              "0.0.0.0/0"
+            ],
+            "description": "Allow inbound HTTPS",
+            "from_port": 443,
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "protocol": "tcp",
+            "security_groups": [],
+            "self": false,
+            "to_port": 443
+          },
+          {
+            "cidr_blocks": [
+              "0.0.0.0/0"
+            ],
+            "description": "Allow inbound gRPC",
+            "from_port": 26500,
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "protocol": "tcp",
+            "security_groups": [],
+            "self": false,
+            "to_port": 26500
+          },
+          {
+            "cidr_blocks": [
+              "0.0.0.0/0"
+            ],
+            "description": "Allow inbound management",
+            "from_port": 9600,
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "protocol": "tcp",
+            "security_groups": [],
+            "self": false,
+            "to_port": 9600
+          }
+        ],
+        "name": "camunda-r0-remote-access",
+        "region": "eu-west-2",
+        "revoke_rules_on_delete": false,
+        "tags": {
+          "Name": "camunda-r0-remote-access"
+        },
+        "tags_all": {
+          "Name": "camunda-r0-remote-access"
+        },
+        "timeouts": null,
+        "vpc_id": "vpc-00000000000000000"
+      }
+    },
+    "aws_security_group.remote_access_region_1": {
+      "identity": {
+        "account_id": null,
+        "id": null,
+        "region": null
+      },
+      "identity_schema_version": 0,
+      "mode": "managed",
+      "name": "remote_access_region_1",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "schema_version": 1,
+      "sensitive_values": {
+        "egress": [
+          {
+            "cidr_blocks": [
+              false
+            ],
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "security_groups": []
+          }
+        ],
+        "ingress": [
+          {
+            "cidr_blocks": [
+              false
+            ],
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "security_groups": []
+          },
+          {
+            "cidr_blocks": [
+              false
+            ],
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "security_groups": []
+          },
+          {
+            "cidr_blocks": [
+              false
+            ],
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "security_groups": []
+          },
+          {
+            "cidr_blocks": [
+              false
+            ],
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "security_groups": []
+          }
+        ],
+        "tags": {},
+        "tags_all": {}
+      },
+      "type": "aws_security_group",
+      "values": {
+        "description": "Allow remote access to LoadBalancers",
+        "egress": [
+          {
+            "cidr_blocks": [
+              "0.0.0.0/0"
+            ],
+            "description": "Allow outbound to remote CIDRs",
+            "from_port": 0,
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "protocol": "-1",
+            "security_groups": [],
+            "self": false,
+            "to_port": 0
+          }
+        ],
+        "ingress": [
+          {
+            "cidr_blocks": [
+              "0.0.0.0/0"
+            ],
+            "description": "Allow inbound HTTP",
+            "from_port": 80,
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "protocol": "tcp",
+            "security_groups": [],
+            "self": false,
+            "to_port": 80
+          },
+          {
+            "cidr_blocks": [
+              "0.0.0.0/0"
+            ],
+            "description": "Allow inbound HTTPS",
+            "from_port": 443,
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "protocol": "tcp",
+            "security_groups": [],
+            "self": false,
+            "to_port": 443
+          },
+          {
+            "cidr_blocks": [
+              "0.0.0.0/0"
+            ],
+            "description": "Allow inbound gRPC",
+            "from_port": 26500,
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "protocol": "tcp",
+            "security_groups": [],
+            "self": false,
+            "to_port": 26500
+          },
+          {
+            "cidr_blocks": [
+              "0.0.0.0/0"
+            ],
+            "description": "Allow inbound management",
+            "from_port": 9600,
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "protocol": "tcp",
+            "security_groups": [],
+            "self": false,
+            "to_port": 9600
+          }
+        ],
+        "name": "camunda-r1-remote-access",
+        "region": "eu-west-3",
+        "revoke_rules_on_delete": false,
+        "tags": {
+          "Name": "camunda-r1-remote-access"
+        },
+        "tags_all": {
+          "Name": "camunda-r1-remote-access"
+        },
+        "timeouts": null,
+        "vpc_id": "vpc-11111111111111111"
+      }
+    },
+    "module.aurora_global[0]": {
+      "resources": {
+        "module.aurora_global[0].aws_db_subnet_group.primary": {
+          "identity": {
+            "account_id": null,
+            "name": null,
+            "region": null
+          },
+          "identity_schema_version": 0,
+          "mode": "managed",
+          "name": "primary",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "subnet_ids": [
+              false,
+              false,
+              false
+            ],
+            "supported_network_types": [],
+            "tags_all": {}
+          },
+          "type": "aws_db_subnet_group",
+          "values": {
+            "description": "Subnet group for Aurora primary cluster camunda-r0-camunda-db",
+            "name": "camunda-r0-camunda-db",
+            "region": "eu-west-2",
+            "subnet_ids": [
+              "subnet-000000000000000a0",
+              "subnet-000000000000000b0",
+              "subnet-000000000000000c0"
+            ],
+            "tags": null
+          }
+        },
+        "module.aurora_global[0].aws_db_subnet_group.secondary": {
+          "identity": {
+            "account_id": null,
+            "name": null,
+            "region": null
+          },
+          "identity_schema_version": 0,
+          "mode": "managed",
+          "name": "secondary",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "subnet_ids": [
+              false,
+              false,
+              false
+            ],
+            "supported_network_types": [],
+            "tags_all": {}
+          },
+          "type": "aws_db_subnet_group",
+          "values": {
+            "description": "Subnet group for Aurora secondary cluster camunda-r1-camunda-db",
+            "name": "camunda-r1-camunda-db",
+            "region": "eu-west-3",
+            "subnet_ids": [
+              "subnet-000000000000000a1",
+              "subnet-000000000000000b1",
+              "subnet-000000000000000c1"
+            ],
+            "tags": null
+          }
+        },
+        "module.aurora_global[0].aws_kms_key.primary": {
+          "identity": {
+            "account_id": null,
+            "id": null,
+            "region": null
+          },
+          "identity_schema_version": 0,
+          "mode": "managed",
+          "name": "primary",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "tags_all": {}
+          },
+          "type": "aws_kms_key",
+          "values": {
+            "bypass_policy_lockout_safety_check": false,
+            "custom_key_store_id": null,
+            "customer_master_key_spec": "SYMMETRIC_DEFAULT",
+            "deletion_window_in_days": 7,
+            "description": "camunda-r0-camunda-db-key",
+            "enable_key_rotation": true,
+            "is_enabled": true,
+            "key_usage": "ENCRYPT_DECRYPT",
+            "region": "eu-west-2",
+            "tags": null,
+            "timeouts": null,
+            "xks_key_id": null
+          }
+        },
+        "module.aurora_global[0].aws_kms_key.secondary": {
+          "identity": {
+            "account_id": null,
+            "id": null,
+            "region": null
+          },
+          "identity_schema_version": 0,
+          "mode": "managed",
+          "name": "secondary",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "tags_all": {}
+          },
+          "type": "aws_kms_key",
+          "values": {
+            "bypass_policy_lockout_safety_check": false,
+            "custom_key_store_id": null,
+            "customer_master_key_spec": "SYMMETRIC_DEFAULT",
+            "deletion_window_in_days": 7,
+            "description": "camunda-r1-camunda-db-key",
+            "enable_key_rotation": true,
+            "is_enabled": true,
+            "key_usage": "ENCRYPT_DECRYPT",
+            "region": "eu-west-3",
+            "tags": null,
+            "timeouts": null,
+            "xks_key_id": null
+          }
+        },
+        "module.aurora_global[0].aws_rds_cluster.primary": {
+          "identity": {
+            "account_id": null,
+            "cluster_identifier": null,
+            "region": null
+          },
+          "identity_schema_version": 0,
+          "mode": "managed",
+          "name": "primary",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 1,
+          "sensitive_values": {
+            "availability_zones": [
+              false,
+              false,
+              false
+            ],
+            "cluster_members": [],
+            "iam_roles": [],
+            "master_password": true,
+            "master_password_wo": true,
+            "master_user_secret": [],
+            "master_username": true,
+            "restore_to_point_in_time": [],
+            "s3_import": [],
+            "scaling_configuration": [],
+            "serverlessv2_scaling_configuration": [],
+            "tags_all": {},
+            "vpc_security_group_ids": []
+          },
+          "type": "aws_rds_cluster",
+          "values": {
+            "allow_major_version_upgrade": null,
+            "apply_immediately": true,
+            "availability_zones": [
+              "eu-west-2a",
+              "eu-west-2b",
+              "eu-west-2c"
+            ],
+            "backtrack_window": null,
+            "backup_retention_period": 7,
+            "cluster_identifier": "camunda-r0-camunda-db",
+            "copy_tags_to_snapshot": true,
+            "database_name": "camunda",
+            "db_cluster_instance_class": null,
+            "db_instance_parameter_group_name": null,
+            "db_subnet_group_name": "camunda-r0-camunda-db",
+            "delete_automated_backups": true,
+            "deletion_protection": null,
+            "domain": null,
+            "domain_iam_role_name": null,
+            "enable_global_write_forwarding": false,
+            "enable_http_endpoint": false,
+            "enable_local_write_forwarding": false,
+            "enabled_cloudwatch_logs_exports": null,
+            "engine": "aurora-postgresql",
+            "engine_mode": "provisioned",
+            "engine_version": "18.3",
+            "final_snapshot_identifier": null,
+            "iam_database_authentication_enabled": true,
+            "iops": null,
+            "manage_master_user_password": null,
+            "master_password_wo": null,
+            "master_password_wo_version": null,
+            "master_username": "camunda_admin",
+            "performance_insights_enabled": null,
+            "region": "eu-west-2",
+            "replication_source_identifier": null,
+            "restore_to_point_in_time": [],
+            "s3_import": [],
+            "scaling_configuration": [],
+            "serverlessv2_scaling_configuration": [],
+            "skip_final_snapshot": true,
+            "snapshot_identifier": null,
+            "source_region": null,
+            "storage_encrypted": true,
+            "tags": null,
+            "timeouts": null
+          }
+        },
+        "module.aurora_global[0].aws_rds_cluster.secondary": {
+          "identity": {
+            "account_id": null,
+            "cluster_identifier": null,
+            "region": null
+          },
+          "identity_schema_version": 0,
+          "mode": "managed",
+          "name": "secondary",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 1,
+          "sensitive_values": {
+            "availability_zones": [],
+            "cluster_members": [],
+            "iam_roles": [],
+            "master_password": true,
+            "master_password_wo": true,
+            "master_user_secret": [],
+            "restore_to_point_in_time": [],
+            "s3_import": [],
+            "scaling_configuration": [],
+            "serverlessv2_scaling_configuration": [],
+            "tags_all": {},
+            "vpc_security_group_ids": []
+          },
+          "type": "aws_rds_cluster",
+          "values": {
+            "allow_major_version_upgrade": null,
+            "apply_immediately": true,
+            "backtrack_window": null,
+            "cluster_identifier": "camunda-r1-camunda-db",
+            "copy_tags_to_snapshot": true,
+            "db_cluster_instance_class": null,
+            "db_instance_parameter_group_name": null,
+            "db_subnet_group_name": "camunda-r1-camunda-db",
+            "delete_automated_backups": true,
+            "deletion_protection": null,
+            "domain": null,
+            "domain_iam_role_name": null,
+            "enable_global_write_forwarding": false,
+            "enable_http_endpoint": false,
+            "enable_local_write_forwarding": false,
+            "enabled_cloudwatch_logs_exports": null,
+            "engine": "aurora-postgresql",
+            "engine_mode": "provisioned",
+            "engine_version": "18.3",
+            "final_snapshot_identifier": null,
+            "iam_database_authentication_enabled": true,
+            "iops": null,
+            "manage_master_user_password": null,
+            "master_password": null,
+            "master_password_wo": null,
+            "master_password_wo_version": null,
+            "performance_insights_enabled": null,
+            "region": "eu-west-3",
+            "replication_source_identifier": null,
+            "restore_to_point_in_time": [],
+            "s3_import": [],
+            "scaling_configuration": [],
+            "serverlessv2_scaling_configuration": [],
+            "skip_final_snapshot": true,
+            "snapshot_identifier": null,
+            "source_region": null,
+            "storage_encrypted": true,
+            "tags": null,
+            "timeouts": null
+          }
+        },
+        "module.aurora_global[0].aws_rds_cluster_instance.primary[0]": {
+          "index": 0,
+          "mode": "managed",
+          "name": "primary",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "tags_all": {}
+          },
+          "type": "aws_rds_cluster_instance",
+          "values": {
+            "apply_immediately": true,
+            "auto_minor_version_upgrade": false,
+            "ca_cert_identifier": "rds-ca-rsa2048-g1",
+            "copy_tags_to_snapshot": true,
+            "custom_iam_instance_profile": null,
+            "db_subnet_group_name": "camunda-r0-camunda-db",
+            "engine": "aurora-postgresql",
+            "engine_version": "18.3",
+            "force_destroy": false,
+            "identifier": "camunda-r0-camunda-db-0",
+            "instance_class": "db.r6g.large",
+            "monitoring_interval": 0,
+            "promotion_tier": 0,
+            "region": "eu-west-2",
+            "tags": null,
+            "timeouts": null
+          }
+        },
+        "module.aurora_global[0].aws_rds_cluster_instance.secondary[0]": {
+          "index": 0,
+          "mode": "managed",
+          "name": "secondary",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "tags_all": {}
+          },
+          "type": "aws_rds_cluster_instance",
+          "values": {
+            "apply_immediately": true,
+            "auto_minor_version_upgrade": false,
+            "ca_cert_identifier": "rds-ca-rsa2048-g1",
+            "copy_tags_to_snapshot": true,
+            "custom_iam_instance_profile": null,
+            "db_subnet_group_name": "camunda-r1-camunda-db",
+            "engine": "aurora-postgresql",
+            "engine_version": "18.3",
+            "force_destroy": false,
+            "identifier": "camunda-r1-camunda-db-0",
+            "instance_class": "db.r6g.large",
+            "monitoring_interval": 0,
+            "promotion_tier": 0,
+            "region": "eu-west-3",
+            "tags": null,
+            "timeouts": null
+          }
+        },
+        "module.aurora_global[0].aws_rds_global_cluster.this": {
+          "mode": "managed",
+          "name": "this",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "global_cluster_members": [],
+            "tags_all": {}
+          },
+          "type": "aws_rds_global_cluster",
+          "values": {
+            "database_name": "camunda",
+            "deletion_protection": false,
+            "engine": "aurora-postgresql",
+            "engine_version": "18.3",
+            "force_destroy": null,
+            "global_cluster_identifier": "camunda-global-db",
+            "region": "eu-west-2",
+            "storage_encrypted": true,
+            "tags": null,
+            "timeouts": null
+          }
+        },
+        "module.aurora_global[0].aws_security_group.primary": {
+          "identity": {
+            "account_id": null,
+            "id": null,
+            "region": null
+          },
+          "identity_schema_version": 0,
+          "mode": "managed",
+          "name": "primary",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 1,
+          "sensitive_values": {
+            "egress": [
+              {
+                "cidr_blocks": [
+                  false,
+                  false
+                ],
+                "ipv6_cidr_blocks": [],
+                "prefix_list_ids": [],
+                "security_groups": []
+              }
+            ],
+            "ingress": [
+              {
+                "cidr_blocks": [
+                  false,
+                  false
+                ],
+                "ipv6_cidr_blocks": [],
+                "prefix_list_ids": [],
+                "security_groups": []
+              }
+            ],
+            "tags": {},
+            "tags_all": {}
+          },
+          "type": "aws_security_group",
+          "values": {
+            "description": "Security group for Aurora primary cluster",
+            "egress": [
+              {
+                "cidr_blocks": [
+                  "10.192.0.0/16",
+                  "10.202.0.0/16"
+                ],
+                "description": "Allow PostgreSQL to allowed CIDRs",
+                "from_port": 5432,
+                "ipv6_cidr_blocks": [],
+                "prefix_list_ids": [],
+                "protocol": "tcp",
+                "security_groups": [],
+                "self": false,
+                "to_port": 5432
+              }
+            ],
+            "ingress": [
+              {
+                "cidr_blocks": [
+                  "10.192.0.0/16",
+                  "10.202.0.0/16"
+                ],
+                "description": "Allow PostgreSQL from allowed CIDRs",
+                "from_port": 5432,
+                "ipv6_cidr_blocks": [],
+                "prefix_list_ids": [],
+                "protocol": "tcp",
+                "security_groups": [],
+                "self": false,
+                "to_port": 5432
+              }
+            ],
+            "name": "camunda-r0-camunda-db-aurora",
+            "region": "eu-west-2",
+            "revoke_rules_on_delete": false,
+            "tags": {
+              "Name": "camunda-r0-camunda-db-aurora"
+            },
+            "tags_all": {
+              "Name": "camunda-r0-camunda-db-aurora"
+            },
+            "timeouts": null,
+            "vpc_id": "vpc-00000000000000000"
+          }
+        },
+        "module.aurora_global[0].aws_security_group.secondary": {
+          "identity": {
+            "account_id": null,
+            "id": null,
+            "region": null
+          },
+          "identity_schema_version": 0,
+          "mode": "managed",
+          "name": "secondary",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 1,
+          "sensitive_values": {
+            "egress": [
+              {
+                "cidr_blocks": [
+                  false,
+                  false
+                ],
+                "ipv6_cidr_blocks": [],
+                "prefix_list_ids": [],
+                "security_groups": []
+              }
+            ],
+            "ingress": [
+              {
+                "cidr_blocks": [
+                  false,
+                  false
+                ],
+                "ipv6_cidr_blocks": [],
+                "prefix_list_ids": [],
+                "security_groups": []
+              }
+            ],
+            "tags": {},
+            "tags_all": {}
+          },
+          "type": "aws_security_group",
+          "values": {
+            "description": "Security group for Aurora secondary cluster",
+            "egress": [
+              {
+                "cidr_blocks": [
+                  "10.192.0.0/16",
+                  "10.202.0.0/16"
+                ],
+                "description": "Allow PostgreSQL to allowed CIDRs",
+                "from_port": 5432,
+                "ipv6_cidr_blocks": [],
+                "prefix_list_ids": [],
+                "protocol": "tcp",
+                "security_groups": [],
+                "self": false,
+                "to_port": 5432
+              }
+            ],
+            "ingress": [
+              {
+                "cidr_blocks": [
+                  "10.192.0.0/16",
+                  "10.202.0.0/16"
+                ],
+                "description": "Allow PostgreSQL from allowed CIDRs",
+                "from_port": 5432,
+                "ipv6_cidr_blocks": [],
+                "prefix_list_ids": [],
+                "protocol": "tcp",
+                "security_groups": [],
+                "self": false,
+                "to_port": 5432
+              }
+            ],
+            "name": "camunda-r1-camunda-db-aurora",
+            "region": "eu-west-3",
+            "revoke_rules_on_delete": false,
+            "tags": {
+              "Name": "camunda-r1-camunda-db-aurora"
+            },
+            "tags_all": {
+              "Name": "camunda-r1-camunda-db-aurora"
+            },
+            "timeouts": null,
+            "vpc_id": "vpc-11111111111111111"
+          }
+        },
+        "module.aurora_global[0].time_sleep.wait_for_primary": {
+          "mode": "managed",
+          "name": "wait_for_primary",
+          "provider_name": "registry.terraform.io/hashicorp/time",
+          "schema_version": 0,
+          "sensitive_values": {},
+          "type": "time_sleep",
+          "values": {
+            "create_duration": "30s",
+            "destroy_duration": null,
+            "triggers": null
+          }
+        }
+      }
+    },
+    "null_resource.run_db_seed_task[0]": {
+      "index": 0,
+      "mode": "managed",
+      "name": "run_db_seed_task",
+      "provider_name": "registry.terraform.io/hashicorp/null",
+      "schema_version": 0,
+      "sensitive_values": {
+        "triggers": {}
+      },
+      "type": "null_resource",
+      "values": {
+        "triggers": {
+          "db_name": "camunda",
+          "iam_auth": "true",
+          "iam_users": "camunda",
+          "run_id": "1"
+        }
+      }
+    },
+    "random_id.bucket_suffix": {
+      "mode": "managed",
+      "name": "bucket_suffix",
+      "provider_name": "registry.terraform.io/hashicorp/random",
+      "schema_version": 0,
+      "sensitive_values": {},
+      "type": "random_id",
+      "values": {
+        "byte_length": 3,
+        "keepers": null,
+        "prefix": null
+      }
+    },
+    "random_password.admin_user_password": {
+      "mode": "managed",
+      "name": "admin_user_password",
+      "provider_name": "registry.terraform.io/hashicorp/random",
+      "schema_version": 3,
+      "sensitive_values": {
+        "bcrypt_hash": true,
+        "result": true
+      },
+      "type": "random_password",
+      "values": {
+        "keepers": null,
+        "length": 32,
+        "lower": true,
+        "min_lower": 0,
+        "min_numeric": 0,
+        "min_special": 0,
+        "min_upper": 0,
+        "number": true,
+        "numeric": true,
+        "override_special": "!#$%^()-_=+[]{}:?",
+        "special": true,
+        "upper": true
+      }
+    },
+    "random_password.connectors_user_password": {
+      "mode": "managed",
+      "name": "connectors_user_password",
+      "provider_name": "registry.terraform.io/hashicorp/random",
+      "schema_version": 3,
+      "sensitive_values": {
+        "bcrypt_hash": true,
+        "result": true
+      },
+      "type": "random_password",
+      "values": {
+        "keepers": null,
+        "length": 32,
+        "lower": true,
+        "min_lower": 0,
+        "min_numeric": 0,
+        "min_special": 0,
+        "min_upper": 0,
+        "number": true,
+        "numeric": true,
+        "override_special": "!#$%^()-_=+[]{}:?",
+        "special": true,
+        "upper": true
+      }
+    },
+    "random_password.db_admin_password[0]": {
+      "index": 0,
+      "mode": "managed",
+      "name": "db_admin_password",
+      "provider_name": "registry.terraform.io/hashicorp/random",
+      "schema_version": 3,
+      "sensitive_values": {
+        "bcrypt_hash": true,
+        "result": true
+      },
+      "type": "random_password",
+      "values": {
+        "keepers": null,
+        "length": 32,
+        "lower": true,
+        "min_lower": 0,
+        "min_numeric": 0,
+        "min_special": 0,
+        "min_upper": 0,
+        "number": true,
+        "numeric": true,
+        "override_special": "!#$%^()-_=+[]{}:?",
+        "special": true,
+        "upper": true
+      }
+    }
+  }
+}

--- a/aws/containers/ecs-dual-region-fargate/terraform/vpc/test/golden/golden.tfvars
+++ b/aws/containers/ecs-dual-region-fargate/terraform/vpc/test/golden/golden.tfvars
@@ -1,0 +1,5 @@
+# use this file for vars without default values
+# for the golden file generation
+
+aws_profile  = null # uses default AWS credential chain (env vars, default profile, instance profile)
+cluster_name = "camunda"

--- a/aws/containers/ecs-dual-region-fargate/terraform/vpc/test/golden/tfplan-golden.json
+++ b/aws/containers/ecs-dual-region-fargate/terraform/vpc/test/golden/tfplan-golden.json
@@ -1,0 +1,2423 @@
+{
+  "resources": {
+    "aws_route.region_0_private_to_region_1_peering[0]": {
+      "identity": {
+        "account_id": null,
+        "destination_cidr_block": null,
+        "destination_ipv6_cidr_block": null,
+        "destination_prefix_list_id": null,
+        "region": null,
+        "route_table_id": null
+      },
+      "identity_schema_version": 0,
+      "index": 0,
+      "mode": "managed",
+      "name": "region_0_private_to_region_1_peering",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "schema_version": 0,
+      "sensitive_values": {},
+      "type": "aws_route",
+      "values": {
+        "carrier_gateway_id": null,
+        "core_network_arn": null,
+        "destination_cidr_block": "10.202.0.0/16",
+        "destination_ipv6_cidr_block": null,
+        "destination_prefix_list_id": null,
+        "egress_only_gateway_id": null,
+        "gateway_id": null,
+        "local_gateway_id": null,
+        "nat_gateway_id": null,
+        "odb_network_arn": null,
+        "region": "eu-west-2",
+        "timeouts": null,
+        "transit_gateway_id": null,
+        "vpc_endpoint_id": null
+      }
+    },
+    "aws_route.region_0_private_to_region_1_peering[1]": {
+      "identity": {
+        "account_id": null,
+        "destination_cidr_block": null,
+        "destination_ipv6_cidr_block": null,
+        "destination_prefix_list_id": null,
+        "region": null,
+        "route_table_id": null
+      },
+      "identity_schema_version": 0,
+      "index": 1,
+      "mode": "managed",
+      "name": "region_0_private_to_region_1_peering",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "schema_version": 0,
+      "sensitive_values": {},
+      "type": "aws_route",
+      "values": {
+        "carrier_gateway_id": null,
+        "core_network_arn": null,
+        "destination_cidr_block": "10.202.0.0/16",
+        "destination_ipv6_cidr_block": null,
+        "destination_prefix_list_id": null,
+        "egress_only_gateway_id": null,
+        "gateway_id": null,
+        "local_gateway_id": null,
+        "nat_gateway_id": null,
+        "odb_network_arn": null,
+        "region": "eu-west-2",
+        "timeouts": null,
+        "transit_gateway_id": null,
+        "vpc_endpoint_id": null
+      }
+    },
+    "aws_route.region_0_private_to_region_1_peering[2]": {
+      "identity": {
+        "account_id": null,
+        "destination_cidr_block": null,
+        "destination_ipv6_cidr_block": null,
+        "destination_prefix_list_id": null,
+        "region": null,
+        "route_table_id": null
+      },
+      "identity_schema_version": 0,
+      "index": 2,
+      "mode": "managed",
+      "name": "region_0_private_to_region_1_peering",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "schema_version": 0,
+      "sensitive_values": {},
+      "type": "aws_route",
+      "values": {
+        "carrier_gateway_id": null,
+        "core_network_arn": null,
+        "destination_cidr_block": "10.202.0.0/16",
+        "destination_ipv6_cidr_block": null,
+        "destination_prefix_list_id": null,
+        "egress_only_gateway_id": null,
+        "gateway_id": null,
+        "local_gateway_id": null,
+        "nat_gateway_id": null,
+        "odb_network_arn": null,
+        "region": "eu-west-2",
+        "timeouts": null,
+        "transit_gateway_id": null,
+        "vpc_endpoint_id": null
+      }
+    },
+    "aws_route.region_1_private_to_region_0_peering[0]": {
+      "identity": {
+        "account_id": null,
+        "destination_cidr_block": null,
+        "destination_ipv6_cidr_block": null,
+        "destination_prefix_list_id": null,
+        "region": null,
+        "route_table_id": null
+      },
+      "identity_schema_version": 0,
+      "index": 0,
+      "mode": "managed",
+      "name": "region_1_private_to_region_0_peering",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "schema_version": 0,
+      "sensitive_values": {},
+      "type": "aws_route",
+      "values": {
+        "carrier_gateway_id": null,
+        "core_network_arn": null,
+        "destination_cidr_block": "10.192.0.0/16",
+        "destination_ipv6_cidr_block": null,
+        "destination_prefix_list_id": null,
+        "egress_only_gateway_id": null,
+        "gateway_id": null,
+        "local_gateway_id": null,
+        "nat_gateway_id": null,
+        "odb_network_arn": null,
+        "region": "eu-west-3",
+        "timeouts": null,
+        "transit_gateway_id": null,
+        "vpc_endpoint_id": null
+      }
+    },
+    "aws_route.region_1_private_to_region_0_peering[1]": {
+      "identity": {
+        "account_id": null,
+        "destination_cidr_block": null,
+        "destination_ipv6_cidr_block": null,
+        "destination_prefix_list_id": null,
+        "region": null,
+        "route_table_id": null
+      },
+      "identity_schema_version": 0,
+      "index": 1,
+      "mode": "managed",
+      "name": "region_1_private_to_region_0_peering",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "schema_version": 0,
+      "sensitive_values": {},
+      "type": "aws_route",
+      "values": {
+        "carrier_gateway_id": null,
+        "core_network_arn": null,
+        "destination_cidr_block": "10.192.0.0/16",
+        "destination_ipv6_cidr_block": null,
+        "destination_prefix_list_id": null,
+        "egress_only_gateway_id": null,
+        "gateway_id": null,
+        "local_gateway_id": null,
+        "nat_gateway_id": null,
+        "odb_network_arn": null,
+        "region": "eu-west-3",
+        "timeouts": null,
+        "transit_gateway_id": null,
+        "vpc_endpoint_id": null
+      }
+    },
+    "aws_route.region_1_private_to_region_0_peering[2]": {
+      "identity": {
+        "account_id": null,
+        "destination_cidr_block": null,
+        "destination_ipv6_cidr_block": null,
+        "destination_prefix_list_id": null,
+        "region": null,
+        "route_table_id": null
+      },
+      "identity_schema_version": 0,
+      "index": 2,
+      "mode": "managed",
+      "name": "region_1_private_to_region_0_peering",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "schema_version": 0,
+      "sensitive_values": {},
+      "type": "aws_route",
+      "values": {
+        "carrier_gateway_id": null,
+        "core_network_arn": null,
+        "destination_cidr_block": "10.192.0.0/16",
+        "destination_ipv6_cidr_block": null,
+        "destination_prefix_list_id": null,
+        "egress_only_gateway_id": null,
+        "gateway_id": null,
+        "local_gateway_id": null,
+        "nat_gateway_id": null,
+        "odb_network_arn": null,
+        "region": "eu-west-3",
+        "timeouts": null,
+        "transit_gateway_id": null,
+        "vpc_endpoint_id": null
+      }
+    },
+    "aws_vpc_peering_connection.cross_region[0]": {
+      "index": 0,
+      "mode": "managed",
+      "name": "cross_region",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "schema_version": 0,
+      "sensitive_values": {
+        "accepter": [],
+        "requester": [],
+        "tags": {},
+        "tags_all": {}
+      },
+      "type": "aws_vpc_peering_connection",
+      "values": {
+        "auto_accept": false,
+        "peer_region": "eu-west-3",
+        "region": "eu-west-2",
+        "tags": {
+          "Name": "camunda-vpc-peering"
+        },
+        "tags_all": {
+          "Name": "camunda-vpc-peering"
+        },
+        "timeouts": null
+      }
+    },
+    "aws_vpc_peering_connection_accepter.cross_region[0]": {
+      "index": 0,
+      "mode": "managed",
+      "name": "cross_region",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "schema_version": 0,
+      "sensitive_values": {
+        "accepter": [],
+        "requester": [],
+        "tags": {},
+        "tags_all": {}
+      },
+      "type": "aws_vpc_peering_connection_accepter",
+      "values": {
+        "auto_accept": true,
+        "region": "eu-west-3",
+        "tags": {
+          "Name": "camunda-vpc-peering"
+        },
+        "tags_all": {
+          "Name": "camunda-vpc-peering"
+        },
+        "timeouts": null
+      }
+    },
+    "aws_vpc_peering_connection_options.accepter[0]": {
+      "index": 0,
+      "mode": "managed",
+      "name": "accepter",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "schema_version": 0,
+      "sensitive_values": {
+        "accepter": [
+          {}
+        ],
+        "requester": []
+      },
+      "type": "aws_vpc_peering_connection_options",
+      "values": {
+        "accepter": [
+          {
+            "allow_remote_vpc_dns_resolution": true
+          }
+        ],
+        "region": "eu-west-3"
+      }
+    },
+    "aws_vpc_peering_connection_options.requester[0]": {
+      "index": 0,
+      "mode": "managed",
+      "name": "requester",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "schema_version": 0,
+      "sensitive_values": {
+        "accepter": [],
+        "requester": [
+          {}
+        ]
+      },
+      "type": "aws_vpc_peering_connection_options",
+      "values": {
+        "region": "eu-west-2",
+        "requester": [
+          {
+            "allow_remote_vpc_dns_resolution": true
+          }
+        ]
+      }
+    },
+    "module.vpc_region_0[0]": {
+      "resources": {
+        "module.vpc_region_0[0].aws_default_network_acl.this[0]": {
+          "index": 0,
+          "mode": "managed",
+          "name": "this",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "egress": [
+              {},
+              {}
+            ],
+            "ingress": [
+              {},
+              {}
+            ],
+            "tags": {},
+            "tags_all": {}
+          },
+          "type": "aws_default_network_acl",
+          "values": {
+            "egress": [
+              {
+                "action": "allow",
+                "cidr_block": "",
+                "from_port": 0,
+                "icmp_code": null,
+                "icmp_type": null,
+                "ipv6_cidr_block": "::/0",
+                "protocol": "-1",
+                "rule_no": 101,
+                "to_port": 0
+              },
+              {
+                "action": "allow",
+                "cidr_block": "0.0.0.0/0",
+                "from_port": 0,
+                "icmp_code": null,
+                "icmp_type": null,
+                "ipv6_cidr_block": "",
+                "protocol": "-1",
+                "rule_no": 100,
+                "to_port": 0
+              }
+            ],
+            "ingress": [
+              {
+                "action": "allow",
+                "cidr_block": "",
+                "from_port": 0,
+                "icmp_code": null,
+                "icmp_type": null,
+                "ipv6_cidr_block": "::/0",
+                "protocol": "-1",
+                "rule_no": 101,
+                "to_port": 0
+              },
+              {
+                "action": "allow",
+                "cidr_block": "0.0.0.0/0",
+                "from_port": 0,
+                "icmp_code": null,
+                "icmp_type": null,
+                "ipv6_cidr_block": "",
+                "protocol": "-1",
+                "rule_no": 100,
+                "to_port": 0
+              }
+            ],
+            "region": "eu-west-2",
+            "subnet_ids": null,
+            "tags": {
+              "Name": "camunda-r0-vpc-default"
+            },
+            "tags_all": {
+              "Name": "camunda-r0-vpc-default"
+            }
+          }
+        },
+        "module.vpc_region_0[0].aws_default_route_table.default[0]": {
+          "index": 0,
+          "mode": "managed",
+          "name": "default",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "route": [],
+            "tags": {},
+            "tags_all": {},
+            "timeouts": {}
+          },
+          "type": "aws_default_route_table",
+          "values": {
+            "propagating_vgws": null,
+            "region": "eu-west-2",
+            "tags": {
+              "Name": "camunda-r0-vpc-default"
+            },
+            "tags_all": {
+              "Name": "camunda-r0-vpc-default"
+            },
+            "timeouts": {
+              "create": "5m",
+              "update": "5m"
+            }
+          }
+        },
+        "module.vpc_region_0[0].aws_default_security_group.this[0]": {
+          "index": 0,
+          "mode": "managed",
+          "name": "this",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 1,
+          "sensitive_values": {
+            "egress": [],
+            "ingress": [],
+            "tags": {},
+            "tags_all": {}
+          },
+          "type": "aws_default_security_group",
+          "values": {
+            "region": "eu-west-2",
+            "revoke_rules_on_delete": false,
+            "tags": {
+              "Name": "camunda-r0-vpc-default"
+            },
+            "tags_all": {
+              "Name": "camunda-r0-vpc-default"
+            }
+          }
+        },
+        "module.vpc_region_0[0].aws_eip.nat[0]": {
+          "identity": {
+            "account_id": null,
+            "id": null,
+            "region": null
+          },
+          "identity_schema_version": 0,
+          "index": 0,
+          "mode": "managed",
+          "name": "nat",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "tags": {},
+            "tags_all": {}
+          },
+          "type": "aws_eip",
+          "values": {
+            "address": null,
+            "associate_with_private_ip": null,
+            "customer_owned_ipv4_pool": null,
+            "domain": "vpc",
+            "region": "eu-west-2",
+            "tags": {
+              "Name": "camunda-r0-vpc-eu-west-2a"
+            },
+            "tags_all": {
+              "Name": "camunda-r0-vpc-eu-west-2a"
+            },
+            "timeouts": null
+          }
+        },
+        "module.vpc_region_0[0].aws_eip.nat[1]": {
+          "identity": {
+            "account_id": null,
+            "id": null,
+            "region": null
+          },
+          "identity_schema_version": 0,
+          "index": 1,
+          "mode": "managed",
+          "name": "nat",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "tags": {},
+            "tags_all": {}
+          },
+          "type": "aws_eip",
+          "values": {
+            "address": null,
+            "associate_with_private_ip": null,
+            "customer_owned_ipv4_pool": null,
+            "domain": "vpc",
+            "region": "eu-west-2",
+            "tags": {
+              "Name": "camunda-r0-vpc-eu-west-2b"
+            },
+            "tags_all": {
+              "Name": "camunda-r0-vpc-eu-west-2b"
+            },
+            "timeouts": null
+          }
+        },
+        "module.vpc_region_0[0].aws_eip.nat[2]": {
+          "identity": {
+            "account_id": null,
+            "id": null,
+            "region": null
+          },
+          "identity_schema_version": 0,
+          "index": 2,
+          "mode": "managed",
+          "name": "nat",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "tags": {},
+            "tags_all": {}
+          },
+          "type": "aws_eip",
+          "values": {
+            "address": null,
+            "associate_with_private_ip": null,
+            "customer_owned_ipv4_pool": null,
+            "domain": "vpc",
+            "region": "eu-west-2",
+            "tags": {
+              "Name": "camunda-r0-vpc-eu-west-2c"
+            },
+            "tags_all": {
+              "Name": "camunda-r0-vpc-eu-west-2c"
+            },
+            "timeouts": null
+          }
+        },
+        "module.vpc_region_0[0].aws_internet_gateway.this[0]": {
+          "identity": {
+            "account_id": null,
+            "id": null,
+            "region": null
+          },
+          "identity_schema_version": 0,
+          "index": 0,
+          "mode": "managed",
+          "name": "this",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "tags": {},
+            "tags_all": {}
+          },
+          "type": "aws_internet_gateway",
+          "values": {
+            "region": "eu-west-2",
+            "tags": {
+              "Name": "camunda-r0-vpc"
+            },
+            "tags_all": {
+              "Name": "camunda-r0-vpc"
+            },
+            "timeouts": null
+          }
+        },
+        "module.vpc_region_0[0].aws_nat_gateway.this[0]": {
+          "identity": {
+            "account_id": null,
+            "id": null,
+            "region": null
+          },
+          "identity_schema_version": 0,
+          "index": 0,
+          "mode": "managed",
+          "name": "this",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "availability_zone_address": [],
+            "regional_nat_gateway_address": [],
+            "secondary_allocation_ids": [],
+            "secondary_private_ip_addresses": [],
+            "tags": {},
+            "tags_all": {}
+          },
+          "type": "aws_nat_gateway",
+          "values": {
+            "availability_zone_address": [],
+            "connectivity_type": "public",
+            "region": "eu-west-2",
+            "tags": {
+              "Name": "camunda-r0-vpc-eu-west-2a"
+            },
+            "tags_all": {
+              "Name": "camunda-r0-vpc-eu-west-2a"
+            },
+            "timeouts": null
+          }
+        },
+        "module.vpc_region_0[0].aws_nat_gateway.this[1]": {
+          "identity": {
+            "account_id": null,
+            "id": null,
+            "region": null
+          },
+          "identity_schema_version": 0,
+          "index": 1,
+          "mode": "managed",
+          "name": "this",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "availability_zone_address": [],
+            "regional_nat_gateway_address": [],
+            "secondary_allocation_ids": [],
+            "secondary_private_ip_addresses": [],
+            "tags": {},
+            "tags_all": {}
+          },
+          "type": "aws_nat_gateway",
+          "values": {
+            "availability_zone_address": [],
+            "connectivity_type": "public",
+            "region": "eu-west-2",
+            "tags": {
+              "Name": "camunda-r0-vpc-eu-west-2b"
+            },
+            "tags_all": {
+              "Name": "camunda-r0-vpc-eu-west-2b"
+            },
+            "timeouts": null
+          }
+        },
+        "module.vpc_region_0[0].aws_nat_gateway.this[2]": {
+          "identity": {
+            "account_id": null,
+            "id": null,
+            "region": null
+          },
+          "identity_schema_version": 0,
+          "index": 2,
+          "mode": "managed",
+          "name": "this",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "availability_zone_address": [],
+            "regional_nat_gateway_address": [],
+            "secondary_allocation_ids": [],
+            "secondary_private_ip_addresses": [],
+            "tags": {},
+            "tags_all": {}
+          },
+          "type": "aws_nat_gateway",
+          "values": {
+            "availability_zone_address": [],
+            "connectivity_type": "public",
+            "region": "eu-west-2",
+            "tags": {
+              "Name": "camunda-r0-vpc-eu-west-2c"
+            },
+            "tags_all": {
+              "Name": "camunda-r0-vpc-eu-west-2c"
+            },
+            "timeouts": null
+          }
+        },
+        "module.vpc_region_0[0].aws_route.private_nat_gateway[0]": {
+          "identity": {
+            "account_id": null,
+            "destination_cidr_block": null,
+            "destination_ipv6_cidr_block": null,
+            "destination_prefix_list_id": null,
+            "region": null,
+            "route_table_id": null
+          },
+          "identity_schema_version": 0,
+          "index": 0,
+          "mode": "managed",
+          "name": "private_nat_gateway",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "timeouts": {}
+          },
+          "type": "aws_route",
+          "values": {
+            "carrier_gateway_id": null,
+            "core_network_arn": null,
+            "destination_cidr_block": "0.0.0.0/0",
+            "destination_ipv6_cidr_block": null,
+            "destination_prefix_list_id": null,
+            "egress_only_gateway_id": null,
+            "gateway_id": null,
+            "local_gateway_id": null,
+            "odb_network_arn": null,
+            "region": "eu-west-2",
+            "timeouts": {
+              "create": "5m",
+              "delete": null,
+              "update": null
+            },
+            "transit_gateway_id": null,
+            "vpc_endpoint_id": null,
+            "vpc_peering_connection_id": null
+          }
+        },
+        "module.vpc_region_0[0].aws_route.private_nat_gateway[1]": {
+          "identity": {
+            "account_id": null,
+            "destination_cidr_block": null,
+            "destination_ipv6_cidr_block": null,
+            "destination_prefix_list_id": null,
+            "region": null,
+            "route_table_id": null
+          },
+          "identity_schema_version": 0,
+          "index": 1,
+          "mode": "managed",
+          "name": "private_nat_gateway",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "timeouts": {}
+          },
+          "type": "aws_route",
+          "values": {
+            "carrier_gateway_id": null,
+            "core_network_arn": null,
+            "destination_cidr_block": "0.0.0.0/0",
+            "destination_ipv6_cidr_block": null,
+            "destination_prefix_list_id": null,
+            "egress_only_gateway_id": null,
+            "gateway_id": null,
+            "local_gateway_id": null,
+            "odb_network_arn": null,
+            "region": "eu-west-2",
+            "timeouts": {
+              "create": "5m",
+              "delete": null,
+              "update": null
+            },
+            "transit_gateway_id": null,
+            "vpc_endpoint_id": null,
+            "vpc_peering_connection_id": null
+          }
+        },
+        "module.vpc_region_0[0].aws_route.private_nat_gateway[2]": {
+          "identity": {
+            "account_id": null,
+            "destination_cidr_block": null,
+            "destination_ipv6_cidr_block": null,
+            "destination_prefix_list_id": null,
+            "region": null,
+            "route_table_id": null
+          },
+          "identity_schema_version": 0,
+          "index": 2,
+          "mode": "managed",
+          "name": "private_nat_gateway",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "timeouts": {}
+          },
+          "type": "aws_route",
+          "values": {
+            "carrier_gateway_id": null,
+            "core_network_arn": null,
+            "destination_cidr_block": "0.0.0.0/0",
+            "destination_ipv6_cidr_block": null,
+            "destination_prefix_list_id": null,
+            "egress_only_gateway_id": null,
+            "gateway_id": null,
+            "local_gateway_id": null,
+            "odb_network_arn": null,
+            "region": "eu-west-2",
+            "timeouts": {
+              "create": "5m",
+              "delete": null,
+              "update": null
+            },
+            "transit_gateway_id": null,
+            "vpc_endpoint_id": null,
+            "vpc_peering_connection_id": null
+          }
+        },
+        "module.vpc_region_0[0].aws_route.public_internet_gateway[0]": {
+          "identity": {
+            "account_id": null,
+            "destination_cidr_block": null,
+            "destination_ipv6_cidr_block": null,
+            "destination_prefix_list_id": null,
+            "region": null,
+            "route_table_id": null
+          },
+          "identity_schema_version": 0,
+          "index": 0,
+          "mode": "managed",
+          "name": "public_internet_gateway",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "timeouts": {}
+          },
+          "type": "aws_route",
+          "values": {
+            "carrier_gateway_id": null,
+            "core_network_arn": null,
+            "destination_cidr_block": "0.0.0.0/0",
+            "destination_ipv6_cidr_block": null,
+            "destination_prefix_list_id": null,
+            "egress_only_gateway_id": null,
+            "local_gateway_id": null,
+            "nat_gateway_id": null,
+            "odb_network_arn": null,
+            "region": "eu-west-2",
+            "timeouts": {
+              "create": "5m",
+              "delete": null,
+              "update": null
+            },
+            "transit_gateway_id": null,
+            "vpc_endpoint_id": null,
+            "vpc_peering_connection_id": null
+          }
+        },
+        "module.vpc_region_0[0].aws_route_table.private[0]": {
+          "identity": {
+            "account_id": null,
+            "id": null,
+            "region": null
+          },
+          "identity_schema_version": 0,
+          "index": 0,
+          "mode": "managed",
+          "name": "private",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "propagating_vgws": [],
+            "route": [],
+            "tags": {},
+            "tags_all": {}
+          },
+          "type": "aws_route_table",
+          "values": {
+            "region": "eu-west-2",
+            "tags": {
+              "Name": "camunda-r0-vpc-private-eu-west-2a"
+            },
+            "tags_all": {
+              "Name": "camunda-r0-vpc-private-eu-west-2a"
+            },
+            "timeouts": null
+          }
+        },
+        "module.vpc_region_0[0].aws_route_table.private[1]": {
+          "identity": {
+            "account_id": null,
+            "id": null,
+            "region": null
+          },
+          "identity_schema_version": 0,
+          "index": 1,
+          "mode": "managed",
+          "name": "private",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "propagating_vgws": [],
+            "route": [],
+            "tags": {},
+            "tags_all": {}
+          },
+          "type": "aws_route_table",
+          "values": {
+            "region": "eu-west-2",
+            "tags": {
+              "Name": "camunda-r0-vpc-private-eu-west-2b"
+            },
+            "tags_all": {
+              "Name": "camunda-r0-vpc-private-eu-west-2b"
+            },
+            "timeouts": null
+          }
+        },
+        "module.vpc_region_0[0].aws_route_table.private[2]": {
+          "identity": {
+            "account_id": null,
+            "id": null,
+            "region": null
+          },
+          "identity_schema_version": 0,
+          "index": 2,
+          "mode": "managed",
+          "name": "private",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "propagating_vgws": [],
+            "route": [],
+            "tags": {},
+            "tags_all": {}
+          },
+          "type": "aws_route_table",
+          "values": {
+            "region": "eu-west-2",
+            "tags": {
+              "Name": "camunda-r0-vpc-private-eu-west-2c"
+            },
+            "tags_all": {
+              "Name": "camunda-r0-vpc-private-eu-west-2c"
+            },
+            "timeouts": null
+          }
+        },
+        "module.vpc_region_0[0].aws_route_table.public[0]": {
+          "identity": {
+            "account_id": null,
+            "id": null,
+            "region": null
+          },
+          "identity_schema_version": 0,
+          "index": 0,
+          "mode": "managed",
+          "name": "public",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "propagating_vgws": [],
+            "route": [],
+            "tags": {},
+            "tags_all": {}
+          },
+          "type": "aws_route_table",
+          "values": {
+            "region": "eu-west-2",
+            "tags": {
+              "Name": "camunda-r0-vpc-public"
+            },
+            "tags_all": {
+              "Name": "camunda-r0-vpc-public"
+            },
+            "timeouts": null
+          }
+        },
+        "module.vpc_region_0[0].aws_route_table_association.private[0]": {
+          "identity": {
+            "account_id": null,
+            "id": null,
+            "region": null
+          },
+          "identity_schema_version": 0,
+          "index": 0,
+          "mode": "managed",
+          "name": "private",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {},
+          "type": "aws_route_table_association",
+          "values": {
+            "gateway_id": null,
+            "region": "eu-west-2",
+            "timeouts": null
+          }
+        },
+        "module.vpc_region_0[0].aws_route_table_association.private[1]": {
+          "identity": {
+            "account_id": null,
+            "id": null,
+            "region": null
+          },
+          "identity_schema_version": 0,
+          "index": 1,
+          "mode": "managed",
+          "name": "private",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {},
+          "type": "aws_route_table_association",
+          "values": {
+            "gateway_id": null,
+            "region": "eu-west-2",
+            "timeouts": null
+          }
+        },
+        "module.vpc_region_0[0].aws_route_table_association.private[2]": {
+          "identity": {
+            "account_id": null,
+            "id": null,
+            "region": null
+          },
+          "identity_schema_version": 0,
+          "index": 2,
+          "mode": "managed",
+          "name": "private",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {},
+          "type": "aws_route_table_association",
+          "values": {
+            "gateway_id": null,
+            "region": "eu-west-2",
+            "timeouts": null
+          }
+        },
+        "module.vpc_region_0[0].aws_route_table_association.public[0]": {
+          "identity": {
+            "account_id": null,
+            "id": null,
+            "region": null
+          },
+          "identity_schema_version": 0,
+          "index": 0,
+          "mode": "managed",
+          "name": "public",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {},
+          "type": "aws_route_table_association",
+          "values": {
+            "gateway_id": null,
+            "region": "eu-west-2",
+            "timeouts": null
+          }
+        },
+        "module.vpc_region_0[0].aws_route_table_association.public[1]": {
+          "identity": {
+            "account_id": null,
+            "id": null,
+            "region": null
+          },
+          "identity_schema_version": 0,
+          "index": 1,
+          "mode": "managed",
+          "name": "public",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {},
+          "type": "aws_route_table_association",
+          "values": {
+            "gateway_id": null,
+            "region": "eu-west-2",
+            "timeouts": null
+          }
+        },
+        "module.vpc_region_0[0].aws_route_table_association.public[2]": {
+          "identity": {
+            "account_id": null,
+            "id": null,
+            "region": null
+          },
+          "identity_schema_version": 0,
+          "index": 2,
+          "mode": "managed",
+          "name": "public",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {},
+          "type": "aws_route_table_association",
+          "values": {
+            "gateway_id": null,
+            "region": "eu-west-2",
+            "timeouts": null
+          }
+        },
+        "module.vpc_region_0[0].aws_subnet.private[0]": {
+          "identity": {
+            "account_id": null,
+            "id": null,
+            "region": null
+          },
+          "identity_schema_version": 0,
+          "index": 0,
+          "mode": "managed",
+          "name": "private",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 1,
+          "sensitive_values": {
+            "tags": {},
+            "tags_all": {}
+          },
+          "type": "aws_subnet",
+          "values": {
+            "assign_ipv6_address_on_creation": false,
+            "availability_zone": "eu-west-2a",
+            "cidr_block": "10.192.0.0/19",
+            "customer_owned_ipv4_pool": null,
+            "enable_dns64": false,
+            "enable_lni_at_device_index": null,
+            "enable_resource_name_dns_a_record_on_launch": false,
+            "enable_resource_name_dns_aaaa_record_on_launch": false,
+            "ipv4_ipam_pool_id": null,
+            "ipv4_netmask_length": null,
+            "ipv6_ipam_pool_id": null,
+            "ipv6_native": false,
+            "ipv6_netmask_length": null,
+            "map_customer_owned_ip_on_launch": null,
+            "map_public_ip_on_launch": false,
+            "outpost_arn": null,
+            "region": "eu-west-2",
+            "tags": {
+              "Name": "camunda-r0-vpc-private-eu-west-2a"
+            },
+            "tags_all": {
+              "Name": "camunda-r0-vpc-private-eu-west-2a"
+            },
+            "timeouts": null
+          }
+        },
+        "module.vpc_region_0[0].aws_subnet.private[1]": {
+          "identity": {
+            "account_id": null,
+            "id": null,
+            "region": null
+          },
+          "identity_schema_version": 0,
+          "index": 1,
+          "mode": "managed",
+          "name": "private",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 1,
+          "sensitive_values": {
+            "tags": {},
+            "tags_all": {}
+          },
+          "type": "aws_subnet",
+          "values": {
+            "assign_ipv6_address_on_creation": false,
+            "availability_zone": "eu-west-2b",
+            "cidr_block": "10.192.32.0/19",
+            "customer_owned_ipv4_pool": null,
+            "enable_dns64": false,
+            "enable_lni_at_device_index": null,
+            "enable_resource_name_dns_a_record_on_launch": false,
+            "enable_resource_name_dns_aaaa_record_on_launch": false,
+            "ipv4_ipam_pool_id": null,
+            "ipv4_netmask_length": null,
+            "ipv6_ipam_pool_id": null,
+            "ipv6_native": false,
+            "ipv6_netmask_length": null,
+            "map_customer_owned_ip_on_launch": null,
+            "map_public_ip_on_launch": false,
+            "outpost_arn": null,
+            "region": "eu-west-2",
+            "tags": {
+              "Name": "camunda-r0-vpc-private-eu-west-2b"
+            },
+            "tags_all": {
+              "Name": "camunda-r0-vpc-private-eu-west-2b"
+            },
+            "timeouts": null
+          }
+        },
+        "module.vpc_region_0[0].aws_subnet.private[2]": {
+          "identity": {
+            "account_id": null,
+            "id": null,
+            "region": null
+          },
+          "identity_schema_version": 0,
+          "index": 2,
+          "mode": "managed",
+          "name": "private",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 1,
+          "sensitive_values": {
+            "tags": {},
+            "tags_all": {}
+          },
+          "type": "aws_subnet",
+          "values": {
+            "assign_ipv6_address_on_creation": false,
+            "availability_zone": "eu-west-2c",
+            "cidr_block": "10.192.64.0/19",
+            "customer_owned_ipv4_pool": null,
+            "enable_dns64": false,
+            "enable_lni_at_device_index": null,
+            "enable_resource_name_dns_a_record_on_launch": false,
+            "enable_resource_name_dns_aaaa_record_on_launch": false,
+            "ipv4_ipam_pool_id": null,
+            "ipv4_netmask_length": null,
+            "ipv6_ipam_pool_id": null,
+            "ipv6_native": false,
+            "ipv6_netmask_length": null,
+            "map_customer_owned_ip_on_launch": null,
+            "map_public_ip_on_launch": false,
+            "outpost_arn": null,
+            "region": "eu-west-2",
+            "tags": {
+              "Name": "camunda-r0-vpc-private-eu-west-2c"
+            },
+            "tags_all": {
+              "Name": "camunda-r0-vpc-private-eu-west-2c"
+            },
+            "timeouts": null
+          }
+        },
+        "module.vpc_region_0[0].aws_subnet.public[0]": {
+          "identity": {
+            "account_id": null,
+            "id": null,
+            "region": null
+          },
+          "identity_schema_version": 0,
+          "index": 0,
+          "mode": "managed",
+          "name": "public",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 1,
+          "sensitive_values": {
+            "tags": {},
+            "tags_all": {}
+          },
+          "type": "aws_subnet",
+          "values": {
+            "assign_ipv6_address_on_creation": false,
+            "availability_zone": "eu-west-2a",
+            "cidr_block": "10.192.96.0/19",
+            "customer_owned_ipv4_pool": null,
+            "enable_dns64": false,
+            "enable_lni_at_device_index": null,
+            "enable_resource_name_dns_a_record_on_launch": false,
+            "enable_resource_name_dns_aaaa_record_on_launch": false,
+            "ipv4_ipam_pool_id": null,
+            "ipv4_netmask_length": null,
+            "ipv6_ipam_pool_id": null,
+            "ipv6_native": false,
+            "ipv6_netmask_length": null,
+            "map_customer_owned_ip_on_launch": null,
+            "map_public_ip_on_launch": false,
+            "outpost_arn": null,
+            "region": "eu-west-2",
+            "tags": {
+              "Name": "camunda-r0-vpc-public-eu-west-2a"
+            },
+            "tags_all": {
+              "Name": "camunda-r0-vpc-public-eu-west-2a"
+            },
+            "timeouts": null
+          }
+        },
+        "module.vpc_region_0[0].aws_subnet.public[1]": {
+          "identity": {
+            "account_id": null,
+            "id": null,
+            "region": null
+          },
+          "identity_schema_version": 0,
+          "index": 1,
+          "mode": "managed",
+          "name": "public",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 1,
+          "sensitive_values": {
+            "tags": {},
+            "tags_all": {}
+          },
+          "type": "aws_subnet",
+          "values": {
+            "assign_ipv6_address_on_creation": false,
+            "availability_zone": "eu-west-2b",
+            "cidr_block": "10.192.128.0/19",
+            "customer_owned_ipv4_pool": null,
+            "enable_dns64": false,
+            "enable_lni_at_device_index": null,
+            "enable_resource_name_dns_a_record_on_launch": false,
+            "enable_resource_name_dns_aaaa_record_on_launch": false,
+            "ipv4_ipam_pool_id": null,
+            "ipv4_netmask_length": null,
+            "ipv6_ipam_pool_id": null,
+            "ipv6_native": false,
+            "ipv6_netmask_length": null,
+            "map_customer_owned_ip_on_launch": null,
+            "map_public_ip_on_launch": false,
+            "outpost_arn": null,
+            "region": "eu-west-2",
+            "tags": {
+              "Name": "camunda-r0-vpc-public-eu-west-2b"
+            },
+            "tags_all": {
+              "Name": "camunda-r0-vpc-public-eu-west-2b"
+            },
+            "timeouts": null
+          }
+        },
+        "module.vpc_region_0[0].aws_subnet.public[2]": {
+          "identity": {
+            "account_id": null,
+            "id": null,
+            "region": null
+          },
+          "identity_schema_version": 0,
+          "index": 2,
+          "mode": "managed",
+          "name": "public",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 1,
+          "sensitive_values": {
+            "tags": {},
+            "tags_all": {}
+          },
+          "type": "aws_subnet",
+          "values": {
+            "assign_ipv6_address_on_creation": false,
+            "availability_zone": "eu-west-2c",
+            "cidr_block": "10.192.160.0/19",
+            "customer_owned_ipv4_pool": null,
+            "enable_dns64": false,
+            "enable_lni_at_device_index": null,
+            "enable_resource_name_dns_a_record_on_launch": false,
+            "enable_resource_name_dns_aaaa_record_on_launch": false,
+            "ipv4_ipam_pool_id": null,
+            "ipv4_netmask_length": null,
+            "ipv6_ipam_pool_id": null,
+            "ipv6_native": false,
+            "ipv6_netmask_length": null,
+            "map_customer_owned_ip_on_launch": null,
+            "map_public_ip_on_launch": false,
+            "outpost_arn": null,
+            "region": "eu-west-2",
+            "tags": {
+              "Name": "camunda-r0-vpc-public-eu-west-2c"
+            },
+            "tags_all": {
+              "Name": "camunda-r0-vpc-public-eu-west-2c"
+            },
+            "timeouts": null
+          }
+        },
+        "module.vpc_region_0[0].aws_vpc.this[0]": {
+          "identity": {
+            "account_id": null,
+            "id": null,
+            "region": null
+          },
+          "identity_schema_version": 0,
+          "index": 0,
+          "mode": "managed",
+          "name": "this",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 1,
+          "sensitive_values": {
+            "tags": {},
+            "tags_all": {}
+          },
+          "type": "aws_vpc",
+          "values": {
+            "assign_generated_ipv6_cidr_block": null,
+            "cidr_block": "10.192.0.0/16",
+            "enable_dns_hostnames": true,
+            "enable_dns_support": true,
+            "instance_tenancy": "default",
+            "ipv4_ipam_pool_id": null,
+            "ipv4_netmask_length": null,
+            "ipv6_ipam_pool_id": null,
+            "ipv6_netmask_length": null,
+            "region": "eu-west-2",
+            "tags": {
+              "Name": "camunda-r0-vpc"
+            },
+            "tags_all": {
+              "Name": "camunda-r0-vpc"
+            }
+          }
+        }
+      }
+    },
+    "module.vpc_region_1[0]": {
+      "resources": {
+        "module.vpc_region_1[0].aws_default_network_acl.this[0]": {
+          "index": 0,
+          "mode": "managed",
+          "name": "this",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "egress": [
+              {},
+              {}
+            ],
+            "ingress": [
+              {},
+              {}
+            ],
+            "tags": {},
+            "tags_all": {}
+          },
+          "type": "aws_default_network_acl",
+          "values": {
+            "egress": [
+              {
+                "action": "allow",
+                "cidr_block": "",
+                "from_port": 0,
+                "icmp_code": null,
+                "icmp_type": null,
+                "ipv6_cidr_block": "::/0",
+                "protocol": "-1",
+                "rule_no": 101,
+                "to_port": 0
+              },
+              {
+                "action": "allow",
+                "cidr_block": "0.0.0.0/0",
+                "from_port": 0,
+                "icmp_code": null,
+                "icmp_type": null,
+                "ipv6_cidr_block": "",
+                "protocol": "-1",
+                "rule_no": 100,
+                "to_port": 0
+              }
+            ],
+            "ingress": [
+              {
+                "action": "allow",
+                "cidr_block": "",
+                "from_port": 0,
+                "icmp_code": null,
+                "icmp_type": null,
+                "ipv6_cidr_block": "::/0",
+                "protocol": "-1",
+                "rule_no": 101,
+                "to_port": 0
+              },
+              {
+                "action": "allow",
+                "cidr_block": "0.0.0.0/0",
+                "from_port": 0,
+                "icmp_code": null,
+                "icmp_type": null,
+                "ipv6_cidr_block": "",
+                "protocol": "-1",
+                "rule_no": 100,
+                "to_port": 0
+              }
+            ],
+            "region": "eu-west-3",
+            "subnet_ids": null,
+            "tags": {
+              "Name": "camunda-r1-vpc-default"
+            },
+            "tags_all": {
+              "Name": "camunda-r1-vpc-default"
+            }
+          }
+        },
+        "module.vpc_region_1[0].aws_default_route_table.default[0]": {
+          "index": 0,
+          "mode": "managed",
+          "name": "default",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "route": [],
+            "tags": {},
+            "tags_all": {},
+            "timeouts": {}
+          },
+          "type": "aws_default_route_table",
+          "values": {
+            "propagating_vgws": null,
+            "region": "eu-west-3",
+            "tags": {
+              "Name": "camunda-r1-vpc-default"
+            },
+            "tags_all": {
+              "Name": "camunda-r1-vpc-default"
+            },
+            "timeouts": {
+              "create": "5m",
+              "update": "5m"
+            }
+          }
+        },
+        "module.vpc_region_1[0].aws_default_security_group.this[0]": {
+          "index": 0,
+          "mode": "managed",
+          "name": "this",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 1,
+          "sensitive_values": {
+            "egress": [],
+            "ingress": [],
+            "tags": {},
+            "tags_all": {}
+          },
+          "type": "aws_default_security_group",
+          "values": {
+            "region": "eu-west-3",
+            "revoke_rules_on_delete": false,
+            "tags": {
+              "Name": "camunda-r1-vpc-default"
+            },
+            "tags_all": {
+              "Name": "camunda-r1-vpc-default"
+            }
+          }
+        },
+        "module.vpc_region_1[0].aws_eip.nat[0]": {
+          "identity": {
+            "account_id": null,
+            "id": null,
+            "region": null
+          },
+          "identity_schema_version": 0,
+          "index": 0,
+          "mode": "managed",
+          "name": "nat",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "tags": {},
+            "tags_all": {}
+          },
+          "type": "aws_eip",
+          "values": {
+            "address": null,
+            "associate_with_private_ip": null,
+            "customer_owned_ipv4_pool": null,
+            "domain": "vpc",
+            "region": "eu-west-3",
+            "tags": {
+              "Name": "camunda-r1-vpc-eu-west-3a"
+            },
+            "tags_all": {
+              "Name": "camunda-r1-vpc-eu-west-3a"
+            },
+            "timeouts": null
+          }
+        },
+        "module.vpc_region_1[0].aws_eip.nat[1]": {
+          "identity": {
+            "account_id": null,
+            "id": null,
+            "region": null
+          },
+          "identity_schema_version": 0,
+          "index": 1,
+          "mode": "managed",
+          "name": "nat",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "tags": {},
+            "tags_all": {}
+          },
+          "type": "aws_eip",
+          "values": {
+            "address": null,
+            "associate_with_private_ip": null,
+            "customer_owned_ipv4_pool": null,
+            "domain": "vpc",
+            "region": "eu-west-3",
+            "tags": {
+              "Name": "camunda-r1-vpc-eu-west-3b"
+            },
+            "tags_all": {
+              "Name": "camunda-r1-vpc-eu-west-3b"
+            },
+            "timeouts": null
+          }
+        },
+        "module.vpc_region_1[0].aws_eip.nat[2]": {
+          "identity": {
+            "account_id": null,
+            "id": null,
+            "region": null
+          },
+          "identity_schema_version": 0,
+          "index": 2,
+          "mode": "managed",
+          "name": "nat",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "tags": {},
+            "tags_all": {}
+          },
+          "type": "aws_eip",
+          "values": {
+            "address": null,
+            "associate_with_private_ip": null,
+            "customer_owned_ipv4_pool": null,
+            "domain": "vpc",
+            "region": "eu-west-3",
+            "tags": {
+              "Name": "camunda-r1-vpc-eu-west-3c"
+            },
+            "tags_all": {
+              "Name": "camunda-r1-vpc-eu-west-3c"
+            },
+            "timeouts": null
+          }
+        },
+        "module.vpc_region_1[0].aws_internet_gateway.this[0]": {
+          "identity": {
+            "account_id": null,
+            "id": null,
+            "region": null
+          },
+          "identity_schema_version": 0,
+          "index": 0,
+          "mode": "managed",
+          "name": "this",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "tags": {},
+            "tags_all": {}
+          },
+          "type": "aws_internet_gateway",
+          "values": {
+            "region": "eu-west-3",
+            "tags": {
+              "Name": "camunda-r1-vpc"
+            },
+            "tags_all": {
+              "Name": "camunda-r1-vpc"
+            },
+            "timeouts": null
+          }
+        },
+        "module.vpc_region_1[0].aws_nat_gateway.this[0]": {
+          "identity": {
+            "account_id": null,
+            "id": null,
+            "region": null
+          },
+          "identity_schema_version": 0,
+          "index": 0,
+          "mode": "managed",
+          "name": "this",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "availability_zone_address": [],
+            "regional_nat_gateway_address": [],
+            "secondary_allocation_ids": [],
+            "secondary_private_ip_addresses": [],
+            "tags": {},
+            "tags_all": {}
+          },
+          "type": "aws_nat_gateway",
+          "values": {
+            "availability_zone_address": [],
+            "connectivity_type": "public",
+            "region": "eu-west-3",
+            "tags": {
+              "Name": "camunda-r1-vpc-eu-west-3a"
+            },
+            "tags_all": {
+              "Name": "camunda-r1-vpc-eu-west-3a"
+            },
+            "timeouts": null
+          }
+        },
+        "module.vpc_region_1[0].aws_nat_gateway.this[1]": {
+          "identity": {
+            "account_id": null,
+            "id": null,
+            "region": null
+          },
+          "identity_schema_version": 0,
+          "index": 1,
+          "mode": "managed",
+          "name": "this",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "availability_zone_address": [],
+            "regional_nat_gateway_address": [],
+            "secondary_allocation_ids": [],
+            "secondary_private_ip_addresses": [],
+            "tags": {},
+            "tags_all": {}
+          },
+          "type": "aws_nat_gateway",
+          "values": {
+            "availability_zone_address": [],
+            "connectivity_type": "public",
+            "region": "eu-west-3",
+            "tags": {
+              "Name": "camunda-r1-vpc-eu-west-3b"
+            },
+            "tags_all": {
+              "Name": "camunda-r1-vpc-eu-west-3b"
+            },
+            "timeouts": null
+          }
+        },
+        "module.vpc_region_1[0].aws_nat_gateway.this[2]": {
+          "identity": {
+            "account_id": null,
+            "id": null,
+            "region": null
+          },
+          "identity_schema_version": 0,
+          "index": 2,
+          "mode": "managed",
+          "name": "this",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "availability_zone_address": [],
+            "regional_nat_gateway_address": [],
+            "secondary_allocation_ids": [],
+            "secondary_private_ip_addresses": [],
+            "tags": {},
+            "tags_all": {}
+          },
+          "type": "aws_nat_gateway",
+          "values": {
+            "availability_zone_address": [],
+            "connectivity_type": "public",
+            "region": "eu-west-3",
+            "tags": {
+              "Name": "camunda-r1-vpc-eu-west-3c"
+            },
+            "tags_all": {
+              "Name": "camunda-r1-vpc-eu-west-3c"
+            },
+            "timeouts": null
+          }
+        },
+        "module.vpc_region_1[0].aws_route.private_nat_gateway[0]": {
+          "identity": {
+            "account_id": null,
+            "destination_cidr_block": null,
+            "destination_ipv6_cidr_block": null,
+            "destination_prefix_list_id": null,
+            "region": null,
+            "route_table_id": null
+          },
+          "identity_schema_version": 0,
+          "index": 0,
+          "mode": "managed",
+          "name": "private_nat_gateway",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "timeouts": {}
+          },
+          "type": "aws_route",
+          "values": {
+            "carrier_gateway_id": null,
+            "core_network_arn": null,
+            "destination_cidr_block": "0.0.0.0/0",
+            "destination_ipv6_cidr_block": null,
+            "destination_prefix_list_id": null,
+            "egress_only_gateway_id": null,
+            "gateway_id": null,
+            "local_gateway_id": null,
+            "odb_network_arn": null,
+            "region": "eu-west-3",
+            "timeouts": {
+              "create": "5m",
+              "delete": null,
+              "update": null
+            },
+            "transit_gateway_id": null,
+            "vpc_endpoint_id": null,
+            "vpc_peering_connection_id": null
+          }
+        },
+        "module.vpc_region_1[0].aws_route.private_nat_gateway[1]": {
+          "identity": {
+            "account_id": null,
+            "destination_cidr_block": null,
+            "destination_ipv6_cidr_block": null,
+            "destination_prefix_list_id": null,
+            "region": null,
+            "route_table_id": null
+          },
+          "identity_schema_version": 0,
+          "index": 1,
+          "mode": "managed",
+          "name": "private_nat_gateway",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "timeouts": {}
+          },
+          "type": "aws_route",
+          "values": {
+            "carrier_gateway_id": null,
+            "core_network_arn": null,
+            "destination_cidr_block": "0.0.0.0/0",
+            "destination_ipv6_cidr_block": null,
+            "destination_prefix_list_id": null,
+            "egress_only_gateway_id": null,
+            "gateway_id": null,
+            "local_gateway_id": null,
+            "odb_network_arn": null,
+            "region": "eu-west-3",
+            "timeouts": {
+              "create": "5m",
+              "delete": null,
+              "update": null
+            },
+            "transit_gateway_id": null,
+            "vpc_endpoint_id": null,
+            "vpc_peering_connection_id": null
+          }
+        },
+        "module.vpc_region_1[0].aws_route.private_nat_gateway[2]": {
+          "identity": {
+            "account_id": null,
+            "destination_cidr_block": null,
+            "destination_ipv6_cidr_block": null,
+            "destination_prefix_list_id": null,
+            "region": null,
+            "route_table_id": null
+          },
+          "identity_schema_version": 0,
+          "index": 2,
+          "mode": "managed",
+          "name": "private_nat_gateway",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "timeouts": {}
+          },
+          "type": "aws_route",
+          "values": {
+            "carrier_gateway_id": null,
+            "core_network_arn": null,
+            "destination_cidr_block": "0.0.0.0/0",
+            "destination_ipv6_cidr_block": null,
+            "destination_prefix_list_id": null,
+            "egress_only_gateway_id": null,
+            "gateway_id": null,
+            "local_gateway_id": null,
+            "odb_network_arn": null,
+            "region": "eu-west-3",
+            "timeouts": {
+              "create": "5m",
+              "delete": null,
+              "update": null
+            },
+            "transit_gateway_id": null,
+            "vpc_endpoint_id": null,
+            "vpc_peering_connection_id": null
+          }
+        },
+        "module.vpc_region_1[0].aws_route.public_internet_gateway[0]": {
+          "identity": {
+            "account_id": null,
+            "destination_cidr_block": null,
+            "destination_ipv6_cidr_block": null,
+            "destination_prefix_list_id": null,
+            "region": null,
+            "route_table_id": null
+          },
+          "identity_schema_version": 0,
+          "index": 0,
+          "mode": "managed",
+          "name": "public_internet_gateway",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "timeouts": {}
+          },
+          "type": "aws_route",
+          "values": {
+            "carrier_gateway_id": null,
+            "core_network_arn": null,
+            "destination_cidr_block": "0.0.0.0/0",
+            "destination_ipv6_cidr_block": null,
+            "destination_prefix_list_id": null,
+            "egress_only_gateway_id": null,
+            "local_gateway_id": null,
+            "nat_gateway_id": null,
+            "odb_network_arn": null,
+            "region": "eu-west-3",
+            "timeouts": {
+              "create": "5m",
+              "delete": null,
+              "update": null
+            },
+            "transit_gateway_id": null,
+            "vpc_endpoint_id": null,
+            "vpc_peering_connection_id": null
+          }
+        },
+        "module.vpc_region_1[0].aws_route_table.private[0]": {
+          "identity": {
+            "account_id": null,
+            "id": null,
+            "region": null
+          },
+          "identity_schema_version": 0,
+          "index": 0,
+          "mode": "managed",
+          "name": "private",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "propagating_vgws": [],
+            "route": [],
+            "tags": {},
+            "tags_all": {}
+          },
+          "type": "aws_route_table",
+          "values": {
+            "region": "eu-west-3",
+            "tags": {
+              "Name": "camunda-r1-vpc-private-eu-west-3a"
+            },
+            "tags_all": {
+              "Name": "camunda-r1-vpc-private-eu-west-3a"
+            },
+            "timeouts": null
+          }
+        },
+        "module.vpc_region_1[0].aws_route_table.private[1]": {
+          "identity": {
+            "account_id": null,
+            "id": null,
+            "region": null
+          },
+          "identity_schema_version": 0,
+          "index": 1,
+          "mode": "managed",
+          "name": "private",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "propagating_vgws": [],
+            "route": [],
+            "tags": {},
+            "tags_all": {}
+          },
+          "type": "aws_route_table",
+          "values": {
+            "region": "eu-west-3",
+            "tags": {
+              "Name": "camunda-r1-vpc-private-eu-west-3b"
+            },
+            "tags_all": {
+              "Name": "camunda-r1-vpc-private-eu-west-3b"
+            },
+            "timeouts": null
+          }
+        },
+        "module.vpc_region_1[0].aws_route_table.private[2]": {
+          "identity": {
+            "account_id": null,
+            "id": null,
+            "region": null
+          },
+          "identity_schema_version": 0,
+          "index": 2,
+          "mode": "managed",
+          "name": "private",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "propagating_vgws": [],
+            "route": [],
+            "tags": {},
+            "tags_all": {}
+          },
+          "type": "aws_route_table",
+          "values": {
+            "region": "eu-west-3",
+            "tags": {
+              "Name": "camunda-r1-vpc-private-eu-west-3c"
+            },
+            "tags_all": {
+              "Name": "camunda-r1-vpc-private-eu-west-3c"
+            },
+            "timeouts": null
+          }
+        },
+        "module.vpc_region_1[0].aws_route_table.public[0]": {
+          "identity": {
+            "account_id": null,
+            "id": null,
+            "region": null
+          },
+          "identity_schema_version": 0,
+          "index": 0,
+          "mode": "managed",
+          "name": "public",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {
+            "propagating_vgws": [],
+            "route": [],
+            "tags": {},
+            "tags_all": {}
+          },
+          "type": "aws_route_table",
+          "values": {
+            "region": "eu-west-3",
+            "tags": {
+              "Name": "camunda-r1-vpc-public"
+            },
+            "tags_all": {
+              "Name": "camunda-r1-vpc-public"
+            },
+            "timeouts": null
+          }
+        },
+        "module.vpc_region_1[0].aws_route_table_association.private[0]": {
+          "identity": {
+            "account_id": null,
+            "id": null,
+            "region": null
+          },
+          "identity_schema_version": 0,
+          "index": 0,
+          "mode": "managed",
+          "name": "private",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {},
+          "type": "aws_route_table_association",
+          "values": {
+            "gateway_id": null,
+            "region": "eu-west-3",
+            "timeouts": null
+          }
+        },
+        "module.vpc_region_1[0].aws_route_table_association.private[1]": {
+          "identity": {
+            "account_id": null,
+            "id": null,
+            "region": null
+          },
+          "identity_schema_version": 0,
+          "index": 1,
+          "mode": "managed",
+          "name": "private",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {},
+          "type": "aws_route_table_association",
+          "values": {
+            "gateway_id": null,
+            "region": "eu-west-3",
+            "timeouts": null
+          }
+        },
+        "module.vpc_region_1[0].aws_route_table_association.private[2]": {
+          "identity": {
+            "account_id": null,
+            "id": null,
+            "region": null
+          },
+          "identity_schema_version": 0,
+          "index": 2,
+          "mode": "managed",
+          "name": "private",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {},
+          "type": "aws_route_table_association",
+          "values": {
+            "gateway_id": null,
+            "region": "eu-west-3",
+            "timeouts": null
+          }
+        },
+        "module.vpc_region_1[0].aws_route_table_association.public[0]": {
+          "identity": {
+            "account_id": null,
+            "id": null,
+            "region": null
+          },
+          "identity_schema_version": 0,
+          "index": 0,
+          "mode": "managed",
+          "name": "public",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {},
+          "type": "aws_route_table_association",
+          "values": {
+            "gateway_id": null,
+            "region": "eu-west-3",
+            "timeouts": null
+          }
+        },
+        "module.vpc_region_1[0].aws_route_table_association.public[1]": {
+          "identity": {
+            "account_id": null,
+            "id": null,
+            "region": null
+          },
+          "identity_schema_version": 0,
+          "index": 1,
+          "mode": "managed",
+          "name": "public",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {},
+          "type": "aws_route_table_association",
+          "values": {
+            "gateway_id": null,
+            "region": "eu-west-3",
+            "timeouts": null
+          }
+        },
+        "module.vpc_region_1[0].aws_route_table_association.public[2]": {
+          "identity": {
+            "account_id": null,
+            "id": null,
+            "region": null
+          },
+          "identity_schema_version": 0,
+          "index": 2,
+          "mode": "managed",
+          "name": "public",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "sensitive_values": {},
+          "type": "aws_route_table_association",
+          "values": {
+            "gateway_id": null,
+            "region": "eu-west-3",
+            "timeouts": null
+          }
+        },
+        "module.vpc_region_1[0].aws_subnet.private[0]": {
+          "identity": {
+            "account_id": null,
+            "id": null,
+            "region": null
+          },
+          "identity_schema_version": 0,
+          "index": 0,
+          "mode": "managed",
+          "name": "private",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 1,
+          "sensitive_values": {
+            "tags": {},
+            "tags_all": {}
+          },
+          "type": "aws_subnet",
+          "values": {
+            "assign_ipv6_address_on_creation": false,
+            "availability_zone": "eu-west-3a",
+            "cidr_block": "10.202.0.0/19",
+            "customer_owned_ipv4_pool": null,
+            "enable_dns64": false,
+            "enable_lni_at_device_index": null,
+            "enable_resource_name_dns_a_record_on_launch": false,
+            "enable_resource_name_dns_aaaa_record_on_launch": false,
+            "ipv4_ipam_pool_id": null,
+            "ipv4_netmask_length": null,
+            "ipv6_ipam_pool_id": null,
+            "ipv6_native": false,
+            "ipv6_netmask_length": null,
+            "map_customer_owned_ip_on_launch": null,
+            "map_public_ip_on_launch": false,
+            "outpost_arn": null,
+            "region": "eu-west-3",
+            "tags": {
+              "Name": "camunda-r1-vpc-private-eu-west-3a"
+            },
+            "tags_all": {
+              "Name": "camunda-r1-vpc-private-eu-west-3a"
+            },
+            "timeouts": null
+          }
+        },
+        "module.vpc_region_1[0].aws_subnet.private[1]": {
+          "identity": {
+            "account_id": null,
+            "id": null,
+            "region": null
+          },
+          "identity_schema_version": 0,
+          "index": 1,
+          "mode": "managed",
+          "name": "private",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 1,
+          "sensitive_values": {
+            "tags": {},
+            "tags_all": {}
+          },
+          "type": "aws_subnet",
+          "values": {
+            "assign_ipv6_address_on_creation": false,
+            "availability_zone": "eu-west-3b",
+            "cidr_block": "10.202.32.0/19",
+            "customer_owned_ipv4_pool": null,
+            "enable_dns64": false,
+            "enable_lni_at_device_index": null,
+            "enable_resource_name_dns_a_record_on_launch": false,
+            "enable_resource_name_dns_aaaa_record_on_launch": false,
+            "ipv4_ipam_pool_id": null,
+            "ipv4_netmask_length": null,
+            "ipv6_ipam_pool_id": null,
+            "ipv6_native": false,
+            "ipv6_netmask_length": null,
+            "map_customer_owned_ip_on_launch": null,
+            "map_public_ip_on_launch": false,
+            "outpost_arn": null,
+            "region": "eu-west-3",
+            "tags": {
+              "Name": "camunda-r1-vpc-private-eu-west-3b"
+            },
+            "tags_all": {
+              "Name": "camunda-r1-vpc-private-eu-west-3b"
+            },
+            "timeouts": null
+          }
+        },
+        "module.vpc_region_1[0].aws_subnet.private[2]": {
+          "identity": {
+            "account_id": null,
+            "id": null,
+            "region": null
+          },
+          "identity_schema_version": 0,
+          "index": 2,
+          "mode": "managed",
+          "name": "private",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 1,
+          "sensitive_values": {
+            "tags": {},
+            "tags_all": {}
+          },
+          "type": "aws_subnet",
+          "values": {
+            "assign_ipv6_address_on_creation": false,
+            "availability_zone": "eu-west-3c",
+            "cidr_block": "10.202.64.0/19",
+            "customer_owned_ipv4_pool": null,
+            "enable_dns64": false,
+            "enable_lni_at_device_index": null,
+            "enable_resource_name_dns_a_record_on_launch": false,
+            "enable_resource_name_dns_aaaa_record_on_launch": false,
+            "ipv4_ipam_pool_id": null,
+            "ipv4_netmask_length": null,
+            "ipv6_ipam_pool_id": null,
+            "ipv6_native": false,
+            "ipv6_netmask_length": null,
+            "map_customer_owned_ip_on_launch": null,
+            "map_public_ip_on_launch": false,
+            "outpost_arn": null,
+            "region": "eu-west-3",
+            "tags": {
+              "Name": "camunda-r1-vpc-private-eu-west-3c"
+            },
+            "tags_all": {
+              "Name": "camunda-r1-vpc-private-eu-west-3c"
+            },
+            "timeouts": null
+          }
+        },
+        "module.vpc_region_1[0].aws_subnet.public[0]": {
+          "identity": {
+            "account_id": null,
+            "id": null,
+            "region": null
+          },
+          "identity_schema_version": 0,
+          "index": 0,
+          "mode": "managed",
+          "name": "public",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 1,
+          "sensitive_values": {
+            "tags": {},
+            "tags_all": {}
+          },
+          "type": "aws_subnet",
+          "values": {
+            "assign_ipv6_address_on_creation": false,
+            "availability_zone": "eu-west-3a",
+            "cidr_block": "10.202.96.0/19",
+            "customer_owned_ipv4_pool": null,
+            "enable_dns64": false,
+            "enable_lni_at_device_index": null,
+            "enable_resource_name_dns_a_record_on_launch": false,
+            "enable_resource_name_dns_aaaa_record_on_launch": false,
+            "ipv4_ipam_pool_id": null,
+            "ipv4_netmask_length": null,
+            "ipv6_ipam_pool_id": null,
+            "ipv6_native": false,
+            "ipv6_netmask_length": null,
+            "map_customer_owned_ip_on_launch": null,
+            "map_public_ip_on_launch": false,
+            "outpost_arn": null,
+            "region": "eu-west-3",
+            "tags": {
+              "Name": "camunda-r1-vpc-public-eu-west-3a"
+            },
+            "tags_all": {
+              "Name": "camunda-r1-vpc-public-eu-west-3a"
+            },
+            "timeouts": null
+          }
+        },
+        "module.vpc_region_1[0].aws_subnet.public[1]": {
+          "identity": {
+            "account_id": null,
+            "id": null,
+            "region": null
+          },
+          "identity_schema_version": 0,
+          "index": 1,
+          "mode": "managed",
+          "name": "public",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 1,
+          "sensitive_values": {
+            "tags": {},
+            "tags_all": {}
+          },
+          "type": "aws_subnet",
+          "values": {
+            "assign_ipv6_address_on_creation": false,
+            "availability_zone": "eu-west-3b",
+            "cidr_block": "10.202.128.0/19",
+            "customer_owned_ipv4_pool": null,
+            "enable_dns64": false,
+            "enable_lni_at_device_index": null,
+            "enable_resource_name_dns_a_record_on_launch": false,
+            "enable_resource_name_dns_aaaa_record_on_launch": false,
+            "ipv4_ipam_pool_id": null,
+            "ipv4_netmask_length": null,
+            "ipv6_ipam_pool_id": null,
+            "ipv6_native": false,
+            "ipv6_netmask_length": null,
+            "map_customer_owned_ip_on_launch": null,
+            "map_public_ip_on_launch": false,
+            "outpost_arn": null,
+            "region": "eu-west-3",
+            "tags": {
+              "Name": "camunda-r1-vpc-public-eu-west-3b"
+            },
+            "tags_all": {
+              "Name": "camunda-r1-vpc-public-eu-west-3b"
+            },
+            "timeouts": null
+          }
+        },
+        "module.vpc_region_1[0].aws_subnet.public[2]": {
+          "identity": {
+            "account_id": null,
+            "id": null,
+            "region": null
+          },
+          "identity_schema_version": 0,
+          "index": 2,
+          "mode": "managed",
+          "name": "public",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 1,
+          "sensitive_values": {
+            "tags": {},
+            "tags_all": {}
+          },
+          "type": "aws_subnet",
+          "values": {
+            "assign_ipv6_address_on_creation": false,
+            "availability_zone": "eu-west-3c",
+            "cidr_block": "10.202.160.0/19",
+            "customer_owned_ipv4_pool": null,
+            "enable_dns64": false,
+            "enable_lni_at_device_index": null,
+            "enable_resource_name_dns_a_record_on_launch": false,
+            "enable_resource_name_dns_aaaa_record_on_launch": false,
+            "ipv4_ipam_pool_id": null,
+            "ipv4_netmask_length": null,
+            "ipv6_ipam_pool_id": null,
+            "ipv6_native": false,
+            "ipv6_netmask_length": null,
+            "map_customer_owned_ip_on_launch": null,
+            "map_public_ip_on_launch": false,
+            "outpost_arn": null,
+            "region": "eu-west-3",
+            "tags": {
+              "Name": "camunda-r1-vpc-public-eu-west-3c"
+            },
+            "tags_all": {
+              "Name": "camunda-r1-vpc-public-eu-west-3c"
+            },
+            "timeouts": null
+          }
+        },
+        "module.vpc_region_1[0].aws_vpc.this[0]": {
+          "identity": {
+            "account_id": null,
+            "id": null,
+            "region": null
+          },
+          "identity_schema_version": 0,
+          "index": 0,
+          "mode": "managed",
+          "name": "this",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 1,
+          "sensitive_values": {
+            "tags": {},
+            "tags_all": {}
+          },
+          "type": "aws_vpc",
+          "values": {
+            "assign_generated_ipv6_cidr_block": null,
+            "cidr_block": "10.202.0.0/16",
+            "enable_dns_hostnames": true,
+            "enable_dns_support": true,
+            "instance_tenancy": "default",
+            "ipv4_ipam_pool_id": null,
+            "ipv4_netmask_length": null,
+            "ipv6_ipam_pool_id": null,
+            "ipv6_netmask_length": null,
+            "region": "eu-west-3",
+            "tags": {
+              "Name": "camunda-r1-vpc"
+            },
+            "tags_all": {
+              "Name": "camunda-r1-vpc"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/justfile
+++ b/justfile
@@ -31,8 +31,13 @@ regenerate-golden-file module_dir backend_bucket_region backend_bucket_name back
 
   rm -Rf {{ justfile_directory() }}/{{ module_dir }}/.terraform*
 
-  # Copy *.tf files from test/fixtures/golden to the current directory before running the plan
+  # Copy *.tf files from test/fixtures/golden to the current directory before running the plan.
+  # Register the cleanup via trap so the copies are removed even if terraform init/plan fails
+  # under `set -e`: a stray fixture_*_override.tf left in the module root would silently
+  # neutralize the real terraform_remote_state read (count = 0) on the next standalone
+  # plan/apply/test, or get accidentally committed (module roots do not gitignore fixture_*.tf).
   if ls test/fixtures/golden/fixture_*.tf 1> /dev/null 2>&1; then
+    trap 'rm -f fixture_*.tf' EXIT
     cp test/fixtures/golden/fixture_*.tf ./
   fi
 
@@ -44,8 +49,8 @@ regenerate-golden-file module_dir backend_bucket_region backend_bucket_name back
   # we always use the same region and fake rhcs token to have a pre-defined output
   RHCS_TOKEN="" AWS_REGION="eu-west-2" terraform plan -var-file=test/golden/golden.tfvars -out=tfplan
 
-  # Clean up copied .tf files (those prefixed with fixture_)
-  rm -f fixture_*.tf
+  # Copied fixture_*.tf are removed by the EXIT trap registered above (runs on
+  # success or failure), so nothing to clean up explicitly here.
 
   terraform show -json tfplan | jq > tfplan.json
   rm -f tfplan
@@ -161,13 +166,11 @@ regenerate-golden-file-all:
 
     # Skip modules that are not golden-tracked. A module opts in to golden
     # regeneration by providing test/golden/golden.tfvars; modules without it
-    # (e.g. freshly added ones, or cross-state modules that cannot be planned
-    # standalone) are skipped instead of failing the whole run.
-    # The ECS dual-region vpc/ state opts in; its sibling infra/ and app/ states
-    # read each other via data.terraform_remote_state (and infra reads live
-    # data.aws_subnet from the vpc outputs), so they cannot be planned standalone
-    # and deliberately omit the marker — same class as rosa-hcp-dual-region peering.
-    # See https://github.com/camunda/team-infrastructure-experience/issues/1158
+    # (e.g. freshly added ones) are skipped instead of failing the whole run.
+    # Cross-state modules that read a sibling state via terraform_remote_state
+    # (e.g. the ECS dual-region infra/ and app/ states) opt in too, by shipping
+    # a test/fixtures/golden/fixture_*_override.tf that neutralises the read with
+    # a static snapshot so the plan is deterministic and offline.
     if [[ ! -f "${module_dir_abs}/test/golden/golden.tfvars" ]]; then
       echo "Skipping: ${module_dir_rel} (no test/golden/golden.tfvars)"
       continue

--- a/justfile
+++ b/justfile
@@ -163,8 +163,11 @@ regenerate-golden-file-all:
     # regeneration by providing test/golden/golden.tfvars; modules without it
     # (e.g. freshly added ones, or cross-state modules that cannot be planned
     # standalone) are skipped instead of failing the whole run.
-    # ECS dual-region modules currently lack golden coverage, tracked in:
-    # https://github.com/camunda/team-infrastructure-experience/issues/1158
+    # The ECS dual-region vpc/ state opts in; its sibling infra/ and app/ states
+    # read each other via data.terraform_remote_state (and infra reads live
+    # data.aws_subnet from the vpc outputs), so they cannot be planned standalone
+    # and deliberately omit the marker — same class as rosa-hcp-dual-region peering.
+    # See https://github.com/camunda/team-infrastructure-experience/issues/1158
     if [[ ! -f "${module_dir_abs}/test/golden/golden.tfvars" ]]; then
       echo "Skipping: ${module_dir_rel} (no test/golden/golden.tfvars)"
       continue


### PR DESCRIPTION
## Motivation

The ECS dual-region Fargate reference architecture (`aws/containers/ecs-dual-region-fargate/`) ships three Terraform states — `vpc`, `infra`, `app` — but none had golden plan coverage. `just regenerate-golden-file-all` (run by the scheduled maintenance job) expects a golden setup per state, and the gap previously broke that job until #2761 made the recipe skip states without `test/golden/golden.tfvars`. As a result these three states were the only reference-architecture modules excluded from golden plan drift detection.

Closes the coverage gap tracked in [team-infrastructure-experience#1158](https://github.com/camunda/team-infrastructure-experience/issues/1158).

## What this does

Adds golden plan coverage for **all three** states, plus a CI workflow that compares each on PRs.

| State | Plannable standalone? | Approach |
|-------|----------------------|----------|
| `vpc` | Yes (only `data.aws_availability_zones`) | `golden.tfvars` + generated `tfplan-golden.json` |
| `infra` | No — reads `terraform_remote_state.vpc` + live `data.aws_subnet` | fixture override + generated golden |
| `app` | No — reads `terraform_remote_state.infra` | fixture override + generated golden |

`infra` and `app` cannot be planned standalone because they read a sibling state over an S3 backend that does not exist during golden generation. Each ships a `test/fixtures/golden/fixture_*_override.tf` (a Terraform override file the `regenerate-golden-file` recipe copies in and removes) that:

- disables the remote-state read (`count = 0`) so no backend is contacted, and
- injects a static, deterministic snapshot of the upstream outputs.

`infra` additionally stubs the live `data.aws_subnet` lookups and re-injects the derived AZ list. `data.aws_caller_identity` stays live — the account ID it yields appears only inside ARNs, which the recipe redacts.

`app` is the most valuable of the three to cover: its golden captures the Camunda ECS task definitions, services and environment variables.

## Implications

- All three states now provide `test/golden/golden.tfvars`, so they participate in `regenerate-golden-file-all` and golden drift detection like every other reference architecture.
- New workflow `.github/workflows/aws_ecs_dual_region_fargate_golden.yml` runs the three comparisons on PRs. Its `paths:` triggers cover the reference architecture's terraform, `.tool-versions`, and the shared modules rendered into the golden plans (`ecs`, `aurora-global`, `opensearch`, `transit-gateway`) so a change to any of them re-runs the comparison.
- The `regenerate-golden-file` recipe now removes copied fixtures via an `EXIT` trap, so a failed run cannot leave a stray `fixture_*_override.tf` in a module root (which would silently neutralize the real remote-state read on a subsequent standalone plan).

## Verification

- All three golden files were generated against the CI state backend, are **deterministic** (fresh regeneration matches the committed file via `delta`), and are **redaction-clean** (no real account IDs, ARNs, developer paths, or emails).
- `pre-commit run --all-files`-equivalent hooks pass (terraform fmt/tflint/docs, trivy, yamllint, actionlint, and the `terraform test` suites for the touched states).

## Notes

Rebased on top of #2910, which repaired the `infra`/`app` `terraform test` suites and renamed `aurora_secondary_endpoint` → `aurora_secondary_cluster_endpoint`; the `app` fixture uses the corrected output name.