### PR TITLE
fix(local): quote Kind helm-values cpu as strings for chart 8.8 schema

### DIFF
--- a/local/kubernetes/kind-single-region/helm-values/values-domain.yml
+++ b/local/kubernetes/kind-single-region/helm-values/values-domain.yml
@@ -64,10 +64,10 @@ connectors:
         mode: disabled
     resources:
         requests:
-            cpu: 0.1
+            cpu: 100m
             memory: 256Mi
         limits:
-            cpu: 1
+            cpu: 1000m
             memory: 1Gi
     security:
         authentication:
@@ -87,10 +87,10 @@ elasticsearch:
         heapSize: 1g
         resources:
             requests:
-                cpu: 0.5
+                cpu: 500m
                 memory: 1536Mi
             limits:
-                cpu: 2
+                cpu: 2000m
                 memory: 3Gi
 
 identity:
@@ -180,10 +180,10 @@ console:
     contextPath: /console
     resources:
         requests:
-            cpu: 0.05
+            cpu: 50m
             memory: 64Mi
         limits:
-            cpu: 0.5
+            cpu: 500m
             memory: 256Mi
 
 webModeler:

--- a/local/kubernetes/kind-single-region/helm-values/values-no-domain.yml
+++ b/local/kubernetes/kind-single-region/helm-values/values-no-domain.yml
@@ -51,10 +51,10 @@ connectors:
         mode: disabled
     resources:
         requests:
-            cpu: 0.1
+            cpu: 100m
             memory: 256Mi
         limits:
-            cpu: 1
+            cpu: 1000m
             memory: 1Gi
     security:
         authentication:
@@ -74,10 +74,10 @@ elasticsearch:
         heapSize: 1g
         resources:
             requests:
-                cpu: 0.5
+                cpu: 500m
                 memory: 1536Mi
             limits:
-                cpu: 2
+                cpu: 2000m
                 memory: 3Gi
 
 identity:
@@ -166,10 +166,10 @@ console:
     enabled: true
     resources:
         requests:
-            cpu: 0.05
+            cpu: 50m
             memory: 64Mi
         limits:
-            cpu: 0.5
+            cpu: 500m
             memory: 256Mi
 
 webModeler:


### PR DESCRIPTION
## Description

The Kind single-region integration tests (`Tests - Integration - Local Kubernetes Kind Single Region`) fail on `stable/8.8` in **both no-domain and domain modes** with Helm chart schema validation errors:

```
Error: values don't meet the specifications of the schema(s) in the following chart(s):
- at '/console/resources/limits/cpu': got number, want string
- at '/console/resources/requests/cpu': got number, want string
- at '/connectors/resources/limits/cpu': got number, want string
- at '/connectors/resources/requests/cpu': got number, want string
```

### Root cause

The Camunda Platform 8.8 Helm chart JSON schema requires `resources.*.cpu` values to be **strings**. The Kind helm-values declared them as **bare numbers** (`0.1`, `1`, `0.05`, `0.5`, `2`), so `helm install` aborted before deploying anything.

`stable/8.9` and `main` already use the millicpu string form, so only `stable/8.8` is affected.

### Fix

Convert every bare-number cpu value to its exact millicpu-string equivalent in `values-no-domain.yml` and `values-domain.yml` — functionally identical, just correctly typed:

| before | after | section |
|--------|-------|---------|
| `0.1` / `1` | `100m` / `1000m` | `connectors.resources` |
| `0.05` / `0.5` | `50m` / `500m` | `console.resources` |
| `0.5` / `2` | `500m` / `2000m` | `elasticsearch.master.resources` |

The `elasticsearch` pair wasn't in the reported schema error but is converted for consistency with the rest of the files (and with `stable/8.9`/`main`).

### Verification

- All cpu values now parse as `!!str` (verified with `yq`).
- pre-commit hooks (yamllint, YAML format, check-yaml) pass.

Failing run: https://github.com/camunda/camunda-deployment-references/actions/runs/29873575314

🤖 Generated with [Claude Code](https://claude.com/claude-code)