### PR TITLE
fix: report Identity failures that block the Keycloak realm

### DIFF
--- a/generic/kubernetes/single-region/procedure/check-deployment-ready.sh
+++ b/generic/kubernetes/single-region/procedure/check-deployment-ready.sh
@@ -1,14 +1,144 @@
 #!/bin/bash
 
-while true; do
-    kubectl get pods -n "$CAMUNDA_NAMESPACE" --output=wide
+# Wait until every pod of the Camunda namespace is Running with all of its
+# containers ready.
+#
+# The wait is bounded and reports *why* it is still waiting: a stuck deployment
+# used to render as an endless stream of "Some pods are not Running or Healthy",
+# which hides the only information that matters (CrashLoopBackOff, OOMKilled,
+# ImagePullBackOff, unschedulable pods...).
+#
+# Configuration (all optional, sensible defaults):
+#   CAMUNDA_NAMESPACE                  namespace Camunda is installed in (default: camunda)
+#   DEPLOYMENT_READY_TIMEOUT_SECONDS   wall-clock budget in seconds, 0 to wait forever (default: 1800)
+#   DEPLOYMENT_READY_INTERVAL_SECONDS  delay between two polls in seconds (default: 5)
 
-    if [ "$(kubectl get pods -n "$CAMUNDA_NAMESPACE" --field-selector=status.phase!=Running -o name | wc -l)" -eq 0 ] &&
-        [ "$(kubectl get pods -n "$CAMUNDA_NAMESPACE" -o json | jq -r '.items[] | select(.status.containerStatuses[]?.ready == false)' | wc -l)" -eq 0 ]; then
+set -uo pipefail
+
+namespace="${CAMUNDA_NAMESPACE:-camunda}"
+timeout_seconds="${DEPLOYMENT_READY_TIMEOUT_SECONDS:-1800}"
+interval_seconds="${DEPLOYMENT_READY_INTERVAL_SECONDS:-5}"
+
+# Require plain non-negative integers; fall back to the defaults otherwise. The
+# digits-only check rejects signs/letters before the 10# normalization (which also
+# stops a leading zero from being read as octal in the arithmetic below).
+case "$timeout_seconds" in
+    '' | *[!0-9]*)
+        echo "WARNING: DEPLOYMENT_READY_TIMEOUT_SECONDS='${timeout_seconds}' is not a non-negative integer; using 1800." >&2
+        timeout_seconds=1800
+        ;;
+esac
+timeout_seconds=$((10#$timeout_seconds))
+
+case "$interval_seconds" in
+    '' | 0 | *[!0-9]*)
+        echo "WARNING: DEPLOYMENT_READY_INTERVAL_SECONDS='${interval_seconds}' is not a positive integer; using 5." >&2
+        interval_seconds=5
+        ;;
+esac
+interval_seconds=$((10#$interval_seconds))
+
+# Containers that are not ready, with the reason they are waiting and how their
+# previous attempt died. 'OOMKilled' or a non-zero exit code here is the actual
+# root cause, and is what a component needing more resources looks like.
+report_unready_containers() {
+    kubectl get pods -n "$namespace" -o json | jq -r '
+        .items[]
+        | . as $pod
+        | (($pod.status.containerStatuses // []) + ($pod.status.initContainerStatuses // []))[]
+        | select(.ready != true)
+        | "  \($pod.metadata.name)/\(.name)"
+          + " phase=\($pod.status.phase)"
+          + " restarts=\(.restartCount)"
+          + " waiting=\(.state.waiting.reason // "-")"
+          + " lastTerminated=\(.lastState.terminated.reason // "-")"
+          + " exitCode=\(.lastState.terminated.exitCode // "-")"
+    '
+}
+
+# Pods that never reached the Running phase have no container status to report,
+# so surface them separately (Pending pods are usually unschedulable ones).
+report_non_running_pods() {
+    kubectl get pods -n "$namespace" -o json | jq -r '
+        .items[]
+        | select(.status.phase != "Running")
+        | "  \(.metadata.name) phase=\(.status.phase) reason=\(.status.reason // "-")"
+    '
+}
+
+report_warning_events() {
+    kubectl get events -n "$namespace" \
+        --field-selector type=Warning \
+        --sort-by=.lastTimestamp \
+        -o custom-columns=OBJECT:.involvedObject.name,REASON:.reason,MESSAGE:.message \
+        2>/dev/null | tail -n 15
+}
+
+diagnostics() {
+    local unready non_running events
+    unready="$(report_unready_containers)"
+    non_running="$(report_non_running_pods)"
+    events="$(report_warning_events)"
+
+    echo "--- why the deployment is not ready yet ---"
+    [ -n "$non_running" ] && printf 'Pods not Running:\n%s\n' "$non_running"
+    [ -n "$unready" ] && printf 'Containers not ready:\n%s\n' "$unready"
+    if [ -n "$events" ]; then
+        printf 'Recent warning events:\n%s\n' "$events"
+    fi
+    echo "-------------------------------------------"
+}
+
+all_pods_ready() {
+    local pods total
+    # Evaluate both conditions from a single snapshot: two independent `kubectl`
+    # calls could disagree, and a failing call used to yield an empty result that
+    # was counted as "nothing unhealthy" and reported the install as complete.
+    pods="$(kubectl get pods -n "$namespace" -o json 2>/dev/null)" || return 1
+    [ -n "$pods" ] || return 1
+
+    total="$(printf '%s' "$pods" | jq -r '.items | length' 2>/dev/null)"
+    case "$total" in
+        '' | *[!0-9]*) return 1 ;;
+        0) return 1 ;; # an empty namespace is not a healthy deployment
+    esac
+
+    [ "$(printf '%s' "$pods" | jq -r '[.items[] | select(.status.phase != "Running")] | length')" -eq 0 ] &&
+        [ "$(printf '%s' "$pods" | jq -r '[.items[] | select(.status.containerStatuses[]?.ready == false)] | length')" -eq 0 ]
+}
+
+if [ "$timeout_seconds" -gt 0 ]; then
+    deadline=$(($(date +%s) + timeout_seconds))
+    echo "Waiting up to ${timeout_seconds}s for all pods in namespace '${namespace}' to be ready..."
+else
+    deadline=0
+    echo "Waiting (no timeout) for all pods in namespace '${namespace}' to be ready..."
+fi
+
+# Report the detailed state roughly once a minute so the output stays readable
+# while still explaining what is blocking the deployment.
+diagnostics_every=$(((60 + interval_seconds - 1) / interval_seconds))
+attempt=0
+
+while true; do
+    kubectl get pods -n "$namespace" --output=wide
+
+    if all_pods_ready; then
         echo "All pods are Running and Healthy - Installation completed!"
         exit 0
-    else
-        echo "Some pods are not Running or Healthy, please wait..."
-        sleep 5
     fi
+
+    attempt=$((attempt + 1))
+    if [ $((attempt % diagnostics_every)) -eq 0 ]; then
+        diagnostics
+    fi
+
+    if [ "$deadline" -ne 0 ] && [ "$(date +%s)" -ge "$deadline" ]; then
+        echo "ERROR: pods in namespace '${namespace}' were still not ready after ${timeout_seconds}s." >&2
+        diagnostics
+        exit 1
+    fi
+
+    echo "Some pods are not Running or Healthy, please wait..."
+    sleep "$interval_seconds"
 done

--- a/generic/kubernetes/single-region/procedure/wait-for-keycloak.sh
+++ b/generic/kubernetes/single-region/procedure/wait-for-keycloak.sh
@@ -15,6 +15,13 @@
 #
 # It is safe to run right after the Helm install, and it FAILS OPEN: if the issuer
 # never answers within the timeout it warns and exits 0, so it never blocks a deploy.
+# The hard readiness gate is check-deployment-ready.sh, which runs afterwards.
+#
+# The realm is created by the Identity component, so a permanently missing issuer is
+# almost always a broken Identity rather than a slow one. Restarting Zeebe/Connectors
+# cannot help in that case, so on timeout this script reports the Identity workload
+# state (restarts, CrashLoopBackOff, OOMKilled, exit codes) instead of just warning
+# that Keycloak was slow.
 #
 # Configuration (all optional, sensible defaults):
 #   CAMUNDA_NAMESPACE              namespace Camunda is installed in (default: camunda)
@@ -33,6 +40,7 @@ domain="${CAMUNDA_DOMAIN:-camunda.example.com}"
 issuer="${CAMUNDA_OIDC_ISSUER_URL:-https://${domain}/auth/realms/camunda-platform}"
 discovery="${issuer%/}/.well-known/openid-configuration"
 timeout_seconds="${KEYCLOAK_WAIT_TIMEOUT_SECONDS:-600}"
+identity_deployment="${release}-identity"
 
 curl_opts=(--silent --output /dev/null --max-time 5)
 if [ "${KEYCLOAK_WAIT_INSECURE:-false}" = "true" ]; then
@@ -42,6 +50,68 @@ fi
 warn() {
     # Non-fatal warning; this script is fail-open and never aborts a deploy.
     printf 'WARNING: %s\n' "$1"
+}
+
+# Ready replica count of the Identity deployment. Prints the count and returns 0
+# when the deployment exists, returns 1 when it does not (Identity disabled, or a
+# release name mismatch). `.status.readyReplicas` is absent - not 0 - while no
+# replica is ready, hence the explicit default.
+identity_ready_replicas() {
+    local out
+    out="$(kubectl --namespace "$namespace" get deployment "$identity_deployment" \
+        -o jsonpath='{.status.readyReplicas}' 2>/dev/null)" || return 1
+    printf '%s' "${out:-0}"
+}
+
+# Names of the pods backing the Identity deployment. Pod names are derived from
+# the deployment name, so a prefix match avoids depending on chart labels (which
+# have changed across chart major versions).
+identity_pods() {
+    kubectl --namespace "$namespace" get pods -o name 2>/dev/null |
+        sed -n "s|^pod/\(${identity_deployment}-[^/]*\)$|\1|p"
+}
+
+# Per-container state of every Identity pod: restarts, why it is waiting, and how
+# the previous attempt died. 'OOMKilled' or a non-zero exit code here is the root
+# cause of a platform-wide OIDC failure, not Keycloak being slow.
+identity_container_states() {
+    local pod
+    for pod in $(identity_pods); do
+        kubectl --namespace "$namespace" get pod "$pod" -o jsonpath="{range .status.containerStatuses[*]}${pod}/{.name} restarts={.restartCount} waiting={.state.waiting.reason} lastTerminated={.lastState.terminated.reason} exitCode={.lastState.terminated.exitCode}{'\n'}{end}" 2>/dev/null
+    done
+}
+
+# Loud, actionable report explaining that Identity - not Keycloak - is the blocker.
+report_identity() {
+    local ready states
+    if ! ready="$(identity_ready_replicas)"; then
+        echo "Identity deployment '${identity_deployment}' not found in namespace '${namespace}'."
+        echo "If Identity is disabled, the 'camunda-platform' realm must be provisioned another way."
+        return 0
+    fi
+    if [ "$ready" -ge 1 ]; then
+        echo "Identity deployment '${identity_deployment}' reports ${ready} ready replica(s);"
+        echo "the issuer is likely still converging (DNS, TLS certificate or ingress)."
+        return 0
+    fi
+
+    echo "ROOT CAUSE: the 'camunda-platform' realm is created by the Identity component,"
+    echo "and '${identity_deployment}' has no ready replica. Until Identity starts, the issuer"
+    echo "${issuer} cannot exist, and every other component will keep failing OIDC discovery"
+    echo "with HTTP 404/503. Restarting Zeebe or Connectors cannot fix this."
+    echo ""
+    echo "Identity container states:"
+    states="$(identity_container_states)"
+    if [ -n "$states" ]; then
+        printf '%s\n' "$states"
+    else
+        echo "  (no Identity pod found)"
+    fi
+    echo ""
+    echo "Next steps:"
+    echo "  kubectl --namespace ${namespace} describe deployment ${identity_deployment}"
+    echo "  kubectl --namespace ${namespace} logs deployment/${identity_deployment} --all-containers --previous"
+    echo "A 'lastTerminated=OOMKilled' above means Identity needs a higher memory limit."
 }
 
 # Require a plain positive integer; fall back otherwise. The digits-only check
@@ -69,6 +139,7 @@ done
 echo "Waiting for the Keycloak OIDC discovery document (up to ${timeout_seconds}s): ${discovery}"
 deadline=$(($(date +%s) + timeout_seconds))
 attempt=0
+identity_warned=false
 while [ "$(date +%s)" -lt "$deadline" ]; do
     attempt=$((attempt + 1))
     code=$(curl "${curl_opts[@]}" -w '%{http_code}' "$discovery" || true)
@@ -94,8 +165,20 @@ while [ "$(date +%s)" -lt "$deadline" ]; do
         exit 0
     fi
     echo "[attempt ${attempt}] not ready yet (HTTP ${code}); retrying in 5s..."
+    # Surface a crash-looping Identity early (once) instead of letting the user
+    # stare at identical retry lines for the whole budget.
+    if [ "$identity_warned" = "false" ] && [ $((attempt % 12)) -eq 0 ]; then
+        case "$(identity_container_states)" in
+            *waiting=CrashLoopBackOff* | *lastTerminated=OOMKilled*)
+                identity_warned=true
+                warn "Identity is not starting; it is what provisions the OIDC realm at ${issuer}."
+                report_identity
+                ;;
+        esac
+    fi
     sleep 5
 done
 
 warn "Keycloak issuer ${discovery} did not return 200 within ${timeout_seconds}s; continuing anyway."
+report_identity
 exit 0

--- a/local/kubernetes/kind-single-region/Makefile
+++ b/local/kubernetes/kind-single-region/Makefile
@@ -23,9 +23,13 @@ CLUSTER_NAME ?= camunda-platform-local
 CAMUNDA_NAMESPACE ?= camunda
 CAMUNDA_RELEASE_NAME ?= camunda
 CERT_DIR ?= .certs
+# Bound `camunda.wait` so a stuck deployment reports its cause instead of looping
+# forever. A local kind cluster that has not converged in 15 minutes is broken.
+DEPLOYMENT_READY_TIMEOUT_SECONDS ?= 900
 # SECONDARY_STORAGE has no default - must be explicitly set to 'elasticsearch' or 'postgres'
 
 export CLUSTER_NAME CAMUNDA_NAMESPACE CAMUNDA_RELEASE_NAME CERT_DIR SECONDARY_STORAGE
+export DEPLOYMENT_READY_TIMEOUT_SECONDS
 
 # Paths
 PROCEDURE_DIR := ./procedure
@@ -278,7 +282,9 @@ camunda.uninstall:
 .PHONY: camunda.wait
 camunda.wait:
 	@echo "Waiting for Camunda pods to be ready..."
-	@CAMUNDA_NAMESPACE=$(CAMUNDA_NAMESPACE) ../../../generic/kubernetes/single-region/procedure/check-deployment-ready.sh
+	@CAMUNDA_NAMESPACE=$(CAMUNDA_NAMESPACE) \
+		DEPLOYMENT_READY_TIMEOUT_SECONDS=$(DEPLOYMENT_READY_TIMEOUT_SECONDS) \
+		../../../generic/kubernetes/single-region/procedure/check-deployment-ready.sh
 
 # =============================================================================
 # Utilities

--- a/local/kubernetes/kind-single-region/README.md
+++ b/local/kubernetes/kind-single-region/README.md
@@ -22,6 +22,10 @@ SECONDARY_STORAGE=elasticsearch make no-domain.clean   # Full cleanup (no-domain
 
 > **Domain mode & Keycloak:** in TLS/domain mode the Camunda pods authenticate against the public Keycloak issuer (`https://camunda.example.com/auth/...`), which only becomes reachable a few minutes after install while DNS, the TLS certificate and the `camunda-platform` realm converge. `domain.init` runs `wait-for-keycloak.sh` automatically: it waits (up to a timeout) for the issuer, then restarts the app pods so a transient first-start `CrashLoopBackOff` clears quickly. If the issuer is slower than the timeout the script warns and continues, and the pods recover on their own once it converges.
 
+> **If the platform never converges:** the `camunda-platform` realm is provisioned by the **Identity** component, so a permanently failing OIDC discovery (`503`/`404` on the issuer) usually means Identity itself never started, not that Keycloak is slow. `wait-for-keycloak.sh` reports the Identity pod state in that case, and `make camunda.wait` prints the unready containers (restarts, `CrashLoopBackOff`, `OOMKilled`, exit codes) and recent warning events roughly once a minute, then fails after `DEPLOYMENT_READY_TIMEOUT_SECONDS` (default: `900`). Restarting Zeebe or Connectors cannot help while Identity is down.
+
+> **Resources:** the full domain stack (Elasticsearch, Keycloak, three PostgreSQL clusters and every Camunda component) needs noticeably more than the 8 GB documented minimum. If pods are `OOMKilled`, give the container runtime more memory or deploy with `SECONDARY_STORAGE=postgres`, which skips Elasticsearch and Optimize.
+
 ## Credentials
 
 **Camunda admin password:**

--- a/local/kubernetes/kind-single-region/helm-values/values-domain.yml
+++ b/local/kubernetes/kind-single-region/helm-values/values-domain.yml
@@ -68,13 +68,19 @@ identity:
     contextPath: /managementidentity
     fullURL: https://camunda.example.com/managementidentity
 
+    # Identity provisions the `camunda-platform` Keycloak realm on startup, and
+    # every other component blocks on that realm for OIDC discovery. If Identity
+    # is starved it is OOMKilled or throttled before the realm exists, and the
+    # whole platform crash-loops with a misleading 503/404 on the issuer URL.
+    # A Spring Boot JVM needs more than 512Mi/500m to get there reliably on a
+    # contended laptop, so keep this component comfortable.
     resources:
         requests:
-            cpu: 50m
-            memory: 128Mi
-        limits:
-            cpu: 500m
+            cpu: 100m
             memory: 512Mi
+        limits:
+            cpu: 1000m
+            memory: 1Gi
 
     firstUser:
         enabled: true

--- a/local/kubernetes/kind-single-region/helm-values/values-no-domain.yml
+++ b/local/kubernetes/kind-single-region/helm-values/values-no-domain.yml
@@ -57,13 +57,19 @@ identity:
     enabled: true
     fullURL: http://localhost:8085
 
+    # Identity provisions the `camunda-platform` Keycloak realm on startup, and
+    # every other component blocks on that realm for OIDC discovery. If Identity
+    # is starved it is OOMKilled or throttled before the realm exists, and the
+    # whole platform crash-loops with a misleading 503/404 on the issuer URL.
+    # A Spring Boot JVM needs more than 512Mi/500m to get there reliably on a
+    # contended laptop, so keep this component comfortable.
     resources:
         requests:
-            cpu: 50m
-            memory: 128Mi
-        limits:
-            cpu: 500m
+            cpu: 100m
             memory: 512Mi
+        limits:
+            cpu: 1000m
+            memory: 1Gi
 
     firstUser:
         enabled: true


### PR DESCRIPTION
## Problem

Reported in #2686 (kind, domain mode). Every component crash-loops with a misleading error:

- orchestration: `503 ... Connection refused` on `https://camunda.example.com/auth/realms/camunda-platform`
- connectors: `Failed to retrieve well known configuration ... 404 Not Found`

The reporter's own attachments show the real chain:

| Evidence | Meaning |
|---|---|
| `curl .../realms/master/.well-known/openid-configuration` returns valid JSON | ingress, CoreDNS rewrite, mkcert TLS all work |
| `curl .../realms/camunda-platform/...` returns `{"error":"Realm does not exist"}` | the realm was never created |
| `camunda-identity ... CrashLoopBackOff 21 (4m15s ago) 101m` | Identity was dead for 100 minutes |

Identity is what provisions the `camunda-platform` realm (see the comment in `operators-deploy.sh`), so a permanently missing issuer is a broken Identity, not a slow Keycloak. This was not a startup race: after the `rollout restart`, the new Zeebe/Connectors pods crashed again within 9 seconds because the realm still did not exist.

Nothing in the procedures pointed at Identity:

- `check-deployment-ready.sh` looped forever printing `Some pods are not Running or Healthy, please wait...` with no diagnostic. The reporter waited 101 minutes.
- `wait-for-keycloak.sh` blamed a slow Keycloak on timeout and restarted Zeebe/Connectors, which cannot help while Identity is down.

## Changes

**1. Identity resources (`values-domain.yml`, `values-no-domain.yml`)**

`requests: 50m/128Mi -> 100m/512Mi`, `limits: 500m/512Mi -> 1000m/1Gi`.

These values were set when the kind flavour was created (#1437, 2026-01-08) and never revisited. kind is the only reference architecture that constrains Identity at all; every cloud flavour uses the chart defaults. A Spring Boot JVM at 512Mi/500m sits right on the OOM cliff, which is consistent with the reporter's Identity log stopping abruptly after `Root WebApplicationContext: initialization completed in 15296 ms` (8.5x slower than Zeebe on the same node) with no exception and no shutdown output.

**2. `wait-for-keycloak.sh` reports the Identity workload**

On timeout, and once mid-flight when Identity is seen in `CrashLoopBackOff`/`OOMKilled`, the script now prints the per-container state and what to do about it:

```
ROOT CAUSE: the 'camunda-platform' realm is created by the Identity component,
and 'camunda-identity' has no ready replica. [...]
Restarting Zeebe or Connectors cannot fix this.

Identity container states:
camunda-identity-xxx/camunda-platform restarts=21 waiting=CrashLoopBackOff lastTerminated=OOMKilled exitCode=137
```

It stays **fail-open** (`exit 0`) on purpose: `camunda-deploy-domain.sh` runs under `set -e`, so failing here would abort the deploy before the readiness gate could report anything.

**3. `check-deployment-ready.sh` is bounded and explains itself**

- `DEPLOYMENT_READY_TIMEOUT_SECONDS` (default `1800`, `900` for kind via the Makefile), `0` to keep the previous unbounded behaviour.
- Prints unready containers (restarts, waiting reason, last termination reason, exit code), non-Running pods, and the last 15 warning events roughly once a minute and on timeout.
- Readiness is now evaluated from a single `kubectl` snapshot. The two independent calls could disagree, and more importantly a *failing* call produced empty output that was counted as "nothing unhealthy" and reported `All pods are Running and Healthy - Installation completed!`. An empty namespace is no longer treated as ready either.

## CI impact

None expected. All CI callers of `check-deployment-ready.sh` already carry a step `timeout-minutes` of 10 (kind) to 20 (EKS/AKS/ROSA), well below the new 1800s default, so the script-level bound never fires first. CI does not override Identity resources, so it gets the same new values.

## Testing

- `shellcheck` and `pre-commit` clean on all touched files.
- Both scripts exercised against a stubbed `kubectl`/`curl` for: all-ready (exit 0), not-ready to timeout (exit 1 + diagnostics), empty namespace (no false success), Identity absent, Identity ready, and the issuer-200 happy path (workload restarts unchanged).

## Follow-up

Sister PR updating the kind guide with the realistic memory requirement and an Identity troubleshooting entry: camunda/camunda-docs#9499

Refs #2686
