### PR TITLE
feat(aws): EKS multi-region reference architecture with replication-agnostic RDBMS secondary storage

### DIFF
--- a/.github/actions/aws-kubernetes-eks-multi-region-rdbms-create/README.md
+++ b/.github/actions/aws-kubernetes-eks-multi-region-rdbms-create/README.md
@@ -1,0 +1,126 @@
+# Deploy AWS Kubernetes EKS Multi Region RDBMS Clusters
+
+## Description
+
+Provisions the aws/kubernetes/eks-multi-region-rdbms reference architecture with Terraform:
+N EKS clusters in N regions, a Transit Gateway full mesh between them, the Submariner
+firewall rules, and an Aurora Global Database used as RDBMS secondary storage.
+
+Everything lives in a single Terraform state, mirroring aws/kubernetes/eks-single-region
+where Aurora sits next to the cluster, so that a single destroy tears the whole
+architecture down.
+
+
+## Inputs
+
+| name | description | required | default |
+| --- | --- | --- | --- |
+| `cluster-name` | <p>Base name of the clusters. Each region appends its short name.</p> | `true` | `""` |
+| `aws-region` | <p>Region of the first region slot, used for the AWS CLI default.</p> | `false` | `eu-west-2` |
+| `active-region-count` | <p>Number of region slots to deploy. Must be the slot count or the slot count minus one; see the reference architecture README for why.</p> | `false` | `3` |
+| `kubernetes-version` | <p>Version of Kubernetes to install</p> | `false` | `1.36` |
+| `np-desired-node-count` | <p>Desired number of nodes per regional node group</p> | `false` | `3` |
+| `single-nat-gateway` | <p>Whether to use a single NAT gateway per region. True in CI to save on IPs.</p> | `false` | `true` |
+| `database-instance-class` | <p>Aurora instance class. Kept small in CI.</p> | `false` | `db.r6g.large` |
+| `tags` | <p>Tags to apply to every resource, in JSON format</p> | `false` | `{}` |
+| `s3-backend-bucket` | <p>Name of the S3 bucket storing the Terraform state</p> | `true` | `""` |
+| `s3-bucket-region` | <p>Region of the bucket containing the state; falls back on aws-region</p> | `false` | `""` |
+| `s3-bucket-key-prefix` | <p>Key prefix inside the state bucket. Must end with a '/'.</p> | `false` | `""` |
+| `ref-arch` | <p>Reference architecture directory under aws/kubernetes</p> | `false` | `eks-multi-region-rdbms` |
+
+
+## Outputs
+
+| name | description |
+| --- | --- |
+| `terraform-state-url` | <p>URL of the Terraform state file in the S3 bucket</p> |
+| `region-slot-count` | <p>Number of region slots defined by the topology</p> |
+| `active-region-count` | <p>Number of region slots actually deployed</p> |
+| `cluster-contexts` | <p>Space-separated kubectl context aliases, one per active region</p> |
+| `aws-regions` | <p>Space-separated AWS regions, one per active region slot</p> |
+| `submariner-cluster-ids` | <p>Space-separated Submariner cluster IDs, one per active region slot</p> |
+| `aurora-global-cluster-id` | <p>Identifier of the Aurora Global Database</p> |
+
+
+## Runs
+
+This action is a `composite` action.
+
+## Usage
+
+```yaml
+- uses: camunda/camunda-deployment-references/.github/actions/aws-kubernetes-eks-multi-region-rdbms-create@main
+  with:
+    cluster-name:
+    # Base name of the clusters. Each region appends its short name.
+    #
+    # Required: true
+    # Default: ""
+
+    aws-region:
+    # Region of the first region slot, used for the AWS CLI default.
+    #
+    # Required: false
+    # Default: eu-west-2
+
+    active-region-count:
+    # Number of region slots to deploy. Must be the slot count or the slot count minus
+    # one; see the reference architecture README for why.
+    #
+    # Required: false
+    # Default: 3
+
+    kubernetes-version:
+    # Version of Kubernetes to install
+    #
+    # Required: false
+    # Default: 1.36
+
+    np-desired-node-count:
+    # Desired number of nodes per regional node group
+    #
+    # Required: false
+    # Default: 3
+
+    single-nat-gateway:
+    # Whether to use a single NAT gateway per region. True in CI to save on IPs.
+    #
+    # Required: false
+    # Default: true
+
+    database-instance-class:
+    # Aurora instance class. Kept small in CI.
+    #
+    # Required: false
+    # Default: db.r6g.large
+
+    tags:
+    # Tags to apply to every resource, in JSON format
+    #
+    # Required: false
+    # Default: {}
+
+    s3-backend-bucket:
+    # Name of the S3 bucket storing the Terraform state
+    #
+    # Required: true
+    # Default: ""
+
+    s3-bucket-region:
+    # Region of the bucket containing the state; falls back on aws-region
+    #
+    # Required: false
+    # Default: ""
+
+    s3-bucket-key-prefix:
+    # Key prefix inside the state bucket. Must end with a '/'.
+    #
+    # Required: false
+    # Default: ""
+
+    ref-arch:
+    # Reference architecture directory under aws/kubernetes
+    #
+    # Required: false
+    # Default: eks-multi-region-rdbms
+```

--- a/.github/actions/aws-kubernetes-eks-multi-region-rdbms-create/action.yml
+++ b/.github/actions/aws-kubernetes-eks-multi-region-rdbms-create/action.yml
@@ -1,0 +1,222 @@
+---
+name: Deploy AWS Kubernetes EKS Multi Region RDBMS Clusters
+
+description: |
+    Provisions the aws/kubernetes/eks-multi-region-rdbms reference architecture with Terraform:
+    N EKS clusters in N regions, a Transit Gateway full mesh between them, the Submariner
+    firewall rules, and an Aurora Global Database used as RDBMS secondary storage.
+
+    Everything lives in a single Terraform state, mirroring aws/kubernetes/eks-single-region
+    where Aurora sits next to the cluster, so that a single destroy tears the whole
+    architecture down.
+
+inputs:
+    cluster-name:
+        description: Base name of the clusters. Each region appends its short name.
+        required: true
+    aws-region:
+        description: Region of the first region slot, used for the AWS CLI default.
+        required: false
+        default: eu-west-2
+    active-region-count:
+        description: |
+            Number of region slots to deploy. Must be the slot count or the slot count minus
+            one; see the reference architecture README for why.
+        required: false
+        default: '3'
+    kubernetes-version:
+        description: Version of Kubernetes to install
+        required: false
+        # renovate: datasource=endoflife-date depName=amazon-eks versioning=loose
+        default: '1.36'
+    np-desired-node-count:
+        description: Desired number of nodes per regional node group
+        required: false
+        default: '3'
+    single-nat-gateway:
+        description: Whether to use a single NAT gateway per region. True in CI to save on IPs.
+        required: false
+        default: 'true'
+    database-instance-class:
+        description: Aurora instance class. Kept small in CI.
+        required: false
+        default: db.r6g.large
+    tags:
+        description: Tags to apply to every resource, in JSON format
+        required: false
+        default: '{}'
+    s3-backend-bucket:
+        description: Name of the S3 bucket storing the Terraform state
+        required: true
+    s3-bucket-region:
+        description: Region of the bucket containing the state; falls back on aws-region
+        required: false
+        default: ''
+    s3-bucket-key-prefix:
+        description: Key prefix inside the state bucket. Must end with a '/'.
+        required: false
+        default: ''
+    ref-arch:
+        description: Reference architecture directory under aws/kubernetes
+        required: false
+        default: eks-multi-region-rdbms
+
+outputs:
+    terraform-state-url:
+        description: URL of the Terraform state file in the S3 bucket
+        value: ${{ steps.init.outputs.terraform-state-url }}
+    region-slot-count:
+        description: Number of region slots defined by the topology
+        value: ${{ steps.outputs.outputs.region-slot-count }}
+    active-region-count:
+        description: Number of region slots actually deployed
+        value: ${{ steps.outputs.outputs.active-region-count }}
+    cluster-contexts:
+        description: Space-separated kubectl context aliases, one per active region
+        value: ${{ steps.outputs.outputs.cluster-contexts }}
+    aws-regions:
+        description: Space-separated AWS regions, one per active region slot
+        value: ${{ steps.outputs.outputs.aws-regions }}
+    submariner-cluster-ids:
+        description: Space-separated Submariner cluster IDs, one per active region slot
+        value: ${{ steps.outputs.outputs.submariner-cluster-ids }}
+    aurora-global-cluster-id:
+        description: Identifier of the Aurora Global Database
+        value: ${{ steps.outputs.outputs.aurora-global-cluster-id }}
+
+runs:
+    using: composite
+    steps:
+
+        - name: Set Terraform variables
+          id: set-terraform-variables
+          shell: bash
+          run: |
+              set -euo pipefail
+              export TFSTATE_BUCKET="${{ inputs.s3-backend-bucket }}"
+              export TFSTATE_BASE_KEY="${{ inputs.s3-bucket-key-prefix }}tfstate-${{ inputs.cluster-name }}/"
+
+              if [ -z "${{ inputs.s3-bucket-region }}" ]; then
+                export TFSTATE_REGION="${{ inputs.aws-region }}"
+              else
+                export TFSTATE_REGION="${{ inputs.s3-bucket-region }}"
+              fi
+
+              echo "TFSTATE_BUCKET=${TFSTATE_BUCKET}" >> "$GITHUB_OUTPUT"
+              echo "TFSTATE_REGION=${TFSTATE_REGION}" >> "$GITHUB_OUTPUT"
+              echo "TFSTATE_BASE_KEY=${TFSTATE_BASE_KEY}" | tee -a "$GITHUB_OUTPUT"
+
+        - name: Sanitize Tags
+          id: sanitize-tags
+          uses: ./.github/actions/internal-sanitize-tags
+          with:
+              raw-tags: ${{ inputs.tags }}
+
+        - name: Terraform Init
+          id: init
+          working-directory: aws/kubernetes/${{ inputs.ref-arch }}/terraform/clusters/
+          shell: bash
+          run: |
+              set -euo pipefail
+
+              terraform_state_key="${{ steps.set-terraform-variables.outputs.TFSTATE_BASE_KEY }}clusters.tfstate"
+              terraform_state_url="s3://${{ steps.set-terraform-variables.outputs.TFSTATE_BUCKET }}/$terraform_state_key"
+              echo "terraform-state-url=${terraform_state_url}" | tee -a "$GITHUB_OUTPUT"
+
+              terraform version
+
+              terraform init \
+                -backend-config="bucket=${{ steps.set-terraform-variables.outputs.TFSTATE_BUCKET }}" \
+                -backend-config="key=$terraform_state_key" \
+                -backend-config="region=${{ steps.set-terraform-variables.outputs.TFSTATE_REGION }}"
+
+              terraform validate -no-color
+
+        - name: Generate tfvars file
+          shell: bash
+          working-directory: aws/kubernetes/${{ inputs.ref-arch }}/terraform/clusters/
+          run: |
+              set -euo pipefail
+
+              cat > terraform-cluster.tfvars <<EOF
+              cluster_name            = "${{ inputs.cluster-name }}"
+              kubernetes_version      = "${{ inputs.kubernetes-version }}"
+              active_region_count     = ${{ inputs.active-region-count }}
+              np_desired_node_count   = ${{ inputs.np-desired-node-count }}
+              single_nat_gateway      = ${{ inputs.single-nat-gateway }}
+              database_instance_class = "${{ inputs.database-instance-class }}"
+              default_tags            = ${{ steps.sanitize-tags.outputs.sanitized_tags }}
+              aws_profile             = "infraex"
+              EOF
+
+              echo "Generated tfvars file:"
+              cat terraform-cluster.tfvars
+
+        - name: Terraform Plan
+          working-directory: aws/kubernetes/${{ inputs.ref-arch }}/terraform/clusters/
+          shell: bash
+          run: |
+              set -euo pipefail
+              terraform plan -no-color -var-file=terraform-cluster.tfvars -out tf.plan
+
+        - name: Terraform Apply
+          working-directory: aws/kubernetes/${{ inputs.ref-arch }}/terraform/clusters/
+          shell: bash
+          run: |
+              set -euo pipefail
+              terraform apply -no-color tf.plan
+
+        - name: Terraform Drift Detection
+          uses: ./.github/actions/internal-terraform-drift-detect
+          with:
+              working-directory: aws/kubernetes/${{ inputs.ref-arch }}/terraform/clusters/
+              plan-extra-args: |
+                  -var-file=terraform-cluster.tfvars
+
+        - name: Export topology outputs
+          id: outputs
+          working-directory: aws/kubernetes/${{ inputs.ref-arch }}/terraform/clusters/
+          shell: bash
+          run: |
+              set -euo pipefail
+
+              # A single terraform output call: each invocation takes the state lock.
+              tf_json="$(terraform output -json)"
+
+              slots="$(echo "$tf_json" | jq -r '.region_slot_count.value')"
+              active="$(echo "$tf_json" | jq -r '.active_region_count.value')"
+              regions="$(echo "$tf_json" | jq -r '[.regions.value | to_entries | sort_by(.key | tonumber) | .[].value.region] | join(" ")')"
+              short_names="$(echo "$tf_json" | jq -r '[.regions.value | to_entries | sort_by(.key | tonumber) | .[].value.short_name] | join(" ")')"
+              global_db="$(echo "$tf_json" | jq -r '.database_global_cluster_id.value // ""')"
+
+              contexts=""
+              for short in $short_names; do
+                contexts="${contexts}cluster-${short} "
+              done
+              contexts="${contexts% }"
+
+              {
+                echo "region-slot-count=${slots}"
+                echo "active-region-count=${active}"
+                echo "aws-regions=${regions}"
+                echo "submariner-cluster-ids=${short_names}"
+                echo "cluster-contexts=${contexts}"
+                echo "aurora-global-cluster-id=${global_db}"
+              } | tee -a "$GITHUB_OUTPUT"
+
+        - name: Register kubectl contexts
+          working-directory: aws/kubernetes/${{ inputs.ref-arch }}/terraform/clusters/
+          shell: bash
+          run: |
+              set -euo pipefail
+
+              read -r -a regions <<< "${{ steps.outputs.outputs.aws-regions }}"
+              read -r -a shorts  <<< "${{ steps.outputs.outputs.submariner-cluster-ids }}"
+
+              for i in "${!shorts[@]}"; do
+                aws eks --region "${regions[$i]}" update-kubeconfig \
+                  --name "${{ inputs.cluster-name }}-${shorts[$i]}" \
+                  --alias "cluster-${shorts[$i]}"
+              done
+
+              kubectl config get-contexts

--- a/.github/workflows-config/aws-kubernetes-eks-multi-region-rdbms/test_matrix.yml
+++ b/.github/workflows-config/aws-kubernetes-eks-multi-region-rdbms/test_matrix.yml
@@ -1,0 +1,14 @@
+---
+matrix:
+    distro:
+        - name: EKS
+          schedule_only: false
+
+    scenario:
+        - name: eks-multi-region-rdbms
+    declination:
+        - name: no-domain
+          desc: |
+              Three EKS clusters connected by a Transit Gateway mesh and Submariner, with an
+              Aurora Global Database as RDBMS secondary storage. Deployed with one spare
+              region slot so that the growth path is exercised.

--- a/.github/workflows/aws_eks_multi_region_rdbms_daily_cleanup.yml
+++ b/.github/workflows/aws_eks_multi_region_rdbms_daily_cleanup.yml
@@ -1,0 +1,143 @@
+---
+name: Tests - Daily Cleanup - AWS EKS Multi Region RDBMS
+
+on:
+    workflow_dispatch:
+        inputs:
+            max_age_hours_cluster:
+                description: Maximum age of clusters in hours
+                required: true
+                default: '12'
+    pull_request:
+        paths:
+            - .github/workflows/aws_eks_multi_region_rdbms_daily_cleanup.yml
+            - .tool-versions
+            - aws/kubernetes/eks-multi-region-rdbms/**
+            - '!aws/kubernetes/eks-multi-region-rdbms/terraform/*/test/golden/**'
+            - .github/actions/aws-generic-terraform-cleanup/**
+            - .github/actions/aws-configure-cli/**
+
+    schedule:
+        - cron: 0 4 * * * # At 04:00 everyday.
+
+# limit to a single execution per actor of this workflow
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    # we don't cancel the previous run, so it can finish it and let clusters in a proper state
+    cancel-in-progress: false
+
+env:
+    IS_SCHEDULE: ${{ (contains(github.head_ref, 'schedules/') || github.event_name == 'schedule') && 'true' || 'false' }}
+
+    MAX_AGE_HOURS_CLUSTER: ${{ github.event.inputs.max_age_hours_cluster || '12' }}
+
+    # please keep those variables synced with aws_eks_multi_region_rdbms_tests.yml
+    AWS_PROFILE: infraex
+    S3_BACKEND_BUCKET: tests-ra-aws-rosa-hcp-tf-state-eu-central-1
+    S3_BUCKET_REGION: eu-central-1
+    AWS_REGION: eu-west-2
+    REF_ARCH: eks-multi-region-rdbms
+
+    # Every region the architecture can create must be swept, including the AWS opt-in
+    # regions used by slots 2 and 3. Keep in sync with the `regions` variable default in
+    # aws/kubernetes/eks-multi-region-rdbms/terraform/clusters/variables.tf.
+    CLEANUP_REGIONS: eu-west-2 eu-west-3 eu-central-2
+
+jobs:
+    triage:
+        runs-on: ubuntu-latest
+        outputs:
+            should_skip: ${{ steps.skip_check.outputs.should_skip }}
+        steps:
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+            - name: Check labels
+              id: skip_check
+              uses: ./.github/actions/internal-triage-skip
+
+    cleanup-clusters:
+        needs: [triage]
+        if: needs.triage.outputs.should_skip == 'false'
+        runs-on: ubuntu-latest
+        timeout-minutes: 120
+        strategy:
+            fail-fast: false
+            matrix:
+                scenario:
+                    - name: eks-multi-region-rdbms
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+              with:
+                  ref: ${{ github.ref }}
+                  fetch-depth: 0
+
+            - name: Install asdf tools with cache
+              uses: camunda/infraex-common-config/./.github/actions/asdf-install-tooling@bde1b69728d323c1c2d02e19153a8e00382eec4a # 1.8.0
+
+            - name: Use repo .tool-version as global version
+              run: cp .tool-versions ~/.tool-versions
+
+            - name: Set current target branch
+              id: target-branch
+              run: |
+                  set -euo pipefail
+                  TARGET_BRANCH=$(cat .target-branch)
+                  echo "TARGET_BRANCH=$TARGET_BRANCH" | tee -a "$GITHUB_OUTPUT"
+
+            - name: Configure AWS CLI
+              uses: ./.github/actions/aws-configure-cli
+              with:
+                  vault-addr: ${{ secrets.VAULT_ADDR }}
+                  vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+                  vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+                  aws-profile: ${{ env.AWS_PROFILE }}
+                  aws-region: ${{ env.AWS_REGION }}
+
+            - name: Export the Terraform state key prefix
+              id: s3_prefix
+              run: |
+                  set -euo pipefail
+                  echo "S3_BACKEND_BUCKET_PREFIX=aws/kubernetes/${{ matrix.scenario.name }}/" | tee -a "$GITHUB_OUTPUT"
+
+            # A single Terraform state holds the EKS clusters, the Transit Gateway mesh and
+            # the Aurora Global Database, so one destroy tears the whole architecture down.
+            - name: Delete clusters
+              id: delete_clusters
+              continue-on-error: true
+              timeout-minutes: 115
+              uses: ./.github/actions/aws-generic-terraform-cleanup
+              with:
+                  tf-bucket: ${{ env.S3_BACKEND_BUCKET }}
+                  tf-bucket-region: ${{ env.S3_BUCKET_REGION }}
+                  max-age-hours: ${{ env.MAX_AGE_HOURS_CLUSTER }}
+                  tf-bucket-key-prefix: ${{ steps.s3_prefix.outputs.S3_BACKEND_BUCKET_PREFIX }}${{ steps.target-branch.outputs.TARGET_BRANCH }}/
+                  modules-order: clusters
+
+            # The previous step has continue-on-error so that a dependency ordering failure
+            # does not mask the rest of the sweep. Retry once with no age filter.
+            - name: Retry delete clusters
+              id: retry_delete_clusters
+              if: steps.delete_clusters.outcome == 'failure'
+              timeout-minutes: 115
+              uses: ./.github/actions/aws-generic-terraform-cleanup
+              with:
+                  tf-bucket: ${{ env.S3_BACKEND_BUCKET }}
+                  tf-bucket-region: ${{ env.S3_BUCKET_REGION }}
+                  max-age-hours: '0'
+                  tf-bucket-key-prefix: ${{ steps.s3_prefix.outputs.S3_BACKEND_BUCKET_PREFIX }}${{ steps.target-branch.outputs.TARGET_BRANCH }}/
+                  modules-order: clusters
+
+    report-failure:
+        if: failure() && github.event_name == 'schedule'
+        needs: [cleanup-clusters]
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+            - name: Notify in Slack in case of failure
+              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@bde1b69728d323c1c2d02e19153a8e00382eec4a # 1.8.0
+              with:
+                  vault_addr: ${{ secrets.VAULT_ADDR }}
+                  vault_role_id: ${{ secrets.VAULT_ROLE_ID }}
+                  vault_secret_id: ${{ secrets.VAULT_SECRET_ID }}

--- a/.github/workflows/aws_eks_multi_region_rdbms_golden.yml
+++ b/.github/workflows/aws_eks_multi_region_rdbms_golden.yml
@@ -1,0 +1,84 @@
+---
+name: Tests - Golden - AWS EKS Multi Region RDBMS
+
+on:
+    workflow_dispatch:
+    pull_request:
+        paths:
+            - .github/workflows/aws_eks_multi_region_rdbms_golden.yml
+            - .tool-versions
+            - aws/modules/eks-cluster/**
+            - aws/modules/transit-gateway-hub/**
+            - aws/modules/transit-gateway-peering/**
+            - aws/modules/aurora-global-member/**
+            - aws/kubernetes/eks-multi-region-rdbms/terraform/**
+            - .github/actions/aws-configure-cli/**
+
+# limit to a single execution per actor of this workflow
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
+env:
+    IS_SCHEDULE: ${{ (contains(github.head_ref, 'schedules/') || github.event_name == 'schedule') && 'true' || 'false' }}
+
+    # keep this synced with other workflows
+    AWS_PROFILE: infraex
+    AWS_REGION: eu-west-2
+    S3_BACKEND_BUCKET: tests-ra-aws-rosa-hcp-tf-state-eu-central-1
+    S3_BUCKET_REGION: eu-central-1
+    S3_BUCKET_KEY: golden.tfstate
+
+jobs:
+    triage:
+        runs-on: ubuntu-latest
+        outputs:
+            should_skip: ${{ steps.skip_check.outputs.should_skip }}
+        steps:
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+            - name: Check labels
+              id: skip_check
+              uses: ./.github/actions/internal-triage-skip
+
+    compare:
+        needs:
+            - triage
+        if: needs.triage.outputs.should_skip == 'false'
+        runs-on: ubuntu-latest
+        strategy:
+            fail-fast: false
+            matrix:
+                module:
+                    - eks-multi-region-rdbms/terraform/clusters/
+        permissions:
+            contents: write
+            pull-requests: write
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+            - name: Install asdf tools with cache
+              uses: camunda/infraex-common-config/./.github/actions/asdf-install-tooling@bde1b69728d323c1c2d02e19153a8e00382eec4a # 1.8.0
+
+            - name: Configure AWS CLI
+              uses: ./.github/actions/aws-configure-cli
+              with:
+                  vault-addr: ${{ secrets.VAULT_ADDR }}
+                  vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+                  vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+                  aws-profile: ${{ env.AWS_PROFILE }}
+                  aws-region: ${{ env.AWS_REGION }}
+
+            - name: Export module_dir depending on scenario
+              id: set-module-dir
+              run: echo "MODULE_DIR=./aws/kubernetes/${{ matrix.module }}" | tee -a "$GITHUB_ENV"
+
+            - name: Run Terraform Golden Plan Comparison
+              uses: ./.github/actions/internal-terraform-golden-plan
+              env:
+                  GH_TOKEN: ${{ github.token }}
+              with:
+                  module-dir: ${{ env.MODULE_DIR }}
+                  s3-bucket-region: ${{ env.S3_BUCKET_REGION }}
+                  s3-backend-bucket: ${{ env.S3_BACKEND_BUCKET }}
+                  s3-bucket-key: ${{ env.S3_BUCKET_KEY }}

--- a/.github/workflows/aws_eks_multi_region_rdbms_tests.yml
+++ b/.github/workflows/aws_eks_multi_region_rdbms_tests.yml
@@ -1,0 +1,263 @@
+---
+name: Tests - Integration - AWS EKS Multi Region RDBMS
+
+on:
+    schedule:
+        - cron: 0 3 * * 4 # At 03:00 on Thursday. Staggered with the other multi-cluster suites.
+    workflow_dispatch:
+        inputs:
+            active_region_count:
+                description: |
+                    Number of region slots to deploy. 2 exercises the growth path (a spare slot
+                    is activated during the run), 3 deploys everything up front.
+                required: false
+                default: '2'
+    pull_request:
+        paths:
+            - .github/workflows/aws_eks_multi_region_rdbms_tests.yml
+            - .github/actions/aws-kubernetes-eks-multi-region-rdbms-create/**
+            - .github/actions/aws-configure-cli/**
+            - .github/actions/aws-generic-terraform-cleanup/**
+            - .github/actions/internal-debug-failed-pods/**
+            - aws/kubernetes/eks-multi-region-rdbms/**
+            - '!aws/kubernetes/eks-multi-region-rdbms/terraform/*/test/golden/**'
+            - aws/modules/transit-gateway-hub/**
+            - aws/modules/transit-gateway-peering/**
+            - aws/modules/aurora-global-member/**
+
+# limit to a single execution per actor of this workflow
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: false
+
+env:
+    IS_SCHEDULE: ${{ (contains(github.head_ref, 'schedules/') || github.event_name == 'schedule') && 'true' || 'false' }}
+
+    # please keep those variables synced with aws_eks_multi_region_rdbms_daily_cleanup.yml
+    AWS_PROFILE: infraex
+    S3_BACKEND_BUCKET: tests-ra-aws-rosa-hcp-tf-state-eu-central-1
+    S3_BUCKET_REGION: eu-central-1
+    AWS_REGION: eu-west-2
+
+    # Region slot 0 drives the AWS CLI default; the other regions are read from the
+    # Terraform outputs so that the topology is defined in exactly one place.
+    #
+    # eu-central-2 (Zurich) is an AWS opt-in region: it must be enabled on the account and
+    # declared in camunda/infraex-common-config before this workflow can pass.
+    REF_ARCH: eks-multi-region-rdbms
+
+    # Bootstrap with one spare region slot so the run exercises the online growth path.
+    ACTIVE_REGION_COUNT: ${{ github.event.inputs.active_region_count || '2' }}
+
+    CAMUNDA_NAMESPACE: camunda
+    CAMUNDA_RELEASE_NAME: camunda
+    CAMUNDA_BROKERS_PER_REGION: '2'
+
+jobs:
+    triage:
+        runs-on: ubuntu-latest
+        outputs:
+            should_skip: ${{ steps.skip_check.outputs.should_skip }}
+        steps:
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+            - name: Check labels
+              id: skip_check
+              uses: ./.github/actions/internal-triage-skip
+
+    clusters-info:
+        needs: [triage]
+        if: needs.triage.outputs.should_skip == 'false'
+        runs-on: ubuntu-latest
+        outputs:
+            platform-matrix: ${{ steps.matrix.outputs.platform_matrix }}
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+            - name: Generate the test matrix
+              id: matrix
+              uses: ./.github/actions/internal-tests-matrix
+              with:
+                  ci_matrix_file: ./.github/workflows-config/aws-kubernetes-eks-multi-region-rdbms/test_matrix.yml
+                  is_schedule: ${{ env.IS_SCHEDULE }}
+                  is_renovate_pr: ${{ github.actor == 'renovate[bot]' && 'true' || 'false' }}
+                  cluster_prefix: eks-mr-
+
+    integration-tests:
+        needs: [triage, clusters-info]
+        if: needs.triage.outputs.should_skip == 'false'
+        runs-on: ubuntu-latest
+        # The infrastructure alone is roughly 40 minutes; the growth and region-loss
+        # scenarios add another 60.
+        timeout-minutes: 180
+        strategy:
+            fail-fast: false
+            matrix: ${{ fromJson(needs.clusters-info.outputs.platform-matrix) }}
+        env:
+            CLUSTER_NAME: eks-mr-${{ github.event.pull_request.number || github.run_id }}
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+            - name: Install asdf tools with cache
+              uses: camunda/infraex-common-config/./.github/actions/asdf-install-tooling@bde1b69728d323c1c2d02e19153a8e00382eec4a # 1.8.0
+
+            - name: Configure AWS CLI
+              uses: ./.github/actions/aws-configure-cli
+              with:
+                  vault-addr: ${{ secrets.VAULT_ADDR }}
+                  vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+                  vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+                  aws-profile: ${{ env.AWS_PROFILE }}
+                  aws-region: ${{ env.AWS_REGION }}
+
+            - name: Set current target branch
+              id: target-branch
+              run: |
+                  set -euo pipefail
+                  TARGET_BRANCH=$(cat .target-branch)
+                  echo "TARGET_BRANCH=$TARGET_BRANCH" | tee -a "$GITHUB_OUTPUT"
+
+            - name: Export the Terraform state key prefix
+              id: s3_prefix
+              run: |
+                  set -euo pipefail
+                  echo "S3_BACKEND_BUCKET_PREFIX=aws/kubernetes/${{ env.REF_ARCH }}/${{ steps.target-branch.outputs.TARGET_BRANCH }}/" | tee -a "$GITHUB_OUTPUT"
+
+            - name: Create the multi-region infrastructure
+              id: create
+              timeout-minutes: 60
+              uses: ./.github/actions/aws-kubernetes-eks-multi-region-rdbms-create
+              with:
+                  cluster-name: ${{ env.CLUSTER_NAME }}
+                  aws-region: ${{ env.AWS_REGION }}
+                  active-region-count: ${{ env.ACTIVE_REGION_COUNT }}
+                  ref-arch: ${{ env.REF_ARCH }}
+                  s3-backend-bucket: ${{ env.S3_BACKEND_BUCKET }}
+                  s3-bucket-region: ${{ env.S3_BUCKET_REGION }}
+                  s3-bucket-key-prefix: ${{ steps.s3_prefix.outputs.S3_BACKEND_BUCKET_PREFIX }}
+                  tags: '{"ci-run-id": "${{ github.run_id }}", "ci-workflow": "${{ github.workflow }}"}'
+
+            - name: Export the environment contract
+              run: |
+                  set -euo pipefail
+                  {
+                    echo "CAMUNDA_REGION_SLOTS=${{ steps.create.outputs.region-slot-count }}"
+                    echo "CAMUNDA_ACTIVE_REGIONS=${{ steps.create.outputs.active-region-count }}"
+                    echo "CLUSTER_CONTEXTS=${{ steps.create.outputs.cluster-contexts }}"
+                    echo "AWS_REGIONS=${{ steps.create.outputs.aws-regions }}"
+                    echo "SUBMARINER_CLUSTER_IDS=${{ steps.create.outputs.submariner-cluster-ids }}"
+                    echo "AURORA_GLOBAL_CLUSTER_ID=${{ steps.create.outputs.aurora-global-cluster-id }}"
+                  } | tee -a "$GITHUB_ENV"
+
+            - name: Install subctl
+              timeout-minutes: 10
+              run: |
+                  set -euo pipefail
+                  source ./aws/kubernetes/${{ env.REF_ARCH }}/procedure/submariner/install-subctl.sh
+                  echo "PATH=$PATH" | tee -a "$GITHUB_ENV"
+
+            - name: Register the Camunda CI credentials
+              uses: ./.github/actions/internal-camunda-ci-credentials
+              with:
+                  vault-addr: ${{ secrets.VAULT_ADDR }}
+                  vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+                  vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+
+            - name: Build the Submariner mesh
+              timeout-minutes: 45
+              working-directory: aws/kubernetes/${{ env.REF_ARCH }}/test
+              run: go test --count=1 -v -timeout 45m -failfast -run TestMultiRegionSubmariner
+
+            - name: Deploy Camunda across the active regions
+              timeout-minutes: 45
+              working-directory: aws/kubernetes/${{ env.REF_ARCH }}/test
+              run: go test --count=1 -v -timeout 45m -failfast -run TestMultiRegionDeployCamunda
+
+            - name: Verify the multi-region topology
+              timeout-minutes: 30
+              working-directory: aws/kubernetes/${{ env.REF_ARCH }}/test
+              run: go test --count=1 -v -timeout 30m -failfast -run TestMultiRegionTopology
+
+            # The differentiating scenario: raise active_region_count and bring the spare
+            # slot online without restarting the running regions.
+            - name: Activate the spare region
+              if: env.ACTIVE_REGION_COUNT != env.CAMUNDA_REGION_SLOTS
+              timeout-minutes: 60
+              working-directory: aws/kubernetes/${{ env.REF_ARCH }}/terraform/clusters
+              run: |
+                  set -euo pipefail
+                  sed -i "s/^active_region_count.*/active_region_count = ${{ env.CAMUNDA_REGION_SLOTS }}/" terraform-cluster.tfvars
+                  terraform apply -no-color -auto-approve -var-file=terraform-cluster.tfvars
+
+            - name: Join the new region and grow the Zeebe cluster
+              if: env.ACTIVE_REGION_COUNT != env.CAMUNDA_REGION_SLOTS
+              timeout-minutes: 60
+              working-directory: aws/kubernetes/${{ env.REF_ARCH }}/test
+              env:
+                  CAMUNDA_ACTIVE_REGIONS: ${{ env.CAMUNDA_REGION_SLOTS }}
+              run: go test --count=1 -v -timeout 60m -failfast -run TestMultiRegionActivateRegion
+
+            # The point of the architecture: losing a region must not stop the engine.
+            - name: Lose a region and keep processing
+              timeout-minutes: 45
+              working-directory: aws/kubernetes/${{ env.REF_ARCH }}/test
+              env:
+                  CAMUNDA_ACTIVE_REGIONS: ${{ env.CAMUNDA_REGION_SLOTS }}
+              run: go test --count=1 -v -timeout 45m -failfast -run TestMultiRegionRegionLoss
+
+            - name: Bring the region back
+              timeout-minutes: 60
+              working-directory: aws/kubernetes/${{ env.REF_ARCH }}/test
+              env:
+                  CAMUNDA_ACTIVE_REGIONS: ${{ env.CAMUNDA_REGION_SLOTS }}
+              run: go test --count=1 -v -timeout 60m -failfast -run TestMultiRegionFailback
+
+            - name: Debug the cross-region networking
+              if: failure()
+              timeout-minutes: 10
+              run: ./aws/kubernetes/${{ env.REF_ARCH }}/procedure/submariner/diagnose-submariner.sh
+
+            - name: Debug failed pods
+              if: failure()
+              timeout-minutes: 10
+              run: |
+                  set -uo pipefail
+                  read -r -a contexts <<< "${{ env.CLUSTER_CONTEXTS }}"
+                  for ctx in "${contexts[@]}"; do
+                    echo "=== $ctx ==="
+                    kubectl --context "$ctx" -n "${{ env.CAMUNDA_NAMESPACE }}" get pods -o wide || true
+                    kubectl --context "$ctx" -n "${{ env.CAMUNDA_NAMESPACE }}" describe pods || true
+                  done
+
+            - name: Uninstall Camunda and Submariner
+              if: always()
+              timeout-minutes: 30
+              working-directory: aws/kubernetes/${{ env.REF_ARCH }}/test
+              run: go test --count=1 -v -timeout 30m -run TestMultiRegionCleanup || true
+
+            - name: Destroy the infrastructure
+              if: always()
+              timeout-minutes: 90
+              uses: ./.github/actions/aws-generic-terraform-cleanup
+              with:
+                  tf-bucket: ${{ env.S3_BACKEND_BUCKET }}
+                  tf-bucket-region: ${{ env.S3_BUCKET_REGION }}
+                  tf-bucket-key-prefix: ${{ steps.s3_prefix.outputs.S3_BACKEND_BUCKET_PREFIX }}
+                  target: ${{ env.CLUSTER_NAME }}
+                  modules-order: clusters
+
+    report-failure:
+        if: failure() && github.event_name == 'schedule'
+        needs: [integration-tests]
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+            - name: Notify in Slack in case of failure
+              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@bde1b69728d323c1c2d02e19153a8e00382eec4a # 1.8.0
+              with:
+                  vault_addr: ${{ secrets.VAULT_ADDR }}
+                  vault_role_id: ${{ secrets.VAULT_ROLE_ID }}
+                  vault_secret_id: ${{ secrets.VAULT_SECRET_ID }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -105,6 +105,9 @@ repos:
       hooks:
           - id: yamlfmt
             # yamlfmt removes quotes around YAML values like "OFF" or "false" which
-            # breaks ES config (boolean/string confusion).
+            # breaks ES config (boolean/string confusion). It also strips the quotes
+            # around '${VAR}' placeholders, which turns the Camunda chart's
+            # string-typed clusterSize/partitionCount/replicationFactor into
+            # integers and fails the chart JSON schema validation.
             # yamllint disable-line rule:line-length
-            exclude: (generic/kubernetes/operator-based/elasticsearch/elasticsearch-cluster.*\.yml|local/kubernetes/kind-single-region/configs/elasticsearch-cluster.yml)
+            exclude: (generic/kubernetes/operator-based/elasticsearch/elasticsearch-cluster.*\.yml|local/kubernetes/kind-single-region/configs/elasticsearch-cluster.yml|aws/kubernetes/eks-multi-region-rdbms/helm-values/camunda-values.yml)

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Where:
 - `{feature}`: A specific feature or deployment model, particularly in relation to **Camunda 8**, such as:
   - `single-region` (deployment in a single region).
   - `dual-region` (high availability across two regions).
+  - `multi-region` (high availability across N regions, where a region loss keeps quorum).
 - `{declination}`: A variation of the solution, such as:
   - `spot-instances` (for EC2 cost optimization).
   - `on-demand` (for standard EC2 instances).

--- a/aws/kubernetes/eks-multi-region-rdbms/DEVELOPER.md
+++ b/aws/kubernetes/eks-multi-region-rdbms/DEVELOPER.md
@@ -1,0 +1,169 @@
+# Developer's Guide
+
+Local development reference for the AWS EKS multi-region RDBMS architecture.
+Read [README.md](./README.md) first: the topology invariants (region slots,
+replication factor, node ID stride) are not obvious and getting them wrong
+produces a cluster that silently never forms a quorum.
+
+## Prerequisites
+
+```bash
+just install-tooling   # terraform, kubectl, helm, yq, jq, go
+pre-commit install
+```
+
+Plus:
+
+- `subctl` — installed by `procedure/submariner/install-subctl.sh`
+- an AWS profile with access to **all** the regions in play
+
+> [!WARNING]
+> `eu-central-2` (Zurich) and `eu-south-1` (Milan) are AWS **opt-in** regions.
+> They must be enabled on the account before anything can be created there:
+> `aws account enable-region --region-name eu-central-2`. Their cleanup schedule
+> also has to be declared in
+> [infraex-common-config](https://github.com/camunda/infraex-common-config).
+
+> [!WARNING]
+> `eu-west-2` and `eu-west-3` are nuked nightly. Use a `cluster_name` of your
+> own, never the CI default, and expect anything left running overnight to be
+> gone.
+
+## Cost awareness
+
+This architecture is significantly more expensive than the dual-region one:
+
+- 3 EKS control planes and node groups instead of 2
+- 3 Transit Gateways plus 3 inter-region peering attachments, billed per
+  attachment-hour **and** per GB of inter-region data
+- 1 Aurora Global Database with a member per database region
+
+Destroy it as soon as you are done. `single_nat_gateway = true` and a smaller
+`np_desired_node_count` cut a meaningful share of the bill for local iteration.
+
+## Bringing it up
+
+```bash
+cd terraform/clusters
+terraform init
+
+# Local iteration: 2 of 3 slots, smallest viable footprint.
+terraform apply \
+  -var cluster_name="$USER-mr" \
+  -var active_region_count=2 \
+  -var single_nat_gateway=true \
+  -var np_desired_node_count=2
+```
+
+`active_region_count=2` with 3 slots is a valid, supported state: every
+partition holds 2 of its 3 replicas. It halves the cost while still exercising
+the cross-region code paths, and it is the starting point of the
+`activate-region.sh` flow.
+
+Then:
+
+```bash
+# kubectl contexts, aliased to the names in CLUSTER_CONTEXTS
+for pair in "eu-west-2:$USER-mr-london:cluster-london" \
+            "eu-west-3:$USER-mr-paris:cluster-paris"; do
+  IFS=: read -r region name alias <<<"$pair"
+  aws eks --region "$region" update-kubeconfig --name "$name" --alias "$alias"
+done
+
+cd ../../procedure
+. ./export-terraform-outputs.sh
+export CAMUNDA_ACTIVE_REGIONS=2
+export CLUSTER_CONTEXTS="cluster-london cluster-paris"
+. ./export_environment_prerequisites.sh
+```
+
+`export-terraform-outputs.sh` derives most of the environment from the state, so
+only the kubectl context aliases really need to be provided by hand.
+
+## Debugging
+
+### Zeebe never reaches the expected broker count
+
+Almost always cross-region DNS. In order:
+
+```bash
+./submariner/verify-submariner.sh          # are the tunnels up?
+./submariner/diagnose-submariner.sh        # full dump incl. cross-cluster nslookup
+kubectl --context cluster-london -n camunda logs camunda-zeebe-0 -c wait-clusterset-dns
+```
+
+The `wait-clusterset-dns` init container logs exactly which name it is waiting
+for. If it times out and the broker starts anyway (fail-open), the broker will
+then hang on `NXDOMAIN` while dialing a peer — see
+[camunda/camunda#55038](https://github.com/camunda/camunda/issues/55038).
+
+### A broker is `Running` but never `Ready`
+
+Same root cause. Delete the pod; it re-resolves on restart.
+
+### Brokers are up but partitions are unhealthy
+
+Check the node ID distribution. Every region slot must own its residue class:
+
+```bash
+./check-cluster-topology.sh
+```
+
+If a slot owns the wrong node IDs, `global.multiregion.regions` does not match
+the Terraform slot count. That is a bootstrap-time mistake and cannot be fixed
+in place.
+
+### RDBMS connection failures
+
+```bash
+kubectl --context cluster-london -n camunda logs camunda-zeebe-0 | grep -i -E 'jdbc|hikari|liquibase'
+```
+
+Common causes:
+
+- the Aurora security group does not include the region's VPC or service CIDR —
+  check `database_allowed_cidr_blocks` in `terraform/clusters/database.tf`;
+- the writer moved and `globalClusterInstanceHostPatterns` does not list the new
+  region;
+- Liquibase is blocked on `DATABASECHANGELOGLOCK` after a crashed startup.
+
+## Exercising the interesting paths
+
+```bash
+# Grow the cluster from 2 to 3 regions without touching the running brokers
+cd terraform/clusters && terraform apply -var active_region_count=3 && cd -
+aws eks --region eu-central-2 update-kubeconfig --name "$USER-mr-zurich" --alias cluster-zurich
+export CLUSTER_CONTEXTS="cluster-london cluster-paris cluster-zurich"
+export CAMUNDA_ACTIVE_REGIONS=3
+./activate-region.sh 2
+
+# Lose a region and observe that nothing stops
+./failover.sh 1
+./check-cluster-topology.sh
+
+# Bring it back
+./failback.sh 1
+```
+
+## Tearing down
+
+```bash
+helm --kube-context cluster-london -n camunda uninstall camunda || true
+# ... one per region
+
+cd terraform/clusters
+terraform destroy -var cluster_name="$USER-mr"
+```
+
+Destroy order matters: Kubernetes-managed load balancers and ENIs keep the VPC
+alive. If `terraform destroy` stalls on a VPC or subnet, look for leftover
+LoadBalancer services and Submariner gateway resources first.
+
+## Golden files
+
+```bash
+just regenerate-golden-file eks-multi-region-rdbms eu-west-2
+```
+
+Golden plans are regenerated from `terraform/clusters/test/golden/golden.tfvars`.
+Never edit them by hand, and check the redaction before committing.

--- a/aws/kubernetes/eks-multi-region-rdbms/README.md
+++ b/aws/kubernetes/eks-multi-region-rdbms/README.md
@@ -1,0 +1,420 @@
+# AWS EKS multi-region with RDBMS secondary storage
+
+> [!WARNING]
+> This reference architecture is **experimental**. Camunda documents and
+> supports **two** regions; the topology described here goes beyond that and is
+> intended for learning, evaluation and design review — not for production.
+> Talk to your Customer Success Manager before planning any multi-region
+> deployment, and expect this document to change.
+
+A Camunda 8.10 Orchestration Cluster stretched across **N AWS regions**
+(3 by default), backed by a relational secondary storage whose replication is
+entirely the database's responsibility.
+
+The design goal is to remove the two structural weaknesses of the dual-region
+architecture:
+
+| | Dual region (existing) | Multi region (this) |
+|---|---|---|
+| Region loss | Zeebe loses quorum and **stops processing** until brokers are force-removed | Quorum is preserved, Zeebe **keeps processing** |
+| Failback | 8 steps, including an Elasticsearch snapshot and restore | Redeploy the region; nothing to restore |
+| Secondary storage | One Elasticsearch cluster per region, two Camunda exporters, manual re-initialisation | One database, one exporter, replication handled by the database |
+| Cross-region DNS | CoreDNS stub forwarding, `O(N²)` stanzas, pod IPs only | Submariner Lighthouse, `*.svc.clusterset.local`, ClusterIP and headless |
+| Cross-region L3 | VPC peering mesh, `O(N²)` peerings and route entries | Transit Gateway, one attachment per VPC |
+| Adding a region | Not possible | Possible, without renumbering brokers |
+
+---
+
+## Contents
+
+- [Topology](#topology)
+- [Why the replication factor equals the number of regions](#why-the-replication-factor-equals-the-number-of-regions)
+- [Region slots vs active regions](#region-slots-vs-active-regions)
+- [Replication-agnostic secondary storage](#replication-agnostic-secondary-storage)
+- [Cross-region networking](#cross-region-networking)
+- [Deploy](#deploy)
+- [Day-2 operations](#day-2-operations)
+- [Known limitations](#known-limitations)
+- [Regions used](#regions-used)
+
+---
+
+## Topology
+
+Default shape, 3 regions:
+
+```
+        eu-west-2 (London)        eu-west-3 (Paris)        eu-central-2 (Zurich)
+        region slot 0             region slot 1            region slot 2
+        ┌───────────────┐         ┌───────────────┐        ┌───────────────┐
+        │ EKS           │         │ EKS           │        │ EKS           │
+        │  zeebe-0 (id0)│         │  zeebe-0 (id1)│        │  zeebe-0 (id2)│
+        │  zeebe-1 (id3)│         │  zeebe-1 (id4)│        │  zeebe-1 (id5)│
+        │  connectors   │         │  connectors   │        │  connectors   │
+        └───────┬───────┘         └───────┬───────┘        └───────┬───────┘
+                │      Transit Gateway full mesh + Submariner      │
+                └─────────────────────────┼───────────────────────-┘
+                                          │
+                            ┌─────────────┴─────────────┐
+                            │  Aurora Global Database   │
+                            │  writer: eu-west-2        │
+                            │  reader: eu-west-3        │
+                            └───────────────────────────┘
+```
+
+| Setting | Default | Meaning |
+|---|---|---|
+| `regions` (Terraform) | 3 slots | London, Paris, Zurich |
+| `global.multiregion.regions` | 3 | Node ID stride, **immutable** |
+| `orchestration.clusterSize` | 6 | `brokersPerRegion * regionSlots` |
+| `orchestration.partitionCount` | 6 | One partition per broker |
+| `orchestration.replicationFactor` | 3 | One replica per region |
+| `database_region_slots` | `[0, 1]` | Aurora members, writer first |
+
+Broker node IDs follow the Helm chart formula
+`nodeId = statefulSetOrdinal * regions + regionId`, so slot *k* owns the node
+IDs congruent to *k* modulo the slot count.
+
+---
+
+## Why the replication factor equals the number of regions
+
+Zeebe distributes partitions round robin over **consecutive node IDs**: partition
+*p* is replicated on nodes `p-1, p, p+1, …` modulo `clusterSize`
+([partition distribution][partitions]). Combined with the chart's node ID
+stride, `replicationFactor == regionSlots` places **exactly one replica of every
+partition in every region**:
+
+```
+clusterSize 6, partitionCount 6, replicationFactor 3, 3 region slots
+node IDs:  slot 0 → {0, 3}   slot 1 → {1, 4}   slot 2 → {2, 5}
+
+partition 1 → nodes 0,1,2  → one replica per region
+partition 2 → nodes 1,2,3  → one replica per region
+…
+partition 6 → nodes 5,0,1  → one replica per region
+```
+
+A partition keeps its Raft majority as long as `N-1 > N/2`, which holds for
+every `N >= 3`. So:
+
+| Region slots | Replication factor | Region losses tolerated |
+|---|---|---|
+| 2 | 4 (dual-region convention) | **0** — quorum is lost |
+| 3 | 3 | 1 |
+| 4 | 4 | 1 |
+| 5 | 5 | 2 |
+
+This is why the dual-region architecture needs a failover procedure at all: with
+two regions there is no assignment of an even replica count that survives losing
+half of it. Three regions is the smallest topology where a region can disappear
+and the workflow engine simply carries on.
+
+Using a multiple of the slot count (`replicationFactor = 2 * regionSlots`) puts
+two replicas per region and increases intra-region durability at the cost of
+write amplification. It does not change the region fault tolerance.
+
+[partitions]: https://docs.camunda.io/docs/components/zeebe/technical-concepts/partitions/#partition-distribution
+
+---
+
+## Region slots vs active regions
+
+The Camunda Helm chart derives every broker's identity from the region count:
+
+```
+nodeId = statefulSetOrdinal * global.multiregion.regions + regionId
+```
+
+Changing `regions` renumbers **every** broker in the cluster, which a running
+Raft cluster cannot survive. The region count is therefore treated as a **slot
+count, fixed at bootstrap**, and regions are brought online independently:
+
+- `var.regions` — the slot definitions. Immutable for the lifetime of the
+  Camunda cluster. Plan for the largest topology you expect.
+- `var.active_region_count` — how many slots are actually deployed. Can be
+  raised at any time.
+
+Bootstrapping with one slot empty is supported and is the intended growth path:
+every partition then has `N-1` of its `N` replicas, which is still a majority, so
+the cluster forms and processes normally. Leaving **two or more** slots empty is
+rejected by `terraform/clusters/checks.tf`, because every partition would lose
+its majority.
+
+```
+3 slots, 2 active                    3 slots, 3 active
+partition 1 → nodes 0,1,[2]          partition 1 → nodes 0,1,2
+              2/3 replicas ✔                       3/3 replicas ✔
+              tolerates 0 losses                   tolerates 1 loss
+```
+
+Activating the last slot is a single command and does not restart the running
+regions:
+
+```bash
+export CAMUNDA_ACTIVE_REGIONS=3
+./procedure/activate-region.sh 2
+```
+
+**What this does not do:** grow a cluster from 3 slots to 4. That requires
+renumbering and is a rebuild. If you may need a fourth region later, provision
+four slots up front and leave the last one inactive.
+
+---
+
+## Replication-agnostic secondary storage
+
+Camunda 8.10 exposes **one JDBC connection per Orchestration Cluster** and the
+RDBMS exporter has no multi-region mode
+([documentation][rdbms-multiregion]): *"Multi-region support for the RDBMS
+Exporter is not planned at this time. For multi-region setups, multi-region
+replication must be handled within the RDBMS itself."*
+
+This reference architecture takes that constraint and turns it into the design:
+
+- Every broker in every region writes to the **same JDBC URL**.
+- There are **no per-region exporters** to enable, disable or re-initialise.
+- Region loss does not desynchronise anything at the Camunda layer, so failback
+  has no snapshot and restore step.
+- Swapping the database swaps one variable.
+
+The reference implementation is **Aurora Global Database** reached through the
+[AWS Advanced JDBC Wrapper][jdbc-wrapper]:
+
+```
+jdbc:aws-wrapper:postgresql://<writer-endpoint>:5432/camunda
+  ?wrapperPlugins=failover
+  &globalClusterInstanceHostPatterns=?.<region0-suffix>,?.<region1-suffix>
+```
+
+The `failover` plugin enumerates the instances of every listed region, so a
+global failover is followed by the driver without restarting or reconfiguring
+Camunda.
+
+To use something else, set `deploy_database = false` and provide your own
+`CAMUNDA_RDBMS_URL`. Anything exposing a single endpoint that follows the writer
+works the same way: Patroni with a floating endpoint, RDS Proxy, PgCat, an
+AlloyDB or CockroachDB cluster, or a plain DNS CNAME you repoint during
+failover.
+
+> [!IMPORTANT]
+> The Zeebe data plane is active-active across all regions. The **database tier
+> is active-standby**: a single writer serves every region. Brokers that are not
+> co-located with the writer pay the inter-region round trip on every export
+> flush. Keep regions within the [100 ms RTT budget][rtt] and size
+> `orchestration.data.secondaryStorage.rdbms.queueSize` accordingly.
+
+[rdbms-multiregion]: https://docs.camunda.io/docs/next/self-managed/concepts/databases/relational-db/configuration/#multi-region-support
+[jdbc-wrapper]: https://github.com/aws/aws-advanced-jdbc-wrapper
+[rtt]: https://docs.camunda.io/docs/next/self-managed/concepts/multi-region/dual-region/#installation-environment
+
+---
+
+## Cross-region networking
+
+Two layers, both chosen because they scale with the number of regions.
+
+### L3: Transit Gateway
+
+One Transit Gateway per region, one VPC attachment each, and a full mesh of
+inter-region peerings. Transit Gateway peering is **not transitive**, so the
+mesh has `N*(N-1)/2` edges — 3 for three regions, 6 for four.
+
+Compared with the VPC peering mesh used by the dual-region architecture, the
+number of *route table entries and attachments per VPC* stays constant as
+regions are added, and the same hub can later carry Direct Connect or
+site-to-site VPN attachments.
+
+CIDRs must not overlap across regions. The defaults are:
+
+| Slot | Region | VPC / pod CIDR | Service CIDR |
+|---|---|---|---|
+| 0 | eu-west-2 | `10.192.0.0/16` | `10.190.0.0/16` |
+| 1 | eu-west-3 | `10.202.0.0/16` | `10.200.0.0/16` |
+| 2 | eu-central-2 | `10.212.0.0/16` | `10.210.0.0/16` |
+| 3 | eu-south-1 | `10.222.0.0/16` | `10.220.0.0/16` |
+
+### L4/L7: Submariner
+
+[Submariner][submariner] provides cross-cluster service discovery and an
+encrypted overlay. It is deployed **upstream** (`subctl deploy-broker` and
+`subctl join`), not through the Red Hat ACM add-on used by the OpenShift
+dual-region reference, because ACM is OpenShift-only.
+
+- Cable driver **libreswan** (IPsec). Transit Gateway traffic crosses the AWS
+  backbone unencrypted, so this is defence in depth, not decoration.
+- `--air-gapped` and `--natt=false`: gateways reach each other over private
+  addresses through the Transit Gateway, never over the internet.
+- **Globalnet disabled**: CIDRs are already non-overlapping, which Transit
+  Gateway requires anyway.
+- One gateway node per cluster by default; raise
+  `SUBMARINER_GATEWAY_NODES_PER_CLUSTER` for gateway HA.
+
+Lighthouse publishes exported services as
+`<clusterID>.<service>.<namespace>.svc.clusterset.local`. This is what lets the
+architecture use **one namespace name in every cluster** instead of the
+`N` namespaces replicated `N` times that CoreDNS stub forwarding would need.
+
+Firewall rules are in `terraform/clusters/security.tf` and are written out
+explicitly rather than "allow all between VPCs", because the port list is the
+part a reader actually needs:
+
+| Port | Protocol | Purpose |
+|---|---|---|
+| 4500 | UDP | IPsec NAT traversal |
+| 4490 | UDP | NAT traversal discovery |
+| 500 | UDP | IKE negotiation |
+| — | ESP (IP 50) | Encrypted tunnel payload |
+| 4800 | UDP | VXLAN pod traffic encapsulation |
+| 8080 | TCP | Submariner metrics, Orchestration REST API |
+| 26500-26502 | TCP | Zeebe gateway, command API, Raft |
+| 9600 | TCP | Orchestration management API |
+| 53 | TCP/UDP | CoreDNS and Lighthouse |
+
+[submariner]: https://submariner.io/
+
+---
+
+## Deploy
+
+```bash
+# 0. Get a copy
+./procedure/get-your-copy.sh
+
+# 1. Infrastructure: EKS clusters, Transit Gateway mesh, Aurora Global Database
+cd terraform/clusters
+terraform init -backend=false
+terraform apply -var cluster_name=camunda
+
+# 2. Environment
+cd ../../procedure
+. ./export-terraform-outputs.sh
+. ./export_environment_prerequisites.sh
+
+# 3. kubectl contexts, one per active region
+#    aws eks --region <region> update-kubeconfig --name <cluster> --alias <context>
+
+# 4. Storage
+./storageclass-configure.sh
+./storageclass-verify.sh
+
+# 5. Submariner
+source ./submariner/install-subctl.sh
+./submariner/label-gateway-nodes.sh
+./submariner/deploy-broker.sh
+./submariner/join-clusters.sh
+./submariner/verify-submariner.sh
+
+# 6. Camunda
+./setup-namespaces.sh
+./create-rdbms-secret.sh
+. ./generate-zeebe-helm-values.sh
+./assemble-envsubst-values.sh
+./install-chart.sh
+./submariner/export-services.sh
+
+# 7. Verify
+./check-cluster-topology.sh
+```
+
+Expect roughly 25 minutes for the EKS clusters, 15 for the Aurora Global
+Database (both in parallel), 5 for Submariner and 10 for the Zeebe cluster to
+converge across regions.
+
+---
+
+## Day-2 operations
+
+| Task | Command |
+|---|---|
+| Verify the topology | `./procedure/check-cluster-topology.sh` |
+| Activate a provisioned but empty region | `./procedure/activate-region.sh <slot>` |
+| Handle a region loss | `./procedure/failover.sh <slot> [--unplanned]` |
+| Bring a region back | `./procedure/failback.sh <slot> [--switch-writer]` |
+| Diagnose cross-region networking | `./procedure/submariner/diagnose-submariner.sh` |
+
+### Region loss
+
+With three or more slots, `failover.sh` mostly **reports**: Zeebe keeps its
+quorum and needs no intervention. Its real work is the database writer, and only
+when the writer was in the lost region:
+
+- **planned** — `failover-global-cluster`, a switchover with no data loss;
+- **unplanned** — `remove-from-global-cluster`, which promotes a surviving
+  member and loses whatever had not replicated yet.
+
+`--drain-brokers` force-removes the lost brokers so that the surviving regions
+run at full replication factor. It trades a partition reconfiguration for
+durability and is worth it only for a long outage.
+
+### Upgrades
+
+Upgrade **one region at a time** and wait for the cluster to be healthy in
+between. Upgrading several regions simultaneously risks losing quorum.
+
+---
+
+## Known limitations
+
+- **Not covered by Camunda documentation or support.** The product documents two
+  regions. Everything beyond that is exploratory.
+- **No Management Identity**, hence **no Optimize** and no Web Modeler. The
+  Orchestration Cluster ships its own Admin component; authentication is basic
+  auth.
+- **Optimize is impossible on RDBMS** regardless of the region count: it
+  requires Elasticsearch or OpenSearch.
+- **Database tier is active-standby.** Every region writes to one region's
+  writer.
+- **The slot count is immutable.** Growing from `N` to `N+1` slots renumbers
+  every broker.
+- **Connectors run in every region** and are not deduplicated. Outbound
+  connector invocations must be idempotent.
+- **Cross-region Raft is unencrypted at L3**; confidentiality comes from the
+  Submariner IPsec tunnels, so a Submariner outage is a security event, not only
+  an availability one.
+- **Broker startup DNS gate.** Brokers resolve their initial contact points once
+  and hang on `NXDOMAIN`
+  ([camunda/camunda#55038](https://github.com/camunda/camunda/issues/55038)).
+  A temporary init container gates startup until clusterset DNS resolves; remove
+  it once the upstream fix ships.
+- **Backups are not wired up yet.** RDBMS backup and restore relies on
+  continuous primary-storage backups plus a database-native backup; see
+  [Backup and restore for RDBMS][rdbms-backup].
+
+[rdbms-backup]: https://docs.camunda.io/docs/next/self-managed/operational-guides/backup-restore/rdbms/backup/
+
+---
+
+## Regions used
+
+| Slot | Region | Cleanup schedule |
+|---|---|---|
+| 0 | `eu-west-2` (London) | CI region, nightly |
+| 1 | `eu-west-3` (Paris) | CI region, nightly |
+| 2 | `eu-central-2` (Zurich) | CI region, nightly |
+| 3 | `eu-south-1` (Milan) | Weekly work region, optional 4th slot |
+
+`eu-central-2` and `eu-south-1` are AWS opt-in regions: they must be enabled on
+the account before use, and their cleanup schedule is declared in
+[infraex-common-config](https://github.com/camunda/infraex-common-config).
+
+Aurora Global Database is not available in every region. `database_region_slots`
+defaults to `[0, 1]` so that the database members live in London and Paris while
+compute spans all three regions — which also demonstrates that the database
+topology is independent of the compute topology.
+
+Round trip times (indicative): London ↔ Paris ~7 ms, London ↔ Zurich ~20 ms,
+Paris ↔ Zurich ~15 ms, all well inside the 100 ms budget.
+
+---
+
+## Related reference architectures
+
+- `aws/kubernetes/eks-dual-region` — two regions, Elasticsearch, VPC peering and
+  CoreDNS chaining. Documented and supported.
+- `aws/openshift/rosa-hcp-dual-region` — two regions on OpenShift, Submariner via
+  Red Hat ACM.
+- `aws/containers/ecs-dual-region-fargate` — two regions on ECS Fargate with
+  Aurora Global Database, the origin of the replication-agnostic RDBMS idea.
+- `azure/kubernetes/aks-single-region-rdbms` — single region RDBMS secondary
+  storage.

--- a/aws/kubernetes/eks-multi-region-rdbms/helm-values/camunda-values.yml
+++ b/aws/kubernetes/eks-multi-region-rdbms/helm-values/camunda-values.yml
@@ -1,0 +1,218 @@
+---
+# Chart values for the Camunda Platform 8 Helm chart, multi-region with RDBMS
+# secondary storage.
+#
+# This file deliberately contains only the values that differ from the defaults.
+# For changes and documentation, use your favorite diff tool to compare it with:
+# https://github.com/camunda/camunda-platform-helm/blob/main/charts/camunda-platform/values.yaml
+#
+# The file is a template: `${...}` placeholders are substituted with envsubst by
+# procedure/assemble-envsubst-values.sh, and `${DOLLAR}` escapes a literal `$`
+# that must survive envsubst and reach the container at runtime.
+#
+# Every region installs the same release from this file. Only two values differ
+# per region: `global.multiregion.regionId` and the advertised host, both
+# injected from the environment.
+
+global:
+    # Multiregion options for the Orchestration Cluster
+    #
+    ## WARNING: In order to get your multi-region setup covered by Camunda enterprise support
+    # you MUST get your configuration and run books reviewed by Camunda before going to production.
+    # This is necessary for us to be able to help you in case of outages,
+    # due to the complexity of operating multi-region setups and the dependencies to the underlying Kubernetes prerequisites.
+    # If you operate this in the wrong way you risk corruption and complete loss of all data.
+    # Please, contact your customer success manager as soon as you start planning a multi-region setup.
+    # Camunda reserves the right to limit support if no review was done prior to launch or the review showed significant risks.
+    multiregion:
+        # Number of REGION SLOTS, not the number of regions currently deployed.
+        # The chart derives every broker node ID from it:
+        #   nodeId = statefulSetOrdinal * regions + regionId
+        # Changing it renumbers every broker, so it is immutable for the
+        # lifetime of the cluster. See ../README.md.
+        regions: ${CAMUNDA_REGION_SLOTS}
+        # Slot this deployment occupies, 0-based.
+        regionId: ${CAMUNDA_REGION_ID}
+    security:
+        authentication:
+            # Basic auth for inter-component communication, because Management
+            # Identity (Keycloak) is not supported in multi-region setups.
+            method: basic
+    identity:
+        auth:
+            enabled: false
+
+# Management Identity is not available in multi-region topologies; the
+# Orchestration Cluster ships its own Admin component instead.
+identity:
+    enabled: false
+
+console:
+    enabled: false
+
+# Optimize requires Elasticsearch or OpenSearch and cannot run on RDBMS
+# secondary storage.
+optimize:
+    enabled: false
+
+# Connectors run in every region. They are idempotency-sensitive: an outbound
+# connector may be executed once per region if a job is retried across a region
+# boundary. Design your connector calls to be idempotent.
+connectors:
+    enabled: true
+
+orchestration:
+    # clusterSize spans ALL region slots: brokersPerRegion * regionSlots.
+    clusterSize: '${CAMUNDA_CLUSTER_SIZE}'
+    partitionCount: '${CAMUNDA_PARTITION_COUNT}'
+    # replicationFactor == number of region slots places exactly one replica of
+    # every partition in each region, because the chart node ID stride is the
+    # region count and Zeebe distributes partitions round robin over
+    # consecutive node IDs. With N >= 3 slots the cluster keeps its quorum when
+    # a whole region is lost, which is the property this architecture exists
+    # for. See ../README.md, section "Why the replication factor equals the
+    # number of regions".
+    replicationFactor: '${CAMUNDA_REPLICATION_FACTOR}'
+
+    ###########################################################################
+    # Secondary storage                                                       #
+    #                                                                         #
+    # Camunda exposes a single JDBC connection per Orchestration Cluster and   #
+    # the RDBMS exporter has no multi-region mode: every broker of every       #
+    # region writes to the same URL. Replication and failover are entirely     #
+    # the database's responsibility, which is what keeps this architecture     #
+    # replication agnostic.                                                   #
+    #                                                                         #
+    # The reference implementation points this URL at an Aurora Global         #
+    # Database through the AWS Advanced JDBC Wrapper, whose `failover` plugin  #
+    # follows the writer across regions without a Camunda reconfiguration.     #
+    ###########################################################################
+    data:
+        secondaryStorage:
+            type: rdbms
+            # Schema management is left at the Camunda default
+            # (camunda.data.secondary-storage.rdbms.auto-ddl = true): Liquibase
+            # creates and migrates the schema on first startup. Concurrent
+            # brokers serialise on DATABASECHANGELOGLOCK, so it is safe to start
+            # every region at once.
+            rdbms:
+                aws:
+                    # IAM database authentication. Keep in sync with the
+                    # `database_iam_auth_enabled` Terraform variable: when it is
+                    # enabled, the JDBC URL must also carry the `iam` wrapper
+                    # plugin and the pods need an IRSA role with rds-db:connect.
+                    enabled: false
+                url: ${CAMUNDA_RDBMS_URL}
+                username: ${CAMUNDA_RDBMS_USERNAME}
+                secret:
+                    existingSecret: camunda-rdbms-secret
+                    existingSecretKey: password
+
+    exporters:
+        # The Camunda exporter targets Elasticsearch or OpenSearch only.
+        camunda:
+            enabled: false
+        rdbms:
+            enabled: true
+
+    env:
+        # One entry per active region, generated by
+        # procedure/generate-zeebe-helm-values.sh.
+        - name: CAMUNDA_CLUSTER_INITIALCONTACTPOINTS
+          value: ${CAMUNDA_CLUSTER_INITIALCONTACTPOINTS}
+
+        # Brokers must advertise a name that resolves from every other region.
+        # The chart default (`<pod>.<service>.<namespace>.svc`) only resolves
+        # inside its own cluster; Submariner Lighthouse publishes the
+        # cross-cluster form `<pod>.<clusterID>.<service>.<namespace>.svc.clusterset.local`.
+        - name: CAMUNDA_CLUSTER_NETWORK_ADVERTISEDHOST
+          value: ${DOLLAR}(K8S_NAME).$ZEEBE_SERVICE_NAME
+
+        - name: CAMUNDA_PERSISTENT_SESSIONS_ENABLED
+          value: 'true'
+
+        # Cross-region SWIM membership tuning for stretched clusters. The
+        # default probe timeout (100ms) is too tight for inter-region latency:
+        # on a cold start brokers transiently see remote peers as unreachable,
+        # SWIM ejects them, membership churns and the topology never converges.
+        - name: CAMUNDA_CLUSTER_MEMBERSHIP_PROBETIMEOUT
+          value: 1000ms
+        - name: CAMUNDA_CLUSTER_MEMBERSHIP_PROBEINTERVAL
+          value: 2s
+        - name: CAMUNDA_CLUSTER_MEMBERSHIP_FAILURETIMEOUT
+          value: 10000ms
+        - name: CAMUNDA_CLUSTER_RAFT_SNAPSHOTREQUESTTIMEOUT
+          value: 10s
+        - name: CAMUNDA_CLUSTER_COMPRESSIONALGORITHM
+          value: GZIP
+        - name: CAMUNDA_DATA_SNAPSHOTPERIOD
+          value: 5m
+
+    # TEMPORARY WORKAROUND — remove once the upstream Camunda fix is released.
+    # A Zeebe broker resolves its initialContactPoints only once at startup; if
+    # a cross-region "*.svc.clusterset.local" name is not yet published by
+    # Submariner Lighthouse at that moment (NXDOMAIN), the broker hangs forever
+    # (pod stays 0/1 Running, port 9600 never opens) instead of re-resolving.
+    # This init container gates broker startup until every initial contact
+    # point resolves, so the broker process never sees an NXDOMAIN.
+    # It reuses the broker image (already pulled on the node) to avoid an extra
+    # image pull; ${DOLLAR}{BROKER_IMAGE} is resolved at deploy time by
+    # procedure/install-chart.sh from the chart being installed.
+    # Tracking issue: https://github.com/camunda/camunda/issues/55038
+    initContainers:
+        - name: wait-clusterset-dns
+          image: ${DOLLAR}{BROKER_IMAGE}
+          command:
+              - /bin/sh
+              - -c
+              - |
+                set -eu
+                # Fail open: if the image ships no resolver, do not block startup.
+                command -v getent >/dev/null 2>&1 || { echo "getent unavailable; skipping cross-region DNS gate."; exit 0; }
+                # Bounded TOTAL wait across all hosts, independent of how many
+                # per-pod names we derive, so a genuine misconfiguration can
+                # never stall startup past the deployment timeout (fail-open).
+                deadline=${DOLLAR}(( ${DOLLAR}(date +%s) + ${DOLLAR}{CLUSTERSET_DNS_TIMEOUT_SECONDS:-720} ))
+                # Brokers advertise and dial PER-POD clusterset names
+                # (<statefulset>-<ordinal>.<contact-point-host>), not just the
+                # per-region headless contact point. The headless name resolves
+                # as soon as the ServiceImport exists, so gating only on it lets
+                # a broker start before individual peer-pod records are
+                # published; it then hits NXDOMAIN dialing a peer and hangs.
+                # The Zeebe service name is the 2nd DNS label of a clusterset
+                # contact point and each pod is reachable at
+                # <service>-<ordinal>.<host>.
+                brokers_per_region="${DOLLAR}{BROKERS_PER_REGION:-$CAMUNDA_BROKERS_PER_REGION}"
+                hosts=""
+                for ep in ${DOLLAR}(echo "${CAMUNDA_CLUSTER_INITIALCONTACTPOINTS}" | tr ',' ' '); do
+                  cp_host=${DOLLAR}(echo "${DOLLAR}ep" | cut -d: -f1)
+                  svc=${DOLLAR}(echo "${DOLLAR}cp_host" | cut -d. -f2)
+                  n=0
+                  while [ "${DOLLAR}n" -lt "${DOLLAR}brokers_per_region" ]; do
+                    hosts="${DOLLAR}hosts ${DOLLAR}{svc}-${DOLLAR}{n}.${DOLLAR}{cp_host}"
+                    n=${DOLLAR}((n + 1))
+                  done
+                done
+                echo "Waiting for cross-region clusterset DNS to resolve all Zeebe broker pods..."
+                for host in ${DOLLAR}hosts; do
+                  until getent hosts "${DOLLAR}host" >/dev/null 2>&1; do
+                    if [ "${DOLLAR}(date +%s)" -ge "${DOLLAR}deadline" ]; then
+                      echo "  giving up on ${DOLLAR}host (DNS budget exhausted); starting broker anyway (fail-open)."
+                      break
+                    fi
+                    echo "  waiting for ${DOLLAR}host ..."
+                    sleep 5
+                  done
+                done
+                echo "Cross-region DNS gate complete; starting broker."
+
+    pvcSize: 32Gi
+    logLevel: ERROR
+
+    resources:
+        requests:
+            cpu: 200m
+            memory: 2Gi
+        limits:
+            cpu: 1512m
+            memory: 5Gi

--- a/aws/kubernetes/eks-multi-region-rdbms/procedure/activate-region.sh
+++ b/aws/kubernetes/eks-multi-region-rdbms/procedure/activate-region.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+# Resolve sourced files relative to this script, not the caller working directory.
+# shellcheck source-path=SCRIPTDIR
+set -euo pipefail
+
+# Brings a previously empty region slot online, without interrupting the running
+# Camunda cluster.
+#
+#   ./activate-region.sh <slot>
+#
+# Prerequisites:
+#   1. Terraform has been applied with `active_region_count` raised to include
+#      the slot, so its EKS cluster, Transit Gateway attachments and firewall
+#      rules exist.
+#   2. A kubectl context for the new cluster exists and is listed in
+#      CLUSTER_CONTEXTS.
+#   3. CAMUNDA_ACTIVE_REGIONS already reflects the NEW number of active regions.
+#
+# What makes this non-disruptive is that the slot count, and therefore every
+# broker node ID, was fixed at bootstrap. Activating a slot only fills in the
+# replicas that the partition layout already reserved for it; no existing broker
+# is renumbered and no partition is redistributed.
+
+: "${CLUSTER_CONTEXTS:?CLUSTER_CONTEXTS must be set, source export_environment_prerequisites.sh}"
+: "${CAMUNDA_ACTIVE_REGIONS:?CAMUNDA_ACTIVE_REGIONS must be set, source export_environment_prerequisites.sh}"
+: "${CAMUNDA_REGION_SLOTS:?CAMUNDA_REGION_SLOTS must be set, source export_environment_prerequisites.sh}"
+: "${CAMUNDA_BROKERS_PER_REGION:?CAMUNDA_BROKERS_PER_REGION must be set, source export_environment_prerequisites.sh}"
+: "${CAMUNDA_REPLICATION_FACTOR:?CAMUNDA_REPLICATION_FACTOR must be set, source export_environment_prerequisites.sh}"
+
+if [ $# -ne 1 ]; then
+    echo "usage: $0 <region-slot>" >&2
+    exit 1
+fi
+
+SLOT="$1"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+. "$SCRIPT_DIR/lib-management-api.sh"
+
+if [ "$SLOT" -ge "$CAMUNDA_REGION_SLOTS" ]; then
+    echo "ERROR: slot $SLOT is outside the provisioned slot range (0..$((CAMUNDA_REGION_SLOTS - 1)))." >&2
+    echo "       The slot count is immutable; growing it renumbers every broker." >&2
+    exit 1
+fi
+
+if [ "$SLOT" -ge "$CAMUNDA_ACTIVE_REGIONS" ]; then
+    echo "ERROR: CAMUNDA_ACTIVE_REGIONS ($CAMUNDA_ACTIVE_REGIONS) does not yet include slot $SLOT." >&2
+    echo "       Export CAMUNDA_ACTIVE_REGIONS=$((SLOT + 1)) (or higher) and re-run." >&2
+    exit 1
+fi
+
+read -r -a contexts <<<"$CLUSTER_CONTEXTS"
+new_context="${contexts[$SLOT]}"
+survivor_context="${contexts[0]}"
+
+echo "==> 1/6 Joining region slot $SLOT ($new_context) to the Submariner ClusterSet"
+"$SCRIPT_DIR/submariner/join-clusters.sh" "$SLOT"
+"$SCRIPT_DIR/submariner/verify-submariner.sh"
+
+echo "==> 2/6 Creating the namespace and the RDBMS secret in $new_context"
+"$SCRIPT_DIR/setup-namespaces.sh"
+"$SCRIPT_DIR/create-rdbms-secret.sh"
+
+echo "==> 3/6 Rendering the Helm values with the new contact point list"
+. "$SCRIPT_DIR/generate-zeebe-helm-values.sh"
+"$SCRIPT_DIR/assemble-envsubst-values.sh"
+
+echo "==> 4/6 Installing Camunda in region slot $SLOT"
+# Only the new region is installed. The already running regions learn about the
+# new brokers through cluster membership gossip; their values files now carry a
+# longer contact point list, which is picked up harmlessly on their next
+# upgrade. Restarting them here would be a needless rolling restart.
+"$SCRIPT_DIR/install-chart.sh" "$SLOT"
+
+echo "==> 5/6 Exporting the new region's services to the ClusterSet"
+"$SCRIPT_DIR/submariner/export-services.sh"
+
+echo "==> 6/6 Waiting for the new brokers to join the Zeebe cluster"
+node_ids="$(camunda::region_node_ids "$SLOT")"
+echo "    Expected broker node IDs for slot $SLOT: $node_ids"
+
+expected_total=$((CAMUNDA_BROKERS_PER_REGION * CAMUNDA_ACTIVE_REGIONS))
+deadline=$((SECONDS + ${ACTIVATE_REGION_TIMEOUT_SECONDS:-1800}))
+
+while true; do
+    topology="$(camunda::management "$survivor_context" GET /actuator/cluster)"
+    known="$(echo "$topology" | jq -r '[.brokers[]?.id] | length')"
+
+    if [ "$known" -ge "$expected_total" ]; then
+        echo "    All $expected_total brokers are known to the cluster."
+        break
+    fi
+
+    if [ "$SECONDS" -ge "$deadline" ]; then
+        echo
+        echo "The new brokers did not join on their own within the timeout."
+        echo "They are part of the partition layout computed at bootstrap, so this"
+        echo "normally happens automatically. Falling back to an explicit membership"
+        echo "change through the cluster scaling API."
+        echo
+
+        add_json="$(printf '%s\n' "$node_ids" | tr ' ' '\n' | jq -R 'tonumber' | jq -sc .)"
+        body="$(jq -nc \
+            --argjson add "$add_json" \
+            --argjson rf "$CAMUNDA_REPLICATION_FACTOR" \
+            '{brokers: {add: $add}, partitions: {replicationFactor: $rf}}')"
+
+        echo "    PATCH /actuator/cluster $body"
+        camunda::management "$survivor_context" PATCH /actuator/cluster "$body"
+        camunda::wait_for_cluster_change "$survivor_context"
+        break
+    fi
+
+    echo "    $known/$expected_total brokers known, waiting ..."
+    sleep 20
+done
+
+echo
+echo "Region slot $SLOT is active. Verifying the resulting topology:"
+"$SCRIPT_DIR/check-cluster-topology.sh"

--- a/aws/kubernetes/eks-multi-region-rdbms/procedure/assemble-envsubst-values.sh
+++ b/aws/kubernetes/eks-multi-region-rdbms/procedure/assemble-envsubst-values.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+set -euo pipefail
+
+# Renders one values file per active region from helm-values/camunda-values.yml.
+#
+# Run after sourcing export_environment_prerequisites.sh and
+# generate-zeebe-helm-values.sh:
+#
+#   . ./export_environment_prerequisites.sh
+#   . ./generate-zeebe-helm-values.sh
+#   ./assemble-envsubst-values.sh
+#
+# Output: generated-values-region-<slot>.yml
+
+: "${CAMUNDA_ACTIVE_REGIONS:?CAMUNDA_ACTIVE_REGIONS must be set, source export_environment_prerequisites.sh}"
+: "${CAMUNDA_REGION_SLOTS:?CAMUNDA_REGION_SLOTS must be set, source export_environment_prerequisites.sh}"
+: "${CAMUNDA_CLUSTER_SIZE:?CAMUNDA_CLUSTER_SIZE must be set, source export_environment_prerequisites.sh}"
+: "${CAMUNDA_PARTITION_COUNT:?CAMUNDA_PARTITION_COUNT must be set, source export_environment_prerequisites.sh}"
+: "${CAMUNDA_REPLICATION_FACTOR:?CAMUNDA_REPLICATION_FACTOR must be set, source export_environment_prerequisites.sh}"
+: "${CAMUNDA_BROKERS_PER_REGION:?CAMUNDA_BROKERS_PER_REGION must be set, source export_environment_prerequisites.sh}"
+: "${CAMUNDA_RDBMS_USERNAME:?CAMUNDA_RDBMS_USERNAME must be set, source export_environment_prerequisites.sh}"
+: "${CAMUNDA_RDBMS_URL:?CAMUNDA_RDBMS_URL must be set, e.g. from 'terraform output -raw camunda_rdbms_url'}"
+: "${CAMUNDA_CLUSTER_INITIALCONTACTPOINTS:?CAMUNDA_CLUSTER_INITIALCONTACTPOINTS must be set, source generate-zeebe-helm-values.sh}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VALUES_TEMPLATE="${VALUES_TEMPLATE:-$SCRIPT_DIR/../helm-values/camunda-values.yml}"
+OUTPUT_DIR="${OUTPUT_DIR:-$PWD}"
+
+# `${DOLLAR}` escapes a literal `$` that must survive envsubst and reach the
+# container at runtime (Kubernetes downward-API expansion and shell variables in
+# the init container).
+export DOLLAR='$'
+
+for ((i = 0; i < CAMUNDA_ACTIVE_REGIONS; i++)); do
+    zeebe_service_var="REGION_${i}_ZEEBE_SERVICE_NAME"
+    : "${!zeebe_service_var:?${zeebe_service_var} must be set, source generate-zeebe-helm-values.sh}"
+
+    CAMUNDA_REGION_ID="$i" \
+        ZEEBE_SERVICE_NAME="${!zeebe_service_var}" \
+        envsubst <"$VALUES_TEMPLATE" >"$OUTPUT_DIR/generated-values-region-${i}.yml"
+
+    echo "Wrote $OUTPUT_DIR/generated-values-region-${i}.yml"
+done

--- a/aws/kubernetes/eks-multi-region-rdbms/procedure/check-cluster-topology.sh
+++ b/aws/kubernetes/eks-multi-region-rdbms/procedure/check-cluster-topology.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+set -euo pipefail
+
+# Prints the Zeebe cluster topology and asserts the expected multi-region shape:
+#
+#   * clusterSize brokers are known
+#   * every region slot hosts exactly CAMUNDA_BROKERS_PER_REGION brokers,
+#     identified by nodeId % regionSlots == regionId
+#   * partitionCount and replicationFactor match the configuration
+#   * no partition is unhealthy
+#
+# Brokers belonging to slots that are not deployed yet are reported as missing
+# rather than treated as a failure, which is the expected state while a cluster
+# is grown one region at a time.
+
+: "${CLUSTER_CONTEXTS:?CLUSTER_CONTEXTS must be set, source export_environment_prerequisites.sh}"
+: "${CAMUNDA_NAMESPACE:?CAMUNDA_NAMESPACE must be set, source export_environment_prerequisites.sh}"
+: "${CAMUNDA_RELEASE_NAME:?CAMUNDA_RELEASE_NAME must be set, source export_environment_prerequisites.sh}"
+: "${CAMUNDA_REGION_SLOTS:?CAMUNDA_REGION_SLOTS must be set, source export_environment_prerequisites.sh}"
+: "${CAMUNDA_ACTIVE_REGIONS:?CAMUNDA_ACTIVE_REGIONS must be set, source export_environment_prerequisites.sh}"
+: "${CAMUNDA_BROKERS_PER_REGION:?CAMUNDA_BROKERS_PER_REGION must be set, source export_environment_prerequisites.sh}"
+: "${CAMUNDA_PARTITION_COUNT:?CAMUNDA_PARTITION_COUNT must be set, source export_environment_prerequisites.sh}"
+: "${CAMUNDA_REPLICATION_FACTOR:?CAMUNDA_REPLICATION_FACTOR must be set, source export_environment_prerequisites.sh}"
+
+CAMUNDA_BASIC_AUTH_USER="${CAMUNDA_BASIC_AUTH_USER:-demo}"
+CAMUNDA_BASIC_AUTH_PASSWORD="${CAMUNDA_BASIC_AUTH_PASSWORD:-demo}"
+LOCAL_PORT="${LOCAL_PORT:-8080}"
+OUTPUT_FILE="${OUTPUT_FILE:-zeebe-topology.json}"
+
+read -r -a contexts <<<"$CLUSTER_CONTEXTS"
+# Query through the first active region; any gateway returns the whole topology.
+context="${contexts[0]}"
+
+kubectl --context "$context" -n "$CAMUNDA_NAMESPACE" \
+    port-forward "svc/${CAMUNDA_RELEASE_NAME}-zeebe-gateway" "${LOCAL_PORT}:8080" >/dev/null 2>&1 &
+port_forward_pid=$!
+# shellcheck disable=SC2064
+trap "kill $port_forward_pid 2>/dev/null || true" EXIT
+
+sleep 5
+
+curl -sSf -u "${CAMUNDA_BASIC_AUTH_USER}:${CAMUNDA_BASIC_AUTH_PASSWORD}" \
+    "http://localhost:${LOCAL_PORT}/v2/topology" -o "$OUTPUT_FILE"
+
+echo "Topology written to $OUTPUT_FILE"
+jq . "$OUTPUT_FILE"
+
+expected_brokers=$((CAMUNDA_BROKERS_PER_REGION * CAMUNDA_ACTIVE_REGIONS))
+actual_brokers="$(jq '.brokers | length' "$OUTPUT_FILE")"
+actual_partitions="$(jq '.partitionsCount' "$OUTPUT_FILE")"
+actual_replication="$(jq '.replicationFactor' "$OUTPUT_FILE")"
+
+failures=0
+fail() {
+    echo "FAIL: $1" >&2
+    failures=$((failures + 1))
+}
+
+[ "$actual_brokers" = "$expected_brokers" ] ||
+    fail "expected $expected_brokers brokers for $CAMUNDA_ACTIVE_REGIONS active region(s), got $actual_brokers"
+[ "$actual_partitions" = "$CAMUNDA_PARTITION_COUNT" ] ||
+    fail "expected partitionsCount $CAMUNDA_PARTITION_COUNT, got $actual_partitions"
+[ "$actual_replication" = "$CAMUNDA_REPLICATION_FACTOR" ] ||
+    fail "expected replicationFactor $CAMUNDA_REPLICATION_FACTOR, got $actual_replication"
+
+echo
+echo "Broker distribution across region slots (nodeId % $CAMUNDA_REGION_SLOTS):"
+for ((slot = 0; slot < CAMUNDA_REGION_SLOTS; slot++)); do
+    count="$(jq --argjson slots "$CAMUNDA_REGION_SLOTS" --argjson slot "$slot" \
+        '[.brokers[] | select(.nodeId % $slots == $slot)] | length' "$OUTPUT_FILE")"
+
+    if [ "$slot" -lt "$CAMUNDA_ACTIVE_REGIONS" ]; then
+        echo "  slot $slot: $count broker(s)"
+        [ "$count" = "$CAMUNDA_BROKERS_PER_REGION" ] ||
+            fail "region slot $slot hosts $count broker(s), expected $CAMUNDA_BROKERS_PER_REGION"
+    else
+        echo "  slot $slot: $count broker(s) (slot not activated yet)"
+    fi
+done
+
+unhealthy="$(jq '[.brokers[].partitions[] | select(.health != "healthy")] | length' "$OUTPUT_FILE")"
+echo
+echo "Unhealthy partition replicas: $unhealthy"
+[ "$unhealthy" = "0" ] || fail "$unhealthy partition replica(s) are not healthy"
+
+if [ "$failures" -ne 0 ]; then
+    echo
+    echo "$failures topology check(s) failed." >&2
+    exit 1
+fi
+
+echo
+echo "Topology matches the expected multi-region shape."

--- a/aws/kubernetes/eks-multi-region-rdbms/procedure/cleanup.sh
+++ b/aws/kubernetes/eks-multi-region-rdbms/procedure/cleanup.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -euo pipefail
+
+# Removes Camunda and Submariner from every active cluster.
+#
+# Run before `terraform destroy`: Submariner creates cloud resources (gateway
+# annotations, routes) and Camunda creates PVCs and load balancers that keep the
+# VPC alive and make the destroy hang.
+
+: "${CLUSTER_CONTEXTS:?CLUSTER_CONTEXTS must be set, source export_environment_prerequisites.sh}"
+: "${CAMUNDA_ACTIVE_REGIONS:?CAMUNDA_ACTIVE_REGIONS must be set, source export_environment_prerequisites.sh}"
+: "${CAMUNDA_NAMESPACE:?CAMUNDA_NAMESPACE must be set, source export_environment_prerequisites.sh}"
+: "${CAMUNDA_RELEASE_NAME:?CAMUNDA_RELEASE_NAME must be set, source export_environment_prerequisites.sh}"
+
+read -r -a contexts <<<"$CLUSTER_CONTEXTS"
+
+for ((i = 0; i < CAMUNDA_ACTIVE_REGIONS; i++)); do
+    context="${contexts[$i]}"
+    echo "Cleaning up $context"
+
+    helm --kube-context "$context" --namespace "$CAMUNDA_NAMESPACE" \
+        uninstall "$CAMUNDA_RELEASE_NAME" --wait --timeout 10m 2>/dev/null || true
+
+    kubectl --context "$context" --namespace "$CAMUNDA_NAMESPACE" \
+        delete pvc --all --wait=false 2>/dev/null || true
+
+    # Removing the ServiceExports first stops Lighthouse from republishing
+    # records while the Submariner components are torn down.
+    kubectl --context "$context" --namespace "$CAMUNDA_NAMESPACE" \
+        delete serviceexports.multicluster.x-k8s.io --all 2>/dev/null || true
+
+    if command -v subctl >/dev/null 2>&1; then
+        subctl uninstall --context "$context" --yes 2>/dev/null || true
+    fi
+
+    kubectl --context "$context" delete namespace "$CAMUNDA_NAMESPACE" --wait=false 2>/dev/null || true
+done
+
+echo "Cleanup complete. terraform destroy can now run."

--- a/aws/kubernetes/eks-multi-region-rdbms/procedure/create-rdbms-secret.sh
+++ b/aws/kubernetes/eks-multi-region-rdbms/procedure/create-rdbms-secret.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -euo pipefail
+
+# Creates the Kubernetes secret holding the RDBMS password in every active
+# cluster. Referenced from the Helm values as
+# `orchestration.data.secondaryStorage.rdbms.secret.existingSecret`.
+#
+# The password never appears in a values file: only the JDBC URL and the
+# username are templated.
+
+: "${CAMUNDA_NAMESPACE:?CAMUNDA_NAMESPACE must be set, source export_environment_prerequisites.sh}"
+: "${CLUSTER_CONTEXTS:?CLUSTER_CONTEXTS must be set, source export_environment_prerequisites.sh}"
+: "${CAMUNDA_ACTIVE_REGIONS:?CAMUNDA_ACTIVE_REGIONS must be set, source export_environment_prerequisites.sh}"
+: "${CAMUNDA_RDBMS_PASSWORD:?CAMUNDA_RDBMS_PASSWORD must be set, e.g. from 'terraform output -raw database_password'}"
+
+read -r -a contexts <<<"$CLUSTER_CONTEXTS"
+
+for ((i = 0; i < CAMUNDA_ACTIVE_REGIONS; i++)); do
+    context="${contexts[$i]}"
+    echo "Creating secret camunda-rdbms-secret in $context/$CAMUNDA_NAMESPACE"
+    kubectl --context "$context" create secret generic camunda-rdbms-secret \
+        --namespace "$CAMUNDA_NAMESPACE" \
+        --from-literal=password="$CAMUNDA_RDBMS_PASSWORD" \
+        --dry-run=client -o yaml | kubectl --context "$context" apply -f -
+done

--- a/aws/kubernetes/eks-multi-region-rdbms/procedure/deploy.sh
+++ b/aws/kubernetes/eks-multi-region-rdbms/procedure/deploy.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Resolve sourced files relative to this script, not the caller working directory.
+# shellcheck source-path=SCRIPTDIR
+set -euo pipefail
+
+# One-shot deployment: renders the per-region values and installs the chart in
+# every active region.
+#
+# Exists so that a non-interactive caller (CI, the Go tests) does not have to
+# source generate-zeebe-helm-values.sh in its own shell. When following the
+# documentation by hand, run the three steps individually instead:
+#
+#   . ./generate-zeebe-helm-values.sh
+#   ./assemble-envsubst-values.sh
+#   ./install-chart.sh
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+. "$SCRIPT_DIR/generate-zeebe-helm-values.sh"
+
+"$SCRIPT_DIR/assemble-envsubst-values.sh"
+"$SCRIPT_DIR/install-chart.sh" "$@"

--- a/aws/kubernetes/eks-multi-region-rdbms/procedure/export-terraform-outputs.sh
+++ b/aws/kubernetes/eks-multi-region-rdbms/procedure/export-terraform-outputs.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+set -euo pipefail
+
+# Exports the Terraform outputs of terraform/clusters into the shell variables
+# consumed by the other procedures:
+#
+#   . ./export-terraform-outputs.sh
+#
+# A single `terraform output -json` call is used on purpose: repeated
+# `terraform output -raw` invocations each take the state lock, which is slow
+# and contends with a concurrent apply.
+
+: "${TF_DIR:=$(cd "$(dirname "${BASH_SOURCE[0]}")/../terraform/clusters" && pwd)}"
+
+_tf_json="$(terraform -chdir="$TF_DIR" output -json)"
+
+_tf_get() { echo "$_tf_json" | jq -r "$1"; }
+
+export CAMUNDA_REGION_SLOTS="$(_tf_get '.region_slot_count.value')"
+export CAMUNDA_ACTIVE_REGIONS="$(_tf_get '.active_region_count.value')"
+
+# Region-indexed maps are flattened into space-separated lists in slot order.
+export AWS_REGIONS="$(_tf_get '[.regions.value | to_entries | sort_by(.key | tonumber) | .[].value.region] | join(" ")')"
+export SUBMARINER_CLUSTER_IDS="$(_tf_get '[.regions.value | to_entries | sort_by(.key | tonumber) | .[].value.short_name] | join(" ")')"
+export REGION_VPC_CIDRS="$(_tf_get '[.vpc_cidr_blocks.value | to_entries | sort_by(.key | tonumber) | .[].value] | join(" ")')"
+export REGION_SERVICE_CIDRS="$(_tf_get '[.service_cidr_blocks.value | to_entries | sort_by(.key | tonumber) | .[].value] | join(" ")')"
+export EKS_CLUSTER_NAMES="$(_tf_get '[.cluster_names.value | to_entries | sort_by(.key | tonumber) | .[].value] | join(" ")')"
+
+export CAMUNDA_RDBMS_URL="$(_tf_get '.camunda_rdbms_url.value // empty')"
+export CAMUNDA_RDBMS_USERNAME="$(_tf_get '.database_username.value // empty')"
+export CAMUNDA_RDBMS_PASSWORD="$(_tf_get '.database_password.value // empty')"
+export AURORA_GLOBAL_CLUSTER_ID="$(_tf_get '.database_global_cluster_id.value // empty')"
+
+unset _tf_json
+
+echo "Terraform outputs exported:"
+echo "  region slots   : $CAMUNDA_REGION_SLOTS (active: $CAMUNDA_ACTIVE_REGIONS)"
+echo "  aws regions    : $AWS_REGIONS"
+echo "  eks clusters   : $EKS_CLUSTER_NAMES"
+echo "  submariner ids : $SUBMARINER_CLUSTER_IDS"
+echo "  rdbms url      : ${CAMUNDA_RDBMS_URL:-<unset>}"

--- a/aws/kubernetes/eks-multi-region-rdbms/procedure/export_environment_prerequisites.sh
+++ b/aws/kubernetes/eks-multi-region-rdbms/procedure/export_environment_prerequisites.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+# shellcheck disable=SC2155
+# The file is meant to be SOURCED, so it ends with `return`; when it is executed
+# directly `return` fails and `exit` takes over. shellcheck only sees the first
+# branch and reports the second as unreachable.
+# shellcheck disable=SC2317
+# Environment contract of the AWS EKS multi-region RDBMS reference architecture.
+#
+# Source this file before running any other procedure:
+#
+#   . ./export_environment_prerequisites.sh
+#
+# Every value can be overridden by exporting it beforehand. Region-indexed
+# values are space-separated lists whose order matches the region SLOT order of
+# the Terraform `regions` variable; index 0 is region slot 0.
+
+set -o pipefail
+
+###############################################################################
+# Region topology                                                             #
+###############################################################################
+
+# Number of REGION SLOTS. Drives the Zeebe broker node ID stride
+# (nodeId = ordinal * slots + regionId) and is immutable for the lifetime of
+# the Camunda cluster.
+export CAMUNDA_REGION_SLOTS="${CAMUNDA_REGION_SLOTS:-3}"
+
+# Number of slots currently deployed. Must be CAMUNDA_REGION_SLOTS or
+# CAMUNDA_REGION_SLOTS - 1; see ../README.md.
+export CAMUNDA_ACTIVE_REGIONS="${CAMUNDA_ACTIVE_REGIONS:-3}"
+
+# AWS regions, kubectl contexts and Submariner cluster IDs, one entry per slot.
+# The Submariner cluster ID becomes the first DNS label of every cross-cluster
+# name (<clusterID>.<service>.<namespace>.svc.clusterset.local) and must be a
+# valid DNS-1123 label.
+export AWS_REGIONS="${AWS_REGIONS:-eu-west-2 eu-west-3 eu-central-2}"
+export CLUSTER_CONTEXTS="${CLUSTER_CONTEXTS:-cluster-london cluster-paris cluster-zurich}"
+export SUBMARINER_CLUSTER_IDS="${SUBMARINER_CLUSTER_IDS:-london paris zurich}"
+
+# Slot hosting the Submariner broker. Any cluster can host it; the broker only
+# stores metadata and its loss does not interrupt established tunnels.
+export SUBMARINER_BROKER_SLOT="${SUBMARINER_BROKER_SLOT:-0}"
+
+###############################################################################
+# Camunda topology                                                            #
+###############################################################################
+
+# A single namespace name is reused in every cluster. Submariner Lighthouse
+# disambiguates identically named services with the cluster ID prefix, so
+# unlike the dual-region CoreDNS-chaining setup there is no need for one
+# namespace per region.
+export CAMUNDA_NAMESPACE="${CAMUNDA_NAMESPACE:-camunda}"
+export CAMUNDA_RELEASE_NAME="${CAMUNDA_RELEASE_NAME:-camunda}"
+
+export CAMUNDA_BROKERS_PER_REGION="${CAMUNDA_BROKERS_PER_REGION:-2}"
+export CAMUNDA_CLUSTER_SIZE="${CAMUNDA_CLUSTER_SIZE:-$((CAMUNDA_BROKERS_PER_REGION * CAMUNDA_REGION_SLOTS))}"
+export CAMUNDA_PARTITION_COUNT="${CAMUNDA_PARTITION_COUNT:-$CAMUNDA_CLUSTER_SIZE}"
+
+# One replica per region slot. See ../README.md, "Why the replication factor
+# equals the number of regions".
+export CAMUNDA_REPLICATION_FACTOR="${CAMUNDA_REPLICATION_FACTOR:-$CAMUNDA_REGION_SLOTS}"
+
+# TODO [release-duty]: pin to the released chart version and switch
+# HELM_CHART_REF to https://helm.camunda.io once 8.10 is generally available.
+# renovate: datasource=helm depName=camunda-platform versioning=regex:^15(\.(?<minor>\d+))?(\.(?<patch>\d+))?$ registryUrl=https://helm.camunda.io
+export HELM_CHART_VERSION="${HELM_CHART_VERSION:-15-dev-latest}"
+export HELM_CHART_REF="${HELM_CHART_REF:-oci://registry.camunda.cloud/team-distribution/camunda-platform}"
+
+###############################################################################
+# Secondary storage                                                           #
+###############################################################################
+
+# Single JDBC URL shared by every broker of every region. Camunda has no
+# multi-region RDBMS mode: replication and writer failover are delegated to the
+# database. Populate it from Terraform with:
+#
+#   export CAMUNDA_RDBMS_URL="$(terraform -chdir=../terraform/clusters output -raw camunda_rdbms_url)"
+export CAMUNDA_RDBMS_URL="${CAMUNDA_RDBMS_URL:-}"
+export CAMUNDA_RDBMS_USERNAME="${CAMUNDA_RDBMS_USERNAME:-camunda}"
+export CAMUNDA_RDBMS_PASSWORD="${CAMUNDA_RDBMS_PASSWORD:-}"
+
+# Aurora Global Database identifier, used by failover.sh and failback.sh. Left
+# empty when bringing your own RDBMS.
+export AURORA_GLOBAL_CLUSTER_ID="${AURORA_GLOBAL_CLUSTER_ID:-}"
+
+###############################################################################
+# Consistency checks                                                          #
+###############################################################################
+
+_multiregion_count() { echo "$#"; }
+
+# Word splitting is intentional here: the region lists are space-separated.
+# shellcheck disable=SC2086
+_aws_region_count="$(_multiregion_count $AWS_REGIONS)"
+# shellcheck disable=SC2086
+_context_count="$(_multiregion_count $CLUSTER_CONTEXTS)"
+# shellcheck disable=SC2086
+_submariner_id_count="$(_multiregion_count $SUBMARINER_CLUSTER_IDS)"
+
+if [ "$_aws_region_count" -lt "$CAMUNDA_ACTIVE_REGIONS" ] ||
+    [ "$_context_count" -lt "$CAMUNDA_ACTIVE_REGIONS" ] ||
+    [ "$_submariner_id_count" -lt "$CAMUNDA_ACTIVE_REGIONS" ]; then
+    echo "ERROR: AWS_REGIONS, CLUSTER_CONTEXTS and SUBMARINER_CLUSTER_IDS must each list at least CAMUNDA_ACTIVE_REGIONS ($CAMUNDA_ACTIVE_REGIONS) entries." >&2
+    return 1 2>/dev/null || exit 1
+fi
+
+if [ "$CAMUNDA_ACTIVE_REGIONS" -gt "$CAMUNDA_REGION_SLOTS" ]; then
+    echo "ERROR: CAMUNDA_ACTIVE_REGIONS ($CAMUNDA_ACTIVE_REGIONS) exceeds CAMUNDA_REGION_SLOTS ($CAMUNDA_REGION_SLOTS)." >&2
+    return 1 2>/dev/null || exit 1
+fi
+
+if [ "$CAMUNDA_ACTIVE_REGIONS" -lt "$((CAMUNDA_REGION_SLOTS - 1))" ]; then
+    echo "ERROR: CAMUNDA_ACTIVE_REGIONS ($CAMUNDA_ACTIVE_REGIONS) leaves more than one slot empty out of $CAMUNDA_REGION_SLOTS." >&2
+    echo "       Every Zeebe partition would lose its majority and the cluster could not form a quorum." >&2
+    return 1 2>/dev/null || exit 1
+fi
+
+if [ $((CAMUNDA_CLUSTER_SIZE % CAMUNDA_REGION_SLOTS)) -ne 0 ]; then
+    echo "ERROR: CAMUNDA_CLUSTER_SIZE ($CAMUNDA_CLUSTER_SIZE) must be a multiple of CAMUNDA_REGION_SLOTS ($CAMUNDA_REGION_SLOTS)." >&2
+    echo "       The Helm chart derives the StatefulSet replica count as clusterSize / regions." >&2
+    return 1 2>/dev/null || exit 1
+fi
+
+echo "Multi-region environment:"
+echo "  region slots       : $CAMUNDA_REGION_SLOTS (active: $CAMUNDA_ACTIVE_REGIONS)"
+echo "  aws regions        : $AWS_REGIONS"
+echo "  kube contexts      : $CLUSTER_CONTEXTS"
+echo "  submariner ids     : $SUBMARINER_CLUSTER_IDS"
+echo "  namespace          : $CAMUNDA_NAMESPACE"
+echo "  cluster size       : $CAMUNDA_CLUSTER_SIZE ($CAMUNDA_BROKERS_PER_REGION per region)"
+echo "  partitions         : $CAMUNDA_PARTITION_COUNT"
+echo "  replication factor : $CAMUNDA_REPLICATION_FACTOR"

--- a/aws/kubernetes/eks-multi-region-rdbms/procedure/failback.sh
+++ b/aws/kubernetes/eks-multi-region-rdbms/procedure/failback.sh
@@ -1,0 +1,171 @@
+#!/bin/bash
+# Resolve sourced files relative to this script, not the caller working directory.
+# shellcheck source-path=SCRIPTDIR
+set -euo pipefail
+
+# Brings a recovered region back into the cluster.
+#
+#   ./failback.sh <recovered-region-slot> [--switch-writer]
+#
+# Compared with the dual-region procedure this is short, and deliberately so.
+# There is no secondary-storage snapshot and restore step: the RDBMS holds a
+# single copy of the exported data, replicated by the database itself, so a
+# region coming back has nothing to catch up on at the Camunda level. The Zeebe
+# brokers replay their Raft log from the surviving replicas exactly as they
+# would after a node restart.
+#
+# `--switch-writer` moves the Aurora writer back to the recovered region. It is
+# optional: leaving the writer where it is costs nothing but cross-region
+# latency for the regions further away from it.
+
+: "${CLUSTER_CONTEXTS:?CLUSTER_CONTEXTS must be set, source export_environment_prerequisites.sh}"
+: "${AWS_REGIONS:?AWS_REGIONS must be set, source export_environment_prerequisites.sh}"
+: "${CAMUNDA_ACTIVE_REGIONS:?CAMUNDA_ACTIVE_REGIONS must be set, source export_environment_prerequisites.sh}"
+: "${CAMUNDA_REGION_SLOTS:?CAMUNDA_REGION_SLOTS must be set, source export_environment_prerequisites.sh}"
+: "${CAMUNDA_BROKERS_PER_REGION:?CAMUNDA_BROKERS_PER_REGION must be set, source export_environment_prerequisites.sh}"
+: "${CAMUNDA_REPLICATION_FACTOR:?CAMUNDA_REPLICATION_FACTOR must be set, source export_environment_prerequisites.sh}"
+
+if [ $# -lt 1 ]; then
+    echo "usage: $0 <recovered-region-slot> [--switch-writer]" >&2
+    exit 1
+fi
+
+RECOVERED_SLOT="$1"
+shift
+SWITCH_WRITER=false
+for arg in "$@"; do
+    case "$arg" in
+    --switch-writer) SWITCH_WRITER=true ;;
+    *)
+        echo "unknown argument: $arg" >&2
+        exit 1
+        ;;
+    esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "$SCRIPT_DIR/lib-management-api.sh"
+
+read -r -a contexts <<<"$CLUSTER_CONTEXTS"
+read -r -a aws_regions <<<"$AWS_REGIONS"
+
+survivor_slot=-1
+for ((i = 0; i < CAMUNDA_ACTIVE_REGIONS; i++)); do
+    if [ "$i" -ne "$RECOVERED_SLOT" ]; then
+        survivor_slot="$i"
+        break
+    fi
+done
+survivor_context="${contexts[$survivor_slot]}"
+
+echo "==============================================================="
+echo " Failback of region slot $RECOVERED_SLOT (${aws_regions[$RECOVERED_SLOT]})"
+echo "==============================================================="
+
+###############################################################################
+# 1. Redeploy Camunda in the recovered region                                 #
+###############################################################################
+
+echo
+echo "--> 1/4 Redeploying Camunda in region slot $RECOVERED_SLOT"
+
+"$SCRIPT_DIR/setup-namespaces.sh"
+"$SCRIPT_DIR/create-rdbms-secret.sh"
+
+. "$SCRIPT_DIR/generate-zeebe-helm-values.sh"
+"$SCRIPT_DIR/assemble-envsubst-values.sh"
+"$SCRIPT_DIR/install-chart.sh" "$RECOVERED_SLOT"
+
+echo
+echo "--> 2/4 Re-exporting the region's services to the ClusterSet"
+"$SCRIPT_DIR/submariner/export-services.sh"
+
+###############################################################################
+# 2. Re-add the brokers if they were drained                                  #
+###############################################################################
+
+echo
+echo "--> 3/4 Checking whether the brokers of slot $RECOVERED_SLOT are cluster members"
+
+node_ids="$(camunda::region_node_ids "$RECOVERED_SLOT")"
+cluster="$(camunda::management "$survivor_context" GET /actuator/cluster)"
+
+missing=()
+for id in $node_ids; do
+    if ! echo "$cluster" | jq -e --argjson id "$id" '[.brokers[]?.id] | index($id) != null' >/dev/null; then
+        missing+=("$id")
+    fi
+done
+
+if [ "${#missing[@]}" -eq 0 ]; then
+    echo "    All brokers of slot $RECOVERED_SLOT are already members; they rejoin and"
+    echo "    catch up from the Raft log without any membership change."
+else
+    echo "    Brokers ${missing[*]} were removed during failover; adding them back."
+    add_json="$(printf '%s\n' "${missing[@]}" | jq -R 'tonumber' | jq -sc .)"
+    body="$(jq -nc \
+        --argjson add "$add_json" \
+        --argjson rf "$CAMUNDA_REPLICATION_FACTOR" \
+        '{brokers: {add: $add}, partitions: {replicationFactor: $rf}}')"
+
+    camunda::management "$survivor_context" PATCH /actuator/cluster "$body"
+    camunda::wait_for_cluster_change "$survivor_context"
+fi
+
+###############################################################################
+# 3. Database                                                                 #
+###############################################################################
+
+echo
+echo "--> 4/4 Database"
+
+if [ -z "${AURORA_GLOBAL_CLUSTER_ID:-}" ]; then
+    echo "    AURORA_GLOBAL_CLUSTER_ID is not set, skipping."
+else
+    members_json="$(aws rds describe-global-clusters \
+        --global-cluster-identifier "$AURORA_GLOBAL_CLUSTER_ID" \
+        --query 'GlobalClusters[0].GlobalClusterMembers' --output json 2>/dev/null || echo '[]')"
+
+    member_count="$(echo "$members_json" | jq 'length')"
+    echo "    Global cluster members: $member_count"
+
+    if [ "$member_count" -le 1 ]; then
+        echo
+        echo "    The global cluster has a single member, which means failover ran with"
+        echo "    --unplanned and detached it. Rebuilding the global topology is a"
+        echo "    Terraform operation, not a script one: re-run"
+        echo
+        echo "        terraform apply"
+        echo
+        echo "    in terraform/clusters so the missing Aurora members are recreated and"
+        echo "    re-attached, then re-run this script if you also want --switch-writer."
+    elif [ "$SWITCH_WRITER" = true ]; then
+        recovered_region="${aws_regions[$RECOVERED_SLOT]}"
+        target_arn="$(echo "$members_json" | jq -r --arg region "$recovered_region" \
+            '[.[] | select((.DBClusterArn | split(":")[3]) == $region)][0].DBClusterArn')"
+
+        if [ -z "$target_arn" ] || [ "$target_arn" = "null" ]; then
+            echo "    No Aurora member in $recovered_region, nothing to switch back to."
+        else
+            echo "    Switching the writer back to $target_arn"
+            aws rds failover-global-cluster \
+                --global-cluster-identifier "$AURORA_GLOBAL_CLUSTER_ID" \
+                --target-db-cluster-identifier "$target_arn"
+
+            target_id="$(basename "$target_arn")"
+            aws rds wait db-cluster-available \
+                --region "$recovered_region" \
+                --db-cluster-identifier "$target_id"
+            echo "    Writer is back in $recovered_region."
+        fi
+    else
+        writer_region="$(echo "$members_json" | jq -r '.[] | select(.IsWriter == true) | .DBClusterArn' | cut -d: -f4)"
+        echo "    Writer stays in $writer_region. Pass --switch-writer to move it back."
+    fi
+fi
+
+echo
+echo "==============================================================="
+echo " Failback complete. Verifying the topology:"
+echo "==============================================================="
+"$SCRIPT_DIR/check-cluster-topology.sh"

--- a/aws/kubernetes/eks-multi-region-rdbms/procedure/failover.sh
+++ b/aws/kubernetes/eks-multi-region-rdbms/procedure/failover.sh
@@ -1,0 +1,195 @@
+#!/bin/bash
+# Resolve sourced files relative to this script, not the caller working directory.
+# shellcheck source-path=SCRIPTDIR
+set -euo pipefail
+
+# Handles the loss of one region.
+#
+#   ./failover.sh <lost-region-slot> [--unplanned] [--drain-brokers]
+#
+# With `replicationFactor == regionSlots` and at least three slots, losing one
+# region leaves every partition with a majority of its replicas: Zeebe keeps
+# processing and NO Zeebe action is required. That is the entire point of this
+# topology, and the difference with the dual-region architecture, where a region
+# loss halts the cluster until brokers are force-removed.
+#
+# What still needs attention is the database, because Aurora Global Database has
+# a single writer region:
+#
+#   * If the writer was NOT in the lost region, nothing to do.
+#   * Planned (region still reachable): `failover-global-cluster` performs a
+#     switchover with no data loss.
+#   * Unplanned (region gone): `remove-from-global-cluster` detaches and
+#     promotes a surviving member. Replication lag at the time of the outage is
+#     lost, and the global cluster must be rebuilt during failback.
+#
+# `--drain-brokers` additionally removes the lost brokers from the Zeebe cluster.
+# Use it only when the region will stay down long enough that running the
+# surviving regions at full replication factor is worth a partition
+# reconfiguration; failback then has to add the brokers back explicitly.
+
+: "${CLUSTER_CONTEXTS:?CLUSTER_CONTEXTS must be set, source export_environment_prerequisites.sh}"
+: "${AWS_REGIONS:?AWS_REGIONS must be set, source export_environment_prerequisites.sh}"
+: "${CAMUNDA_ACTIVE_REGIONS:?CAMUNDA_ACTIVE_REGIONS must be set, source export_environment_prerequisites.sh}"
+: "${CAMUNDA_REGION_SLOTS:?CAMUNDA_REGION_SLOTS must be set, source export_environment_prerequisites.sh}"
+: "${CAMUNDA_BROKERS_PER_REGION:?CAMUNDA_BROKERS_PER_REGION must be set, source export_environment_prerequisites.sh}"
+
+if [ $# -lt 1 ]; then
+    echo "usage: $0 <lost-region-slot> [--unplanned] [--drain-brokers]" >&2
+    exit 1
+fi
+
+LOST_SLOT="$1"
+shift
+UNPLANNED=false
+DRAIN_BROKERS=false
+for arg in "$@"; do
+    case "$arg" in
+    --unplanned) UNPLANNED=true ;;
+    --drain-brokers) DRAIN_BROKERS=true ;;
+    *)
+        echo "unknown argument: $arg" >&2
+        exit 1
+        ;;
+    esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "$SCRIPT_DIR/lib-management-api.sh"
+
+read -r -a contexts <<<"$CLUSTER_CONTEXTS"
+read -r -a aws_regions <<<"$AWS_REGIONS"
+
+# Pick any surviving region to drive the management API from.
+survivor_slot=-1
+for ((i = 0; i < CAMUNDA_ACTIVE_REGIONS; i++)); do
+    if [ "$i" -ne "$LOST_SLOT" ]; then
+        survivor_slot="$i"
+        break
+    fi
+done
+if [ "$survivor_slot" -lt 0 ]; then
+    echo "ERROR: no surviving region left." >&2
+    exit 1
+fi
+survivor_context="${contexts[$survivor_slot]}"
+
+echo "==============================================================="
+echo " Region slot $LOST_SLOT (${aws_regions[$LOST_SLOT]}) declared lost"
+echo " Driving the procedure from region slot $survivor_slot ($survivor_context)"
+echo "==============================================================="
+
+###############################################################################
+# 1. Zeebe: report, do not act                                                #
+###############################################################################
+
+surviving_regions=$((CAMUNDA_ACTIVE_REGIONS - 1))
+echo
+echo "--> Zeebe quorum check"
+echo "    replicationFactor    : ${CAMUNDA_REPLICATION_FACTOR:-$CAMUNDA_REGION_SLOTS}"
+echo "    surviving regions    : $surviving_regions of $CAMUNDA_ACTIVE_REGIONS"
+
+if [ "$surviving_regions" -le $((CAMUNDA_ACTIVE_REGIONS / 2)) ]; then
+    echo
+    echo "WARNING: with $surviving_regions of $CAMUNDA_ACTIVE_REGIONS regions left, partitions no longer hold a" >&2
+    echo "         majority of their replicas and Zeebe has stopped processing. Recovery" >&2
+    echo "         requires force-removing the lost brokers; re-run with --drain-brokers." >&2
+else
+    echo "    Partitions keep a majority of their replicas: Zeebe keeps processing."
+fi
+
+echo
+echo "--> Current cluster view"
+camunda::management "$survivor_context" GET /actuator/cluster | jq '{lastChange, brokers: [.brokers[]?.id]}'
+
+###############################################################################
+# 2. Database writer                                                          #
+###############################################################################
+
+if [ -z "${AURORA_GLOBAL_CLUSTER_ID:-}" ]; then
+    echo
+    echo "--> Database: AURORA_GLOBAL_CLUSTER_ID is not set, skipping."
+    echo "    Bring-your-own RDBMS: promote a surviving replica with your own tooling."
+    echo "    Camunda needs no reconfiguration as long as the JDBC URL keeps resolving"
+    echo "    to the current writer."
+else
+    echo
+    echo "--> Database: inspecting the Aurora Global Database $AURORA_GLOBAL_CLUSTER_ID"
+
+    members_json="$(aws rds describe-global-clusters \
+        --global-cluster-identifier "$AURORA_GLOBAL_CLUSTER_ID" \
+        --query 'GlobalClusters[0].GlobalClusterMembers' --output json)"
+
+    writer_arn="$(echo "$members_json" | jq -r '.[] | select(.IsWriter == true) | .DBClusterArn')"
+    writer_region="$(echo "$writer_arn" | cut -d: -f4)"
+    lost_region="${aws_regions[$LOST_SLOT]}"
+
+    echo "    current writer region: $writer_region"
+
+    if [ "$writer_region" != "$lost_region" ]; then
+        echo "    The writer is not in the lost region: no database action required."
+    else
+        target_arn="$(echo "$members_json" | jq -r --arg lost "$lost_region" \
+            '[.[] | select(.IsWriter != true) | select((.DBClusterArn | split(":")[3]) != $lost)][0].DBClusterArn')"
+
+        if [ -z "$target_arn" ] || [ "$target_arn" = "null" ]; then
+            echo "ERROR: no surviving Aurora member to promote." >&2
+            exit 1
+        fi
+
+        if [ "$UNPLANNED" = true ]; then
+            echo "    Unplanned: detaching and promoting $target_arn"
+            echo "    Data not yet replicated at the time of the outage is lost."
+            aws rds remove-from-global-cluster \
+                --global-cluster-identifier "$AURORA_GLOBAL_CLUSTER_ID" \
+                --db-cluster-identifier "$target_arn"
+        else
+            echo "    Planned switchover to $target_arn"
+            aws rds failover-global-cluster \
+                --global-cluster-identifier "$AURORA_GLOBAL_CLUSTER_ID" \
+                --target-db-cluster-identifier "$target_arn"
+        fi
+
+        echo "    Waiting for the promoted cluster to become available ..."
+        target_id="$(basename "$target_arn")"
+        target_region="$(echo "$target_arn" | cut -d: -f4)"
+        aws rds wait db-cluster-available \
+            --region "$target_region" \
+            --db-cluster-identifier "$target_id"
+
+        echo "    Promotion complete."
+        echo
+        echo "    The AWS Advanced JDBC Wrapper failover plugin discovers the new writer"
+        echo "    from globalClusterInstanceHostPatterns, so Camunda needs no restart."
+        echo "    Connections in flight during the promotion are retried by the driver."
+    fi
+fi
+
+###############################################################################
+# 3. Optional: drain the lost brokers                                         #
+###############################################################################
+
+if [ "$DRAIN_BROKERS" = true ]; then
+    node_ids="$(camunda::region_node_ids "$LOST_SLOT")"
+    echo
+    echo "--> Removing the brokers of region slot $LOST_SLOT: $node_ids"
+    echo "    force=true is required because the brokers are unreachable. It reduces"
+    echo "    the replication factor of the affected partitions instead of moving"
+    echo "    their replicas."
+
+    remove_json="$(printf '%s\n' "$node_ids" | tr ' ' '\n' | jq -R 'tonumber' | jq -sc .)"
+    body="$(jq -nc --argjson remove "$remove_json" '{brokers: {remove: $remove}}')"
+
+    camunda::management "$survivor_context" PATCH "/actuator/cluster?force=true" "$body"
+    camunda::wait_for_cluster_change "$survivor_context"
+fi
+
+echo
+echo "==============================================================="
+echo " Failover complete."
+echo
+echo " Next steps:"
+echo "   * Route client traffic away from region slot $LOST_SLOT."
+echo "   * Run ./check-cluster-topology.sh to confirm the degraded but healthy state."
+echo "   * When the region is back, run ./failback.sh $LOST_SLOT."
+echo "==============================================================="

--- a/aws/kubernetes/eks-multi-region-rdbms/procedure/generate-zeebe-helm-values.sh
+++ b/aws/kubernetes/eks-multi-region-rdbms/procedure/generate-zeebe-helm-values.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+set -euo pipefail
+
+# Emits the region-dependent Camunda settings that cannot be hardcoded in the
+# Helm values, then exports them so that assemble-envsubst-values.sh can
+# substitute them.
+#
+# Two values are produced:
+#
+#   CAMUNDA_CLUSTER_INITIALCONTACTPOINTS
+#       One entry per ACTIVE region, pointing at the headless Zeebe service of
+#       that region through Submariner Lighthouse. Zeebe resolves a headless
+#       clusterset name to every broker pod IP of the exporting cluster, so the
+#       list stays independent of the number of brokers per region.
+#
+#   REGION_<slot>_ZEEBE_SERVICE_NAME
+#       Suffix of the advertised host of each broker. The chart default
+#       (`<pod>.<service>.<namespace>.svc`) only resolves inside its own
+#       cluster.
+#
+# Contact points intentionally cover only the active regions: a slot that has
+# not been deployed yet has no DNS record, and listing it would make every
+# broker wait on the startup DNS gate for nothing.
+
+: "${CLUSTER_CONTEXTS:?CLUSTER_CONTEXTS must be set, source export_environment_prerequisites.sh}"
+: "${SUBMARINER_CLUSTER_IDS:?SUBMARINER_CLUSTER_IDS must be set, source export_environment_prerequisites.sh}"
+: "${CAMUNDA_ACTIVE_REGIONS:?CAMUNDA_ACTIVE_REGIONS must be set, source export_environment_prerequisites.sh}"
+: "${CAMUNDA_NAMESPACE:?CAMUNDA_NAMESPACE must be set, source export_environment_prerequisites.sh}"
+: "${CAMUNDA_RELEASE_NAME:?CAMUNDA_RELEASE_NAME must be set, source export_environment_prerequisites.sh}"
+
+INTERNAL_PORT="${CAMUNDA_CLUSTER_INTERNAL_PORT:-26502}"
+
+read -r -a cluster_ids <<<"$SUBMARINER_CLUSTER_IDS"
+
+contact_points=""
+for ((i = 0; i < CAMUNDA_ACTIVE_REGIONS; i++)); do
+    fqdn="${cluster_ids[$i]}.${CAMUNDA_RELEASE_NAME}-zeebe.${CAMUNDA_NAMESPACE}.svc.clusterset.local"
+
+    export "REGION_${i}_ZEEBE_SERVICE_NAME=$fqdn"
+
+    if [ -z "$contact_points" ]; then
+        contact_points="${fqdn}:${INTERNAL_PORT}"
+    else
+        contact_points="${contact_points},${fqdn}:${INTERNAL_PORT}"
+    fi
+done
+
+export CAMUNDA_CLUSTER_INITIALCONTACTPOINTS="$contact_points"
+
+echo "CAMUNDA_CLUSTER_INITIALCONTACTPOINTS=$CAMUNDA_CLUSTER_INITIALCONTACTPOINTS"
+for ((i = 0; i < CAMUNDA_ACTIVE_REGIONS; i++)); do
+    varname="REGION_${i}_ZEEBE_SERVICE_NAME"
+    echo "${varname}=${!varname}"
+done

--- a/aws/kubernetes/eks-multi-region-rdbms/procedure/get-your-copy.sh
+++ b/aws/kubernetes/eks-multi-region-rdbms/procedure/get-your-copy.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -euo pipefail
+
+# TODO [release-duty]: pin to the released branch (stable/8.10) at release time.
+BRANCH="main"
+
+git clone --depth 1 --branch "$BRANCH" https://github.com/camunda/camunda-deployment-references.git
+
+cd camunda-deployment-references/aws/kubernetes/eks-multi-region-rdbms || exit 1

--- a/aws/kubernetes/eks-multi-region-rdbms/procedure/install-chart.sh
+++ b/aws/kubernetes/eks-multi-region-rdbms/procedure/install-chart.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+set -euo pipefail
+
+# Installs or upgrades the Camunda chart in every active region.
+#
+# Optional first argument: a single region slot, used by activate-region.sh when
+# a new region joins a running cluster.
+#
+# Expects the per-region values files produced by assemble-envsubst-values.sh in
+# the current directory.
+
+# Warn that this deploys an unreleased, in-development chart (to stderr).
+# TODO: [release-duty] remove this pre-release warning at release.
+cat >&2 <<'PRERELEASE_WARNING'
+
+  ############################################################################
+  #  ⚠  PRE-RELEASE — NOT A STABLE CAMUNDA RELEASE                           #
+  #                                                                          #
+  #  This deploys an unreleased, in-development Camunda 8 chart.             #
+  #  It may be unstable or fail to start — that is expected here.            #
+  #                                                                          #
+  #  Need a stable, supported setup? Follow the Administrator quickstart:    #
+  #  https://docs.camunda.io/docs/self-managed/quickstart/administrator-quickstart/
+  ############################################################################
+
+PRERELEASE_WARNING
+
+: "${CLUSTER_CONTEXTS:?CLUSTER_CONTEXTS must be set, source export_environment_prerequisites.sh}"
+: "${CAMUNDA_ACTIVE_REGIONS:?CAMUNDA_ACTIVE_REGIONS must be set, source export_environment_prerequisites.sh}"
+: "${CAMUNDA_NAMESPACE:?CAMUNDA_NAMESPACE must be set, source export_environment_prerequisites.sh}"
+: "${CAMUNDA_RELEASE_NAME:?CAMUNDA_RELEASE_NAME must be set, source export_environment_prerequisites.sh}"
+
+# yq is required below to resolve the broker image for the cross-region DNS gate.
+# Check it up front so we fail fast with a clear message before the network-heavy
+# chart source-build, instead of a generic "command not found" mid-install.
+if ! command -v yq >/dev/null 2>&1; then
+    echo "ERROR: 'yq' is required to resolve the broker image for the cross-region DNS gate but was not found in PATH." >&2
+    exit 1
+fi
+
+# Build the chart from source so no registry authentication is required; prints
+# the local chart directory. The build helper is shared with the generic
+# Kubernetes guide.
+_repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+LOCAL_CHART="$("$_repo_root/generic/kubernetes/single-region/procedure/build-camunda-chart.sh")"
+
+# Resolve the broker image of the chart being installed so the cross-region
+# DNS-gate initContainer (see helm-values/camunda-values.yml) reuses the exact
+# same image as the broker: already pulled on the node, no extra pull, and no
+# hardcoded tag to maintain.
+# TODO: [release-duty] resolve the broker image from the public chart
+# `camunda/camunda-platform` instead of the source-built chart.
+BROKER_IMAGE="$(helm show values "$LOCAL_CHART" |
+    yq -r '(.orchestration.image // .zeebe.image) | ([.registry, .repository] | map(. // "") | map(select(. != "")) | join("/")) + ":" + .tag')"
+
+broker_image_repo="${BROKER_IMAGE%:*}"
+broker_image_tag="${BROKER_IMAGE##*:}"
+if [ -z "$BROKER_IMAGE" ] || [ "$BROKER_IMAGE" = "$broker_image_tag" ] ||
+    [ -z "$broker_image_repo" ] || [ -z "$broker_image_tag" ] || [ "$broker_image_tag" = "null" ]; then
+    echo "ERROR: failed to resolve a valid broker image (registry/repository:tag) from the chart values (got '$BROKER_IMAGE')." >&2
+    exit 1
+fi
+export BROKER_IMAGE
+echo "Cross-region DNS-gate initContainer will reuse broker image: $BROKER_IMAGE"
+
+read -r -a contexts <<<"$CLUSTER_CONTEXTS"
+
+install_slot() {
+    local slot="$1"
+    local values="generated-values-region-${slot}.yml"
+
+    if [ ! -f "$values" ]; then
+        echo "ERROR: $values not found. Run assemble-envsubst-values.sh first." >&2
+        exit 1
+    fi
+
+    # Single quotes are envsubst's SHELL-FORMAT (only ${BROKER_IMAGE} is
+    # replaced), not a shell expansion: everything else stays untouched.
+    # shellcheck disable=SC2016
+    envsubst '${BROKER_IMAGE}' <"$values" >"$values.tmp"
+    mv "$values.tmp" "$values"
+
+    echo "Installing $CAMUNDA_RELEASE_NAME into ${contexts[$slot]}/$CAMUNDA_NAMESPACE (region slot $slot)"
+    helm upgrade --install \
+        "$CAMUNDA_RELEASE_NAME" "$LOCAL_CHART" \
+        --kube-context "${contexts[$slot]}" \
+        --namespace "$CAMUNDA_NAMESPACE" \
+        -f "$values"
+}
+
+if [ $# -ge 1 ]; then
+    install_slot "$1"
+else
+    for ((i = 0; i < CAMUNDA_ACTIVE_REGIONS; i++)); do
+        install_slot "$i"
+    done
+fi
+
+# TODO: [release-duty] remove the source-build above and use the public chart:
+#
+#   helm repo add camunda https://helm.camunda.io --force-update
+#   helm repo update
+#   helm upgrade --install "$CAMUNDA_RELEASE_NAME" camunda/camunda-platform \
+#     --version "$HELM_CHART_VERSION" \
+#     --kube-context "${contexts[$slot]}" \
+#     --namespace "$CAMUNDA_NAMESPACE" \
+#     -f "generated-values-region-${slot}.yml"

--- a/aws/kubernetes/eks-multi-region-rdbms/procedure/lib-management-api.sh
+++ b/aws/kubernetes/eks-multi-region-rdbms/procedure/lib-management-api.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+# Shared helpers for the Orchestration Cluster management API (port 9600).
+#
+# Source this file; it defines functions rather than running anything:
+#
+#   . ./lib-management-api.sh
+#
+# Every call opens a short-lived port-forward. Long-lived tunnels break when a
+# broker restarts, which happens routinely while a cluster change is applied.
+
+# shellcheck shell=bash
+
+MANAGEMENT_LOCAL_PORT="${MANAGEMENT_LOCAL_PORT:-9600}"
+
+# camunda::region_node_ids <slot> -> space-separated broker node IDs of a slot.
+#
+# The Helm chart derives node IDs as `ordinal * regionSlots + regionId`, so the
+# brokers of a slot are that slot's residue class modulo the number of slots.
+camunda::region_node_ids() {
+    local slot="$1"
+    local ids=()
+    local ordinal
+    for ((ordinal = 0; ordinal < CAMUNDA_BROKERS_PER_REGION; ordinal++)); do
+        ids+=($((ordinal * CAMUNDA_REGION_SLOTS + slot)))
+    done
+    echo "${ids[@]}"
+}
+
+# camunda::management <context> <method> <path> [body]
+#
+# Performs a request against the management API of a region's gateway.
+camunda::management() {
+    local context="$1"
+    local method="$2"
+    local path="$3"
+    local body="${4:-}"
+
+    kubectl --context "$context" -n "$CAMUNDA_NAMESPACE" \
+        port-forward "svc/${CAMUNDA_RELEASE_NAME}-zeebe-gateway" \
+        "${MANAGEMENT_LOCAL_PORT}:9600" >/dev/null 2>&1 &
+    local pid=$!
+    # Give the tunnel time to establish; the port-forward is torn down below
+    # even when curl fails, so a stray process cannot leak.
+    sleep 3
+
+    local response
+    if [ -n "$body" ]; then
+        response="$(curl -sS -X "$method" \
+            -H 'Content-Type: application/json' \
+            -d "$body" \
+            "http://localhost:${MANAGEMENT_LOCAL_PORT}${path}")" || true
+    else
+        response="$(curl -sS -X "$method" \
+            "http://localhost:${MANAGEMENT_LOCAL_PORT}${path}")" || true
+    fi
+
+    kill "$pid" 2>/dev/null || true
+    wait "$pid" 2>/dev/null || true
+
+    echo "$response"
+}
+
+# camunda::wait_for_cluster_change <context> [timeout_seconds]
+#
+# Polls GET /actuator/cluster until no change is pending and the last change
+# reports COMPLETED.
+camunda::wait_for_cluster_change() {
+    local context="$1"
+    local timeout="${2:-900}"
+    local deadline=$((SECONDS + timeout))
+
+    while true; do
+        local cluster
+        cluster="$(camunda::management "$context" GET /actuator/cluster)"
+
+        local pending
+        pending="$(echo "$cluster" | jq -r '.pendingChange // empty')"
+        local status
+        status="$(echo "$cluster" | jq -r '.lastChange.status // empty')"
+
+        if [ -z "$pending" ] && [ "$status" = "COMPLETED" ]; then
+            echo "Cluster change completed."
+            return 0
+        fi
+
+        if [ "$SECONDS" -ge "$deadline" ]; then
+            echo "ERROR: cluster change did not complete within ${timeout}s." >&2
+            echo "$cluster" >&2
+            return 1
+        fi
+
+        echo "  waiting for the cluster change to complete (last status: ${status:-unknown}) ..."
+        sleep 15
+    done
+}

--- a/aws/kubernetes/eks-multi-region-rdbms/procedure/manifests/storage-class.yml
+++ b/aws/kubernetes/eks-multi-region-rdbms/procedure/manifests/storage-class.yml
@@ -1,0 +1,20 @@
+---
+# StorageClass manifest for EKS using AWS EBS CSI driver.
+# gp3 is not enabled as the default in EKS, so we explicitly define it here.
+# We also set a minimum of 3000 IOPS to ensure performance requirements.
+
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+    name: ebs-sc
+    annotations:
+        storageclass.kubernetes.io/is-default-class: 'true'
+provisioner: ebs.csi.aws.com
+reclaimPolicy: Retain
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+parameters:
+    type: gp3
+    iops: '3000'
+    throughput: '125'
+    encrypted: 'true'

--- a/aws/kubernetes/eks-multi-region-rdbms/procedure/setup-namespaces.sh
+++ b/aws/kubernetes/eks-multi-region-rdbms/procedure/setup-namespaces.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -euo pipefail
+
+# Creates the Camunda namespace in every active cluster.
+#
+# Unlike the dual-region reference architecture, a single namespace name is
+# reused in every cluster: Submariner Lighthouse disambiguates identically
+# named services with the exporting cluster ID, so `<clusterID>.<service>.<ns>.
+# svc.clusterset.local` stays unambiguous. This keeps the number of namespaces
+# linear instead of quadratic in the number of regions.
+
+: "${CAMUNDA_NAMESPACE:?CAMUNDA_NAMESPACE must be set, source export_environment_prerequisites.sh}"
+: "${CLUSTER_CONTEXTS:?CLUSTER_CONTEXTS must be set, source export_environment_prerequisites.sh}"
+: "${CAMUNDA_ACTIVE_REGIONS:?CAMUNDA_ACTIVE_REGIONS must be set, source export_environment_prerequisites.sh}"
+
+read -r -a contexts <<<"$CLUSTER_CONTEXTS"
+
+for ((i = 0; i < CAMUNDA_ACTIVE_REGIONS; i++)); do
+    context="${contexts[$i]}"
+    echo "Creating namespace $CAMUNDA_NAMESPACE in $context"
+    kubectl --context "$context" create namespace "$CAMUNDA_NAMESPACE" \
+        --dry-run=client -o yaml | kubectl --context "$context" apply -f -
+done

--- a/aws/kubernetes/eks-multi-region-rdbms/procedure/simulate-region-loss.sh
+++ b/aws/kubernetes/eks-multi-region-rdbms/procedure/simulate-region-loss.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+set -euo pipefail
+
+# Simulates the loss of one region by removing everything Camunda from it.
+#
+#   ./simulate-region-loss.sh <slot>
+#
+# This is a TEST helper, not an operational procedure. A real region loss is
+# abrupt: the API server becomes unreachable and nothing can be uninstalled
+# cleanly. Removing the workload is the closest reproducible approximation and
+# is what the dual-region suite does as well.
+#
+# It deliberately does NOT tear down the EKS cluster or the Transit Gateway
+# attachments: recreating them would take 25 minutes and would test Terraform
+# rather than the Camunda failure behaviour.
+
+: "${CLUSTER_CONTEXTS:?CLUSTER_CONTEXTS must be set, source export_environment_prerequisites.sh}"
+: "${CAMUNDA_NAMESPACE:?CAMUNDA_NAMESPACE must be set, source export_environment_prerequisites.sh}"
+: "${CAMUNDA_RELEASE_NAME:?CAMUNDA_RELEASE_NAME must be set, source export_environment_prerequisites.sh}"
+
+if [ $# -ne 1 ]; then
+    echo "usage: $0 <region-slot>" >&2
+    exit 1
+fi
+
+SLOT="$1"
+read -r -a contexts <<<"$CLUSTER_CONTEXTS"
+context="${contexts[$SLOT]}"
+
+echo "Simulating the loss of region slot $SLOT ($context)"
+
+helm --kube-context "$context" --namespace "$CAMUNDA_NAMESPACE" \
+    uninstall "$CAMUNDA_RELEASE_NAME" --wait --timeout 10m || true
+
+# The PVCs must go too: a region that comes back reuses its node IDs but must
+# rebuild its Raft state from the surviving replicas, which is what a genuinely
+# lost region would do.
+kubectl --context "$context" --namespace "$CAMUNDA_NAMESPACE" \
+    delete pvc --all --wait=false || true
+
+echo "Region slot $SLOT no longer runs Camunda."

--- a/aws/kubernetes/eks-multi-region-rdbms/procedure/storageclass-configure.sh
+++ b/aws/kubernetes/eks-multi-region-rdbms/procedure/storageclass-configure.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -euo pipefail
+
+# EKS ships gp2 as the default StorageClass. Zeebe writes its Raft log and
+# snapshots to this volume, so gp3 with a guaranteed IOPS floor is used instead.
+# Applied to every active cluster.
+
+: "${CLUSTER_CONTEXTS:?CLUSTER_CONTEXTS must be set, source export_environment_prerequisites.sh}"
+: "${CAMUNDA_ACTIVE_REGIONS:?CAMUNDA_ACTIVE_REGIONS must be set, source export_environment_prerequisites.sh}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+read -r -a contexts <<<"$CLUSTER_CONTEXTS"
+
+for ((i = 0; i < CAMUNDA_ACTIVE_REGIONS; i++)); do
+    context="${contexts[$i]}"
+
+    echo "Configuring the default StorageClass on $context"
+    kubectl --context "$context" patch storageclass gp2 \
+        -p '{"metadata":{"annotations":{"storageclass.kubernetes.io/is-default-class":"false"}}}'
+    kubectl --context "$context" apply -f "$SCRIPT_DIR/manifests/storage-class.yml"
+done

--- a/aws/kubernetes/eks-multi-region-rdbms/procedure/storageclass-verify.sh
+++ b/aws/kubernetes/eks-multi-region-rdbms/procedure/storageclass-verify.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -euo pipefail
+
+# Asserts that ebs-sc is the one and only default StorageClass in every active
+# cluster. A second default makes PVC binding non-deterministic.
+
+: "${CLUSTER_CONTEXTS:?CLUSTER_CONTEXTS must be set, source export_environment_prerequisites.sh}"
+: "${CAMUNDA_ACTIVE_REGIONS:?CAMUNDA_ACTIVE_REGIONS must be set, source export_environment_prerequisites.sh}"
+
+SC_NAME="ebs-sc"
+
+read -r -a contexts <<<"$CLUSTER_CONTEXTS"
+
+failed=0
+for ((i = 0; i < CAMUNDA_ACTIVE_REGIONS; i++)); do
+    context="${contexts[$i]}"
+
+    defaults="$(kubectl --context "$context" get storageclass -o json |
+        jq -r '.items[] | select(.metadata.annotations."storageclass.kubernetes.io/is-default-class"=="true") | .metadata.name')"
+
+    if [ "$defaults" = "$SC_NAME" ]; then
+        echo "OK: $context has '$SC_NAME' as its only default StorageClass."
+    else
+        echo "FAIL: $context default StorageClass(es): ${defaults:-<none>}" >&2
+        failed=1
+    fi
+done
+
+exit "$failed"

--- a/aws/kubernetes/eks-multi-region-rdbms/procedure/submariner/deploy-broker.sh
+++ b/aws/kubernetes/eks-multi-region-rdbms/procedure/submariner/deploy-broker.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -euo pipefail
+
+# Deploys the Submariner broker into one of the clusters.
+#
+# The broker is a metadata-only component: it holds the Endpoint and Cluster
+# custom resources that let the gateways discover each other, plus the
+# ServiceImport registry used by Lighthouse. Established IPsec tunnels keep
+# working while it is unavailable, so it is deliberately not replicated across
+# regions.
+#
+# It writes broker-info.subm into the current directory. That file contains the
+# broker API endpoint and its credentials: treat it as a secret and delete it
+# once every cluster has joined.
+
+: "${CLUSTER_CONTEXTS:?CLUSTER_CONTEXTS must be set, source export_environment_prerequisites.sh}"
+: "${SUBMARINER_BROKER_SLOT:?SUBMARINER_BROKER_SLOT must be set, source export_environment_prerequisites.sh}"
+
+read -r -a contexts <<<"$CLUSTER_CONTEXTS"
+broker_context="${contexts[$SUBMARINER_BROKER_SLOT]}"
+
+echo "Deploying the Submariner broker into $broker_context"
+
+# Globalnet stays disabled: the reference architecture allocates
+# non-overlapping VPC, pod and service CIDRs per region, which is a hard
+# requirement of Transit Gateway routing anyway. Enabling Globalnet would add a
+# NAT layer and a second address plan for no benefit here.
+subctl deploy-broker \
+    --context "$broker_context" \
+    --globalnet=false
+
+echo
+echo "Broker deployed. broker-info.subm written to $(pwd)."
+echo "It carries broker credentials: delete it once every cluster has joined."

--- a/aws/kubernetes/eks-multi-region-rdbms/procedure/submariner/diagnose-submariner.sh
+++ b/aws/kubernetes/eks-multi-region-rdbms/procedure/submariner/diagnose-submariner.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Best-effort Submariner diagnostics. Never fails, so it can be wired into the
+# `if: failure()` step of a workflow without masking the original error.
+set +e
+
+: "${CLUSTER_CONTEXTS:?CLUSTER_CONTEXTS must be set, source export_environment_prerequisites.sh}"
+: "${CAMUNDA_ACTIVE_REGIONS:?CAMUNDA_ACTIVE_REGIONS must be set, source export_environment_prerequisites.sh}"
+
+read -r -a contexts <<<"$CLUSTER_CONTEXTS"
+
+for ((i = 0; i < CAMUNDA_ACTIVE_REGIONS; i++)); do
+    context="${contexts[$i]}"
+
+    echo "=============================================================="
+    echo "== Submariner diagnostics for $context"
+    echo "=============================================================="
+
+    echo "--- subctl show all"
+    subctl show all --contexts "$context" 2>&1
+
+    echo "--- submariner-operator pods"
+    kubectl --context "$context" -n submariner-operator get pods -o wide 2>&1
+
+    echo "--- gateway logs (last 200 lines)"
+    kubectl --context "$context" -n submariner-operator logs -l app=submariner-gateway --tail=200 --prefix 2>&1
+
+    echo "--- gateways and endpoints"
+    kubectl --context "$context" get gateways.submariner.io,endpoints.submariner.io -A -o wide 2>&1
+
+    echo "--- gateway-labelled nodes"
+    kubectl --context "$context" get nodes -l submariner.io/gateway=true -o wide 2>&1
+
+    echo "--- service exports / imports"
+    kubectl --context "$context" get serviceexports.multicluster.x-k8s.io,serviceimports.multicluster.x-k8s.io -A -o wide 2>&1
+done
+
+echo "=============================================================="
+echo "== Cross-cluster DNS resolution"
+echo "=============================================================="
+
+read -r -a cluster_ids <<<"${SUBMARINER_CLUSTER_IDS:-}"
+for ((i = 0; i < CAMUNDA_ACTIVE_REGIONS; i++)); do
+    for ((j = 0; j < CAMUNDA_ACTIVE_REGIONS; j++)); do
+        [ "$i" -eq "$j" ] && continue
+        target="${cluster_ids[$j]}.${CAMUNDA_RELEASE_NAME:-camunda}-zeebe.${CAMUNDA_NAMESPACE:-camunda}.svc.clusterset.local"
+        echo "--- ${contexts[$i]} -> $target"
+        kubectl --context "${contexts[$i]}" -n "${CAMUNDA_NAMESPACE:-camunda}" \
+            run "submariner-dns-probe-$i-$j" --rm -i --restart=Never \
+            --image=busybox:1.37 --command -- nslookup "$target" 2>&1
+    done
+done
+
+exit 0

--- a/aws/kubernetes/eks-multi-region-rdbms/procedure/submariner/export-services.sh
+++ b/aws/kubernetes/eks-multi-region-rdbms/procedure/submariner/export-services.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+set -euo pipefail
+
+# Exports the Camunda services of every active cluster to the Submariner
+# ClusterSet, then waits for the resulting ServiceImports to appear.
+#
+# Only the services actually consumed across regions are exported, instead of
+# every service in the namespace:
+#   * <release>-zeebe          headless, carries Raft replication and the
+#                              per-pod DNS records brokers dial each other on
+#   * <release>-zeebe-gateway  gRPC entry point, lets a client in one region
+#                              reach a gateway in another
+#
+# Re-run this after any operation that recreates services, for example after
+# activating a new region.
+
+: "${CLUSTER_CONTEXTS:?CLUSTER_CONTEXTS must be set, source export_environment_prerequisites.sh}"
+: "${CAMUNDA_ACTIVE_REGIONS:?CAMUNDA_ACTIVE_REGIONS must be set, source export_environment_prerequisites.sh}"
+: "${CAMUNDA_NAMESPACE:?CAMUNDA_NAMESPACE must be set, source export_environment_prerequisites.sh}"
+: "${CAMUNDA_RELEASE_NAME:?CAMUNDA_RELEASE_NAME must be set, source export_environment_prerequisites.sh}"
+
+DNS_WAIT_TIMEOUT="${DNS_WAIT_TIMEOUT:-300}"
+
+read -r -a contexts <<<"$CLUSTER_CONTEXTS"
+
+services=(
+    "${CAMUNDA_RELEASE_NAME}-zeebe"
+    "${CAMUNDA_RELEASE_NAME}-zeebe-gateway"
+)
+
+for ((i = 0; i < CAMUNDA_ACTIVE_REGIONS; i++)); do
+    context="${contexts[$i]}"
+
+    for svc in "${services[@]}"; do
+        if ! kubectl --context "$context" -n "$CAMUNDA_NAMESPACE" get svc "$svc" >/dev/null 2>&1; then
+            echo "  skipping $svc on $context: service does not exist (yet)"
+            continue
+        fi
+        echo "Exporting $svc from $context"
+        subctl --context "$context" export service --namespace "$CAMUNDA_NAMESPACE" "$svc"
+    done
+done
+
+echo
+echo "Waiting for Lighthouse ServiceImports to be published ..."
+
+deadline=$((SECONDS + DNS_WAIT_TIMEOUT))
+zeebe_svc="${CAMUNDA_RELEASE_NAME}-zeebe"
+
+for ((i = 0; i < CAMUNDA_ACTIVE_REGIONS; i++)); do
+    context="${contexts[$i]}"
+    while ! kubectl --context "$context" -n "$CAMUNDA_NAMESPACE" get serviceimport "$zeebe_svc" >/dev/null 2>&1; do
+        if [ "$SECONDS" -ge "$deadline" ]; then
+            echo "WARNING: ServiceImport $zeebe_svc not visible on $context after ${DNS_WAIT_TIMEOUT}s." >&2
+            echo "         Broker startup is gated on clusterset DNS anyway (see helm-values/camunda-values.yml)." >&2
+            break
+        fi
+        sleep 5
+    done
+done
+
+# Lighthouse publishes the DNS records shortly after the ServiceImport object.
+sleep 15
+
+echo "Exported services:"
+for ((i = 0; i < CAMUNDA_ACTIVE_REGIONS; i++)); do
+    kubectl --context "${contexts[$i]}" -n "$CAMUNDA_NAMESPACE" get serviceexports.multicluster.x-k8s.io 2>/dev/null || true
+done

--- a/aws/kubernetes/eks-multi-region-rdbms/procedure/submariner/install-subctl.sh
+++ b/aws/kubernetes/eks-multi-region-rdbms/procedure/submariner/install-subctl.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -euo pipefail
+
+# Installs the subctl CLI. Must be sourced so that the PATH change survives:
+#
+#   source ./install-subctl.sh
+#
+# Instructions from https://submariner.io/operations/deployment/subctl/
+
+curl -Ls https://get.submariner.io -o submariner-install.sh
+cat submariner-install.sh
+
+# renovate: datasource=github-releases depName=submariner-io/subctl
+SUBCTL_VERSION=0.24.0
+
+VERSION="$SUBCTL_VERSION" bash submariner-install.sh
+
+export PATH=$PATH:~/.local/bin
+echo export PATH=\$PATH:~/.local/bin >>~/.profile
+
+subctl version

--- a/aws/kubernetes/eks-multi-region-rdbms/procedure/submariner/join-clusters.sh
+++ b/aws/kubernetes/eks-multi-region-rdbms/procedure/submariner/join-clusters.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+set -euo pipefail
+
+# Joins every active cluster to the Submariner broker.
+#
+# Run from the directory containing broker-info.subm (see deploy-broker.sh).
+#
+# Optional first argument: a single region slot to join, used by
+# ../activate-region.sh when a new region is added to a running cluster.
+#
+# EKS specifics:
+#   * The AWS VPC CNI gives pods routable VPC addresses, so the pod CIDR is the
+#     VPC CIDR. subctl cannot infer that reliably, hence the explicit
+#     --clustercidr / --servicecidr.
+#   * --air-gapped disables public IP discovery: gateways reach each other over
+#     the private Transit Gateway mesh, never over the internet.
+#   * --natt=false because there is no NAT between the peered VPCs.
+#   * libreswan encrypts the tunnels. Transit Gateway traffic crosses the AWS
+#     backbone unencrypted, so this is defence in depth rather than optional.
+
+: "${CLUSTER_CONTEXTS:?CLUSTER_CONTEXTS must be set, source export_environment_prerequisites.sh}"
+: "${SUBMARINER_CLUSTER_IDS:?SUBMARINER_CLUSTER_IDS must be set, source export_environment_prerequisites.sh}"
+: "${CAMUNDA_ACTIVE_REGIONS:?CAMUNDA_ACTIVE_REGIONS must be set, source export_environment_prerequisites.sh}"
+: "${REGION_VPC_CIDRS:?REGION_VPC_CIDRS must be set, e.g. from 'terraform output -json vpc_cidr_blocks'}"
+: "${REGION_SERVICE_CIDRS:?REGION_SERVICE_CIDRS must be set, e.g. from 'terraform output -json service_cidr_blocks'}"
+
+BROKER_INFO="${BROKER_INFO:-broker-info.subm}"
+CABLE_DRIVER="${SUBMARINER_CABLE_DRIVER:-libreswan}"
+
+if [ ! -f "$BROKER_INFO" ]; then
+    echo "ERROR: $BROKER_INFO not found. Run deploy-broker.sh first, or set BROKER_INFO." >&2
+    exit 1
+fi
+
+read -r -a contexts <<<"$CLUSTER_CONTEXTS"
+read -r -a cluster_ids <<<"$SUBMARINER_CLUSTER_IDS"
+read -r -a vpc_cidrs <<<"$REGION_VPC_CIDRS"
+read -r -a service_cidrs <<<"$REGION_SERVICE_CIDRS"
+
+join_slot() {
+    local slot="$1"
+
+    echo "Joining ${contexts[$slot]} as cluster id '${cluster_ids[$slot]}'"
+    subctl join "$BROKER_INFO" \
+        --context "${contexts[$slot]}" \
+        --clusterid "${cluster_ids[$slot]}" \
+        --clustercidr "${vpc_cidrs[$slot]}" \
+        --servicecidr "${service_cidrs[$slot]}" \
+        --cable-driver "$CABLE_DRIVER" \
+        --natt=false \
+        --air-gapped \
+        --globalnet=false \
+        --label-gateway=false \
+        --check-broker-certificate=false
+}
+
+if [ $# -ge 1 ]; then
+    join_slot "$1"
+else
+    for ((i = 0; i < CAMUNDA_ACTIVE_REGIONS; i++)); do
+        join_slot "$i"
+    done
+fi

--- a/aws/kubernetes/eks-multi-region-rdbms/procedure/submariner/label-gateway-nodes.sh
+++ b/aws/kubernetes/eks-multi-region-rdbms/procedure/submariner/label-gateway-nodes.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -euo pipefail
+
+# Labels one node per cluster as a Submariner gateway.
+#
+# Submariner runs the IPsec tunnel endpoint on the host network of a labelled
+# node. Labelling explicitly (instead of letting `subctl join --label-gateway`
+# pick one) keeps the choice deterministic across re-runs, which matters because
+# the gateway node IP is what the remote clusters dial.
+#
+# A single gateway per cluster is a single point of failure for cross-region
+# traffic: Submariner elects a new active gateway if more nodes carry the label.
+# Set SUBMARINER_GATEWAY_NODES_PER_CLUSTER to label more than one for HA.
+
+: "${CLUSTER_CONTEXTS:?CLUSTER_CONTEXTS must be set, source export_environment_prerequisites.sh}"
+: "${CAMUNDA_ACTIVE_REGIONS:?CAMUNDA_ACTIVE_REGIONS must be set, source export_environment_prerequisites.sh}"
+
+GATEWAYS_PER_CLUSTER="${SUBMARINER_GATEWAY_NODES_PER_CLUSTER:-1}"
+
+read -r -a contexts <<<"$CLUSTER_CONTEXTS"
+
+for ((i = 0; i < CAMUNDA_ACTIVE_REGIONS; i++)); do
+    context="${contexts[$i]}"
+
+    mapfile -t nodes < <(kubectl --context "$context" get nodes \
+        -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' | sort)
+
+    if [ "${#nodes[@]}" -lt "$GATEWAYS_PER_CLUSTER" ]; then
+        echo "ERROR: $context has ${#nodes[@]} node(s), need at least $GATEWAYS_PER_CLUSTER for the gateway label." >&2
+        exit 1
+    fi
+
+    # Sorted node list keeps the selection stable across re-runs.
+    for ((g = 0; g < GATEWAYS_PER_CLUSTER; g++)); do
+        node="${nodes[$g]}"
+        echo "Labelling $context/$node as a Submariner gateway"
+        kubectl --context "$context" label node "$node" submariner.io/gateway=true --overwrite
+    done
+done
+
+echo
+echo "Gateway nodes:"
+for ((i = 0; i < CAMUNDA_ACTIVE_REGIONS; i++)); do
+    kubectl --context "${contexts[$i]}" get nodes -l submariner.io/gateway=true
+done

--- a/aws/kubernetes/eks-multi-region-rdbms/procedure/submariner/verify-submariner.sh
+++ b/aws/kubernetes/eks-multi-region-rdbms/procedure/submariner/verify-submariner.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+set -euo pipefail
+
+# Waits until every cluster reports N-1 established Submariner connections,
+# where N is the number of active regions. Submariner builds a full mesh of
+# tunnels, so each cluster connects to every other one.
+
+: "${CLUSTER_CONTEXTS:?CLUSTER_CONTEXTS must be set, source export_environment_prerequisites.sh}"
+: "${CAMUNDA_ACTIVE_REGIONS:?CAMUNDA_ACTIVE_REGIONS must be set, source export_environment_prerequisites.sh}"
+
+TIMEOUT_SECONDS="${SUBMARINER_VERIFY_TIMEOUT_SECONDS:-900}"
+POLL_INTERVAL_SECONDS="${SUBMARINER_VERIFY_POLL_INTERVAL_SECONDS:-15}"
+
+read -r -a contexts <<<"$CLUSTER_CONTEXTS"
+expected_connections=$((CAMUNDA_ACTIVE_REGIONS - 1))
+
+deadline=$((SECONDS + TIMEOUT_SECONDS))
+
+for ((i = 0; i < CAMUNDA_ACTIVE_REGIONS; i++)); do
+    context="${contexts[$i]}"
+    echo "Verifying Submariner on $context (expecting $expected_connections established connection(s))"
+
+    while true; do
+        status="$(subctl show all --contexts "$context" 2>&1 || true)"
+
+        if echo "$status" | grep -q "All connections ($expected_connections) are established"; then
+            echo "  OK"
+            break
+        fi
+
+        if [ "$SECONDS" -ge "$deadline" ]; then
+            echo "ERROR: Submariner did not converge on $context within ${TIMEOUT_SECONDS}s." >&2
+            echo "$status" >&2
+            exit 1
+        fi
+
+        echo "  not converged yet, retrying in ${POLL_INTERVAL_SECONDS}s ..."
+        sleep "$POLL_INTERVAL_SECONDS"
+    done
+done
+
+echo
+echo "Submariner mesh is established across $CAMUNDA_ACTIVE_REGIONS clusters."

--- a/aws/kubernetes/eks-multi-region-rdbms/procedure/verify-degraded-cluster.sh
+++ b/aws/kubernetes/eks-multi-region-rdbms/procedure/verify-degraded-cluster.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+set -euo pipefail
+
+# Asserts that the cluster still works after losing one region.
+#
+#   ./verify-degraded-cluster.sh <lost-slot>
+#
+# The point of the multi-region topology is that this state is NOT an outage:
+# every partition keeps a majority of its replicas, so the engine accepts new
+# work. The checks below are therefore about liveness, not about completeness of
+# the replica set.
+
+: "${CLUSTER_CONTEXTS:?CLUSTER_CONTEXTS must be set, source export_environment_prerequisites.sh}"
+: "${CAMUNDA_NAMESPACE:?CAMUNDA_NAMESPACE must be set, source export_environment_prerequisites.sh}"
+: "${CAMUNDA_RELEASE_NAME:?CAMUNDA_RELEASE_NAME must be set, source export_environment_prerequisites.sh}"
+: "${CAMUNDA_ACTIVE_REGIONS:?CAMUNDA_ACTIVE_REGIONS must be set, source export_environment_prerequisites.sh}"
+: "${CAMUNDA_BROKERS_PER_REGION:?CAMUNDA_BROKERS_PER_REGION must be set, source export_environment_prerequisites.sh}"
+
+if [ $# -ne 1 ]; then
+    echo "usage: $0 <lost-region-slot>" >&2
+    exit 1
+fi
+
+LOST_SLOT="$1"
+CAMUNDA_BASIC_AUTH_USER="${CAMUNDA_BASIC_AUTH_USER:-demo}"
+CAMUNDA_BASIC_AUTH_PASSWORD="${CAMUNDA_BASIC_AUTH_PASSWORD:-demo}"
+LOCAL_PORT="${LOCAL_PORT:-8080}"
+
+read -r -a contexts <<<"$CLUSTER_CONTEXTS"
+
+survivor_slot=-1
+for ((i = 0; i < CAMUNDA_ACTIVE_REGIONS; i++)); do
+    if [ "$i" -ne "$LOST_SLOT" ]; then
+        survivor_slot="$i"
+        break
+    fi
+done
+survivor_context="${contexts[$survivor_slot]}"
+
+echo "Verifying the surviving cluster from region slot $survivor_slot ($survivor_context)"
+
+kubectl --context "$survivor_context" -n "$CAMUNDA_NAMESPACE" \
+    port-forward "svc/${CAMUNDA_RELEASE_NAME}-zeebe-gateway" "${LOCAL_PORT}:8080" >/dev/null 2>&1 &
+port_forward_pid=$!
+# shellcheck disable=SC2064
+trap "kill $port_forward_pid 2>/dev/null || true" EXIT
+sleep 5
+
+expected_survivors=$((CAMUNDA_BROKERS_PER_REGION * (CAMUNDA_ACTIVE_REGIONS - 1)))
+deadline=$((SECONDS + ${VERIFY_DEGRADED_TIMEOUT_SECONDS:-900}))
+
+echo "--> Waiting for the topology to converge on $expected_survivors surviving broker(s)"
+while true; do
+    topology="$(curl -sS -u "${CAMUNDA_BASIC_AUTH_USER}:${CAMUNDA_BASIC_AUTH_PASSWORD}" \
+        "http://localhost:${LOCAL_PORT}/v2/topology" || echo '{}')"
+
+    brokers="$(echo "$topology" | jq '.brokers | length // 0')"
+    if [ "$brokers" -ge "$expected_survivors" ]; then
+        echo "    $brokers broker(s) reachable."
+        break
+    fi
+
+    if [ "$SECONDS" -ge "$deadline" ]; then
+        echo "ERROR: only $brokers broker(s) reachable, expected at least $expected_survivors." >&2
+        echo "$topology" >&2
+        exit 1
+    fi
+
+    echo "    $brokers/$expected_survivors reachable, waiting ..."
+    sleep 15
+done
+
+echo "--> Checking that every partition still has a leader"
+partitions="$(echo "$topology" | jq '.partitionsCount')"
+partitions_with_leader="$(echo "$topology" | jq '
+    [.brokers[].partitions[] | select(.role == "leader") | .partitionId] | unique | length')"
+
+if [ "$partitions_with_leader" -lt "$partitions" ]; then
+    echo "ERROR: only $partitions_with_leader of $partitions partitions have a leader." >&2
+    echo "       The surviving regions did not keep a quorum. Check that" >&2
+    echo "       replicationFactor equals the region slot count." >&2
+    echo "$topology" >&2
+    exit 1
+fi
+echo "    all $partitions partitions have a leader."
+
+echo "--> Checking that the gateway still serves the v2 API"
+# A quorum loss shows up to a client as a timeout or a 5xx. Anything the gateway
+# answers itself, including an authorisation error, proves it is serving.
+response="$(curl -sS -o /dev/null -w '%{http_code}' \
+    -u "${CAMUNDA_BASIC_AUTH_USER}:${CAMUNDA_BASIC_AUTH_PASSWORD}" \
+    "http://localhost:${LOCAL_PORT}/v2/license" 2>/dev/null || echo 000)"
+
+case "$response" in
+2* | 401 | 403)
+    echo "    gateway responded with HTTP $response."
+    ;;
+*)
+    echo "ERROR: the gateway returned HTTP $response, it is not serving requests." >&2
+    exit 1
+    ;;
+esac
+
+echo
+echo "The cluster survived the loss of region slot $LOST_SLOT without intervention."

--- a/aws/kubernetes/eks-multi-region-rdbms/terraform/clusters/README.md
+++ b/aws/kubernetes/eks-multi-region-rdbms/terraform/clusters/README.md
@@ -1,0 +1,82 @@
+# clusters
+
+<!-- BEGIN_TF_DOCS -->
+## Modules
+
+| Name | Source | Version |
+| ---- | ------ | ------- |
+| <a name="module_database_region_0"></a> [database\_region\_0](#module\_database\_region\_0) | ../../../../modules/aurora-global-member | n/a |
+| <a name="module_database_region_1"></a> [database\_region\_1](#module\_database\_region\_1) | ../../../../modules/aurora-global-member | n/a |
+| <a name="module_database_region_2"></a> [database\_region\_2](#module\_database\_region\_2) | ../../../../modules/aurora-global-member | n/a |
+| <a name="module_database_region_3"></a> [database\_region\_3](#module\_database\_region\_3) | ../../../../modules/aurora-global-member | n/a |
+| <a name="module_eks_cluster_region_0"></a> [eks\_cluster\_region\_0](#module\_eks\_cluster\_region\_0) | ../../../../modules/eks-cluster | n/a |
+| <a name="module_eks_cluster_region_1"></a> [eks\_cluster\_region\_1](#module\_eks\_cluster\_region\_1) | ../../../../modules/eks-cluster | n/a |
+| <a name="module_eks_cluster_region_2"></a> [eks\_cluster\_region\_2](#module\_eks\_cluster\_region\_2) | ../../../../modules/eks-cluster | n/a |
+| <a name="module_eks_cluster_region_3"></a> [eks\_cluster\_region\_3](#module\_eks\_cluster\_region\_3) | ../../../../modules/eks-cluster | n/a |
+| <a name="module_tgw_hub_region_0"></a> [tgw\_hub\_region\_0](#module\_tgw\_hub\_region\_0) | ../../../../modules/transit-gateway-hub | n/a |
+| <a name="module_tgw_hub_region_1"></a> [tgw\_hub\_region\_1](#module\_tgw\_hub\_region\_1) | ../../../../modules/transit-gateway-hub | n/a |
+| <a name="module_tgw_hub_region_2"></a> [tgw\_hub\_region\_2](#module\_tgw\_hub\_region\_2) | ../../../../modules/transit-gateway-hub | n/a |
+| <a name="module_tgw_hub_region_3"></a> [tgw\_hub\_region\_3](#module\_tgw\_hub\_region\_3) | ../../../../modules/transit-gateway-hub | n/a |
+| <a name="module_tgw_peering_0_1"></a> [tgw\_peering\_0\_1](#module\_tgw\_peering\_0\_1) | ../../../../modules/transit-gateway-peering | n/a |
+| <a name="module_tgw_peering_0_2"></a> [tgw\_peering\_0\_2](#module\_tgw\_peering\_0\_2) | ../../../../modules/transit-gateway-peering | n/a |
+| <a name="module_tgw_peering_0_3"></a> [tgw\_peering\_0\_3](#module\_tgw\_peering\_0\_3) | ../../../../modules/transit-gateway-peering | n/a |
+| <a name="module_tgw_peering_1_2"></a> [tgw\_peering\_1\_2](#module\_tgw\_peering\_1\_2) | ../../../../modules/transit-gateway-peering | n/a |
+| <a name="module_tgw_peering_1_3"></a> [tgw\_peering\_1\_3](#module\_tgw\_peering\_1\_3) | ../../../../modules/transit-gateway-peering | n/a |
+| <a name="module_tgw_peering_2_3"></a> [tgw\_peering\_2\_3](#module\_tgw\_peering\_2\_3) | ../../../../modules/transit-gateway-peering | n/a |
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [aws_rds_global_cluster.camunda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_global_cluster) | resource |
+| [aws_vpc_security_group_ingress_rule.region_0](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_ingress_rule) | resource |
+| [aws_vpc_security_group_ingress_rule.region_1](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_ingress_rule) | resource |
+| [aws_vpc_security_group_ingress_rule.region_2](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_ingress_rule) | resource |
+| [aws_vpc_security_group_ingress_rule.region_3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_ingress_rule) | resource |
+| [random_password.database](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
+| [time_sleep.wait_for_database_writer](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_active_region_count"></a> [active\_region\_count](#input\_active\_region\_count) | Number of region slots actually deployed. Must be at least<br/>`length(var.regions) - 1` so that every Zeebe partition keeps a majority of<br/>its replicas, and at most `length(var.regions)`.<br/><br/>Deploying fewer regions than slots is the "growth" mode: the cluster runs<br/>with one replica missing per partition and tolerates no further region<br/>loss until the remaining regions are activated. | `number` | `3` | no |
+| <a name="input_aws_profile"></a> [aws\_profile](#input\_aws\_profile) | AWS Profile to use (null = use default credential chain) | `string` | `null` | no |
+| <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of the cluster to prefix resources. Each region appends its short\_name. | `string` | n/a | yes |
+| <a name="input_database_engine_version"></a> [database\_engine\_version](#input\_database\_engine\_version) | Aurora PostgreSQL engine version. Camunda 8.10 supports PostgreSQL 15 to 18. | `string` | `"17.9"` | no |
+| <a name="input_database_iam_auth_enabled"></a> [database\_iam\_auth\_enabled](#input\_database\_iam\_auth\_enabled) | Whether IAM database authentication is enabled on the Aurora clusters.<br/><br/>Kept off by default: the reference deployment authenticates with a password<br/>stored in a Kubernetes secret, which is the portable path that works with<br/>any RDBMS. Turning it on additionally requires IRSA roles carrying<br/>rds-db:connect for every regional cluster; see<br/>aws/kubernetes/eks-single-region-irsa for the IRSA pattern. | `bool` | `false` | no |
+| <a name="input_database_instance_class"></a> [database\_instance\_class](#input\_database\_instance\_class) | Instance class of the Aurora cluster instances | `string` | `"db.r6g.large"` | no |
+| <a name="input_database_instances_per_region"></a> [database\_instances\_per\_region](#input\_database\_instances\_per\_region) | Number of Aurora instances per region. Use at least 2 in production for intra-region failover. | `number` | `1` | no |
+| <a name="input_database_name"></a> [database\_name](#input\_database\_name) | Name of the database backing the Camunda secondary storage | `string` | `"camunda"` | no |
+| <a name="input_database_region_slots"></a> [database\_region\_slots](#input\_database\_region\_slots) | Region slots that host an Aurora Global Database member. The first entry is<br/>the writer. Must be a subset of the active region slots.<br/><br/>Defaults to two regions: Aurora Global Database is not available in every<br/>AWS region, and the Zeebe topology does not require a database member in<br/>each region. Brokers in regions without a member reach the writer over the<br/>Transit Gateway mesh. | `list(number)` | <pre>[<br/>  0,<br/>  1<br/>]</pre> | no |
+| <a name="input_database_username"></a> [database\_username](#input\_database\_username) | Master username of the Aurora Global Database | `string` | `"camunda"` | no |
+| <a name="input_default_tags"></a> [default\_tags](#input\_default\_tags) | Default tags to apply to all resources | `map(string)` | `{}` | no |
+| <a name="input_deploy_database"></a> [deploy\_database](#input\_deploy\_database) | Whether to create the Aurora Global Database. Set to false to bring your own RDBMS. | `bool` | `true` | no |
+| <a name="input_kubernetes_version"></a> [kubernetes\_version](#input\_kubernetes\_version) | Kubernetes version to use | `string` | `"1.36"` | no |
+| <a name="input_np_capacity_type"></a> [np\_capacity\_type](#input\_np\_capacity\_type) | Allows setting the capacity type to ON\_DEMAND or SPOT to determine stable nodes | `string` | `"ON_DEMAND"` | no |
+| <a name="input_np_desired_node_count"></a> [np\_desired\_node\_count](#input\_np\_desired\_node\_count) | Desired number of nodes in the node pool | `number` | `4` | no |
+| <a name="input_np_instance_types"></a> [np\_instance\_types](#input\_np\_instance\_types) | Instance types for the node pool | `list(string)` | <pre>[<br/>  "m6i.xlarge"<br/>]</pre> | no |
+| <a name="input_np_max_node_count"></a> [np\_max\_node\_count](#input\_np\_max\_node\_count) | Maximum number of nodes in the node pool | `number` | `10` | no |
+| <a name="input_regions"></a> [regions](#input\_regions) | Ordered list of region slots. Index 0 is region slot 0, index 1 is region<br/>slot 1, and so on. The list length is immutable for the lifetime of the<br/>Camunda cluster because it drives the Zeebe broker node ID stride.<br/><br/>`vpc_cidr_block` and `service_cidr_block` must not overlap across regions:<br/>Submariner is deployed without Globalnet, and Transit Gateway cannot route<br/>duplicate prefixes.<br/><br/>`short_name` is used to suffix cluster and resource names and must be a<br/>valid DNS label. | <pre>list(object({<br/>    region             = string<br/>    short_name         = string<br/>    vpc_cidr_block     = string<br/>    service_cidr_block = string<br/>  }))</pre> | <pre>[<br/>  {<br/>    "region": "eu-west-2",<br/>    "service_cidr_block": "10.190.0.0/16",<br/>    "short_name": "london",<br/>    "vpc_cidr_block": "10.192.0.0/16"<br/>  },<br/>  {<br/>    "region": "eu-west-3",<br/>    "service_cidr_block": "10.200.0.0/16",<br/>    "short_name": "paris",<br/>    "vpc_cidr_block": "10.202.0.0/16"<br/>  },<br/>  {<br/>    "region": "eu-central-2",<br/>    "service_cidr_block": "10.210.0.0/16",<br/>    "short_name": "zurich",<br/>    "vpc_cidr_block": "10.212.0.0/16"<br/>  }<br/>]</pre> | no |
+| <a name="input_single_nat_gateway"></a> [single\_nat\_gateway](#input\_single\_nat\_gateway) | If true, only one NAT gateway will be created to save on e.g. IPs, not good for HA | `bool` | `false` | no |
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_active_region_count"></a> [active\_region\_count](#output\_active\_region\_count) | Number of region slots currently deployed |
+| <a name="output_all_cidr_blocks"></a> [all\_cidr\_blocks](#output\_all\_cidr\_blocks) | Every VPC and Kubernetes service CIDR of the active regions, used to build database firewall rules |
+| <a name="output_camunda_rdbms_url"></a> [camunda\_rdbms\_url](#output\_camunda\_rdbms\_url) | JDBC URL for `orchestration.data.secondaryStorage.rdbms.url`.<br/><br/>It uses the AWS Advanced JDBC Wrapper with the `failover` plugin and the<br/>instance host patterns of every Aurora Global member, so that a global<br/>failover is followed transparently and Camunda never has to be<br/>reconfigured. Replace this URL with any single-writer endpoint to run the<br/>same architecture on a different database. |
+| <a name="output_cluster_names"></a> [cluster\_names](#output\_cluster\_names) | EKS cluster name per region slot |
+| <a name="output_database_cluster_identifiers"></a> [database\_cluster\_identifiers](#output\_database\_cluster\_identifiers) | Aurora cluster identifier per region slot hosting a database member |
+| <a name="output_database_global_cluster_id"></a> [database\_global\_cluster\_id](#output\_database\_global\_cluster\_id) | Identifier of the Aurora Global Database, consumed by the failover and failback procedures |
+| <a name="output_database_name"></a> [database\_name](#output\_database\_name) | Name of the database backing the Camunda secondary storage |
+| <a name="output_database_password"></a> [database\_password](#output\_database\_password) | Master password of the Aurora Global Database |
+| <a name="output_database_username"></a> [database\_username](#output\_database\_username) | Master username of the Aurora Global Database |
+| <a name="output_database_writer_endpoint"></a> [database\_writer\_endpoint](#output\_database\_writer\_endpoint) | Writer endpoint of the current Aurora Global Database primary |
+| <a name="output_oidc_provider_arns"></a> [oidc\_provider\_arns](#output\_oidc\_provider\_arns) | OIDC provider ARN per region slot, used to bind IRSA roles |
+| <a name="output_private_subnet_ids"></a> [private\_subnet\_ids](#output\_private\_subnet\_ids) | Private subnet IDs per region slot, used by the database root module |
+| <a name="output_region_slot_count"></a> [region\_slot\_count](#output\_region\_slot\_count) | Number of region slots. Feeds `global.multiregion.regions` in the Camunda<br/>Helm values and therefore the Zeebe broker node ID stride. Immutable for<br/>the lifetime of the Camunda cluster. |
+| <a name="output_regions"></a> [regions](#output\_regions) | Region slot definitions, indexed by slot number |
+| <a name="output_service_cidr_blocks"></a> [service\_cidr\_blocks](#output\_service\_cidr\_blocks) | Kubernetes service CIDR block per region slot |
+| <a name="output_transit_gateway_ids"></a> [transit\_gateway\_ids](#output\_transit\_gateway\_ids) | Transit Gateway ID per region slot |
+| <a name="output_vpc_cidr_blocks"></a> [vpc\_cidr\_blocks](#output\_vpc\_cidr\_blocks) | VPC CIDR block per region slot |
+| <a name="output_vpc_ids"></a> [vpc\_ids](#output\_vpc\_ids) | VPC ID per region slot |
+<!-- END_TF_DOCS -->

--- a/aws/kubernetes/eks-multi-region-rdbms/terraform/clusters/checks.tf
+++ b/aws/kubernetes/eks-multi-region-rdbms/terraform/clusters/checks.tf
@@ -1,0 +1,30 @@
+################################################################################
+# Topology guardrails                                                          #
+#                                                                              #
+# Terraform variable validation cannot reference another variable, so the       #
+# cross-variable invariants of the region topology are asserted here. `check`   #
+# blocks report during plan without blocking a destroy, which keeps the         #
+# reference architecture recoverable when a region is intentionally torn down.  #
+################################################################################
+
+check "active_region_count_within_slots" {
+  assert {
+    condition     = var.active_region_count <= local.region_slot_count
+    error_message = "active_region_count (${var.active_region_count}) exceeds the number of region slots (${local.region_slot_count}). Add a slot to var.regions first."
+  }
+}
+
+check "quorum_preserved_during_growth" {
+  assert {
+    condition     = var.active_region_count >= local.region_slot_count - 1
+    error_message = <<-EOT
+      active_region_count (${var.active_region_count}) leaves more than one region slot empty out of ${local.region_slot_count}.
+
+      With replicationFactor == number of region slots, each Zeebe partition
+      places exactly one replica per slot. Leaving two or more slots empty
+      means every partition loses its majority and the cluster cannot form a
+      quorum. Bootstrap with at least ${local.region_slot_count - 1} regions,
+      then activate the remaining one.
+    EOT
+  }
+}

--- a/aws/kubernetes/eks-multi-region-rdbms/terraform/clusters/clusters.tf
+++ b/aws/kubernetes/eks-multi-region-rdbms/terraform/clusters/clusters.tf
@@ -1,0 +1,111 @@
+################################################################################
+# Cluster creation, one EKS cluster per active region slot                     #
+#                                                                              #
+# Terraform providers cannot be iterated, so each slot is written out           #
+# explicitly and gated with `count`. Slots are activated in order, which keeps  #
+# the Zeebe region IDs and the AWS resource addresses stable when a region is   #
+# added later.                                                                 #
+################################################################################
+
+module "eks_cluster_region_0" {
+  # tflint-ignore: terraform_module_pinned_source
+  source = "../../../../modules/eks-cluster"
+
+  count = var.active_region_count > 0 ? 1 : 0
+
+  region                = var.regions[0].region
+  name                  = "${var.cluster_name}-${var.regions[0].short_name}"
+  kubernetes_version    = var.kubernetes_version
+  np_instance_types     = var.np_instance_types
+  np_capacity_type      = var.np_capacity_type
+  np_max_node_count     = var.np_max_node_count
+  np_desired_node_count = var.np_desired_node_count
+  single_nat_gateway    = var.single_nat_gateway
+
+  cluster_service_ipv4_cidr = var.regions[0].service_cidr_block
+  cluster_node_ipv4_cidr    = var.regions[0].vpc_cidr_block
+}
+
+module "eks_cluster_region_1" {
+  # tflint-ignore: terraform_module_pinned_source
+  source = "../../../../modules/eks-cluster"
+
+  count = var.active_region_count > 1 ? 1 : 0
+
+  region                = var.regions[1].region
+  name                  = "${var.cluster_name}-${var.regions[1].short_name}"
+  kubernetes_version    = var.kubernetes_version
+  np_instance_types     = var.np_instance_types
+  np_capacity_type      = var.np_capacity_type
+  np_max_node_count     = var.np_max_node_count
+  np_desired_node_count = var.np_desired_node_count
+  single_nat_gateway    = var.single_nat_gateway
+
+  cluster_service_ipv4_cidr = var.regions[1].service_cidr_block
+  cluster_node_ipv4_cidr    = var.regions[1].vpc_cidr_block
+
+  # Every resource of a non-default region must be pinned to its provider alias,
+  # otherwise it is silently created in the default region.
+  providers = {
+    aws = aws.region_1
+  }
+}
+
+module "eks_cluster_region_2" {
+  # tflint-ignore: terraform_module_pinned_source
+  source = "../../../../modules/eks-cluster"
+
+  count = var.active_region_count > 2 ? 1 : 0
+
+  region                = var.regions[2].region
+  name                  = "${var.cluster_name}-${var.regions[2].short_name}"
+  kubernetes_version    = var.kubernetes_version
+  np_instance_types     = var.np_instance_types
+  np_capacity_type      = var.np_capacity_type
+  np_max_node_count     = var.np_max_node_count
+  np_desired_node_count = var.np_desired_node_count
+  single_nat_gateway    = var.single_nat_gateway
+
+  cluster_service_ipv4_cidr = var.regions[2].service_cidr_block
+  cluster_node_ipv4_cidr    = var.regions[2].vpc_cidr_block
+
+  providers = {
+    aws = aws.region_2
+  }
+}
+
+module "eks_cluster_region_3" {
+  # tflint-ignore: terraform_module_pinned_source
+  source = "../../../../modules/eks-cluster"
+
+  count = var.active_region_count > 3 ? 1 : 0
+
+  region                = var.regions[3].region
+  name                  = "${var.cluster_name}-${var.regions[3].short_name}"
+  kubernetes_version    = var.kubernetes_version
+  np_instance_types     = var.np_instance_types
+  np_capacity_type      = var.np_capacity_type
+  np_max_node_count     = var.np_max_node_count
+  np_desired_node_count = var.np_desired_node_count
+  single_nat_gateway    = var.single_nat_gateway
+
+  cluster_service_ipv4_cidr = var.regions[3].service_cidr_block
+  cluster_node_ipv4_cidr    = var.regions[3].vpc_cidr_block
+
+  providers = {
+    aws = aws.region_3
+  }
+}
+
+locals {
+  # Uniform view over the count-gated modules so that the rest of the
+  # configuration can index by region slot instead of repeating ternaries.
+  clusters = {
+    for i, m in [
+      module.eks_cluster_region_0,
+      module.eks_cluster_region_1,
+      module.eks_cluster_region_2,
+      module.eks_cluster_region_3,
+    ] : i => one(m) if length(m) > 0
+  }
+}

--- a/aws/kubernetes/eks-multi-region-rdbms/terraform/clusters/config.tf
+++ b/aws/kubernetes/eks-multi-region-rdbms/terraform/clusters/config.tf
@@ -1,0 +1,74 @@
+################################
+# Backend & Provider Setup    #
+################################
+
+terraform {
+  required_version = ">= 1.6.0"
+
+  backend "s3" {
+    encrypt = true
+  }
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+    time = {
+      source  = "hashicorp/time"
+      version = "~> 0.13"
+    }
+  }
+}
+
+################################################################################
+# Provider slots                                                               #
+#                                                                              #
+# Terraform cannot generate provider configurations dynamically, so one alias   #
+# per region SLOT is declared statically. `local.region_slot_count` is derived  #
+# from `var.regions`; slots beyond that length fall back to region 0 and are    #
+# never used because every resource attached to them is count-gated to zero.    #
+#                                                                              #
+# Raising MAX_REGION_SLOTS is a mechanical change: add a provider block here,   #
+# a cluster module in clusters.tf, a Transit Gateway hub in                     #
+# transit-gateway.tf and the new peering pairs. See README.md.                  #
+################################################################################
+
+provider "aws" {
+  region  = var.regions[0].region
+  profile = var.aws_profile # optional, feel free to remove if you use the default profile
+  default_tags {
+    tags = var.default_tags
+  }
+}
+
+provider "aws" {
+  alias   = "region_1"
+  region  = try(var.regions[1].region, var.regions[0].region)
+  profile = var.aws_profile
+  default_tags {
+    tags = var.default_tags
+  }
+}
+
+provider "aws" {
+  alias   = "region_2"
+  region  = try(var.regions[2].region, var.regions[0].region)
+  profile = var.aws_profile
+  default_tags {
+    tags = var.default_tags
+  }
+}
+
+provider "aws" {
+  alias   = "region_3"
+  region  = try(var.regions[3].region, var.regions[0].region)
+  profile = var.aws_profile
+  default_tags {
+    tags = var.default_tags
+  }
+}

--- a/aws/kubernetes/eks-multi-region-rdbms/terraform/clusters/database.tf
+++ b/aws/kubernetes/eks-multi-region-rdbms/terraform/clusters/database.tf
@@ -1,0 +1,295 @@
+################################################################################
+# Secondary storage: Aurora Global Database                                    #
+#                                                                              #
+# Camunda 8.10 exposes exactly ONE JDBC connection per Orchestration Cluster    #
+# when RDBMS secondary storage is used, and the RDBMS exporter has no           #
+# multi-region mode. Replication is therefore delegated entirely to the         #
+# database, which is what makes this reference architecture replication         #
+# agnostic: Camunda only ever sees a single URL.                                #
+#                                                                              #
+# Aurora Global Database is the implementation exercised here, but any backend  #
+# exposing a single writer endpoint that survives a region loss works the same  #
+# way (Patroni + a floating endpoint, CockroachDB, AlloyDB, a managed proxy...). #
+# Set `deploy_database = false` and feed `CAMUNDA_RDBMS_URL` yourself to use     #
+# one.                                                                          #
+#                                                                              #
+# Note that the database regions are deliberately decoupled from the compute    #
+# regions: `database_region_slots` selects which region slots host a database   #
+# member. A three-region Zeebe cluster backed by a two-region Aurora Global      #
+# database is a valid and cheaper topology.                                     #
+################################################################################
+
+variable "deploy_database" {
+  type        = bool
+  default     = true
+  description = "Whether to create the Aurora Global Database. Set to false to bring your own RDBMS."
+}
+
+variable "database_region_slots" {
+  type        = list(number)
+  default     = [0, 1]
+  description = <<-EOT
+    Region slots that host an Aurora Global Database member. The first entry is
+    the writer. Must be a subset of the active region slots.
+
+    Defaults to two regions: Aurora Global Database is not available in every
+    AWS region, and the Zeebe topology does not require a database member in
+    each region. Brokers in regions without a member reach the writer over the
+    Transit Gateway mesh.
+  EOT
+
+  validation {
+    condition     = length(var.database_region_slots) >= 1 && length(var.database_region_slots) <= 4
+    error_message = "Between 1 and 4 database region slots are supported."
+  }
+
+  validation {
+    condition     = length(distinct(var.database_region_slots)) == length(var.database_region_slots)
+    error_message = "database_region_slots must not contain duplicates."
+  }
+}
+
+variable "database_name" {
+  type        = string
+  default     = "camunda"
+  description = "Name of the database backing the Camunda secondary storage"
+}
+
+variable "database_username" {
+  type        = string
+  default     = "camunda"
+  description = "Master username of the Aurora Global Database"
+  sensitive   = true
+}
+
+variable "database_engine_version" {
+  type = string
+  # renovate: datasource=custom.aurora-pg-camunda depName=aurora-postgresql versioning=loose
+  default     = "17.9"
+  description = "Aurora PostgreSQL engine version. Camunda 8.10 supports PostgreSQL 15 to 18."
+}
+
+variable "database_instance_class" {
+  type        = string
+  default     = "db.r6g.large"
+  description = "Instance class of the Aurora cluster instances"
+}
+
+variable "database_instances_per_region" {
+  type        = number
+  default     = 1
+  description = "Number of Aurora instances per region. Use at least 2 in production for intra-region failover."
+}
+
+variable "database_iam_auth_enabled" {
+  type        = bool
+  default     = false
+  description = <<-EOT
+    Whether IAM database authentication is enabled on the Aurora clusters.
+
+    Kept off by default: the reference deployment authenticates with a password
+    stored in a Kubernetes secret, which is the portable path that works with
+    any RDBMS. Turning it on additionally requires IRSA roles carrying
+    rds-db:connect for every regional cluster; see
+    aws/kubernetes/eks-single-region-irsa for the IRSA pattern.
+  EOT
+}
+
+check "database_region_slots_are_active" {
+  assert {
+    condition     = alltrue([for slot in var.database_region_slots : slot < var.active_region_count])
+    error_message = "database_region_slots must only reference region slots that are active (active_region_count = ${var.active_region_count})."
+  }
+}
+
+################################
+# Credentials                  #
+################################
+
+resource "random_password" "database" {
+  count = var.deploy_database ? 1 : 0
+
+  length           = 32
+  special          = true
+  override_special = "!#%&*()-_=+[]{}:?"
+}
+
+################################
+# Global cluster               #
+################################
+
+resource "aws_rds_global_cluster" "camunda" {
+  count = var.deploy_database ? 1 : 0
+
+  global_cluster_identifier = "${var.cluster_name}-global-db"
+  engine                    = "aurora-postgresql"
+  engine_version            = var.database_engine_version
+  database_name             = var.database_name
+  storage_encrypted         = true
+}
+
+locals {
+  database_enabled = var.deploy_database
+
+  # Every CIDR that must be able to reach the database. Brokers in regions
+  # without a local member connect to the writer across the Transit Gateway.
+  database_allowed_cidr_blocks = concat(local.active_vpc_cidr_blocks, local.active_svc_cidr_blocks)
+
+  database_writer_slot = try(var.database_region_slots[0], 0)
+
+  database_member_enabled = {
+    for i in range(4) : i => local.database_enabled && contains(var.database_region_slots, i)
+  }
+}
+
+################################################################################
+# Regional members                                                             #
+#                                                                              #
+# `is_primary` marks the writer. Secondary members must be created after the    #
+# primary is available, otherwise AWS creates them standalone and refuses to    #
+# attach them to the global cluster afterwards.                                 #
+################################################################################
+
+module "database_region_0" {
+  # tflint-ignore: terraform_module_pinned_source
+  source = "../../../../modules/aurora-global-member"
+
+  count = local.database_member_enabled[0] ? 1 : 0
+
+  cluster_identifier        = "${var.cluster_name}-${var.regions[0].short_name}-db"
+  global_cluster_identifier = one(aws_rds_global_cluster.camunda[*].id)
+  is_primary                = local.database_writer_slot == 0
+
+  engine_version = var.database_engine_version
+  instance_class = var.database_instance_class
+  num_instances  = var.database_instances_per_region
+
+  database_name      = var.database_name
+  master_username    = local.database_writer_slot == 0 ? var.database_username : null
+  master_password    = local.database_writer_slot == 0 ? one(random_password.database[*].result) : null
+  availability_zones = local.database_writer_slot == 0 ? local.clusters[0].vpc_azs : null
+
+  vpc_id              = local.clusters[0].vpc_id
+  subnet_ids          = local.clusters[0].private_subnet_ids
+  allowed_cidr_blocks = local.database_allowed_cidr_blocks
+  iam_auth_enabled    = var.database_iam_auth_enabled
+}
+
+# Secondary members wait for the writer to settle before attaching.
+resource "time_sleep" "wait_for_database_writer" {
+  count = local.database_enabled ? 1 : 0
+
+  depends_on      = [module.database_region_0]
+  create_duration = "30s"
+}
+
+module "database_region_1" {
+  # tflint-ignore: terraform_module_pinned_source
+  source = "../../../../modules/aurora-global-member"
+
+  count = local.database_member_enabled[1] ? 1 : 0
+
+  cluster_identifier        = "${var.cluster_name}-${var.regions[1].short_name}-db"
+  global_cluster_identifier = one(aws_rds_global_cluster.camunda[*].id)
+  is_primary                = local.database_writer_slot == 1
+
+  engine_version = var.database_engine_version
+  instance_class = var.database_instance_class
+  num_instances  = var.database_instances_per_region
+
+  database_name      = var.database_name
+  master_username    = local.database_writer_slot == 1 ? var.database_username : null
+  master_password    = local.database_writer_slot == 1 ? one(random_password.database[*].result) : null
+  availability_zones = local.database_writer_slot == 1 ? local.clusters[1].vpc_azs : null
+
+  vpc_id              = local.clusters[1].vpc_id
+  subnet_ids          = local.clusters[1].private_subnet_ids
+  allowed_cidr_blocks = local.database_allowed_cidr_blocks
+  iam_auth_enabled    = var.database_iam_auth_enabled
+
+  providers = {
+    aws = aws.region_1
+  }
+
+  depends_on = [time_sleep.wait_for_database_writer]
+}
+
+module "database_region_2" {
+  # tflint-ignore: terraform_module_pinned_source
+  source = "../../../../modules/aurora-global-member"
+
+  count = local.database_member_enabled[2] ? 1 : 0
+
+  cluster_identifier        = "${var.cluster_name}-${var.regions[2].short_name}-db"
+  global_cluster_identifier = one(aws_rds_global_cluster.camunda[*].id)
+  is_primary                = local.database_writer_slot == 2
+
+  engine_version = var.database_engine_version
+  instance_class = var.database_instance_class
+  num_instances  = var.database_instances_per_region
+
+  database_name      = var.database_name
+  master_username    = local.database_writer_slot == 2 ? var.database_username : null
+  master_password    = local.database_writer_slot == 2 ? one(random_password.database[*].result) : null
+  availability_zones = local.database_writer_slot == 2 ? local.clusters[2].vpc_azs : null
+
+  vpc_id              = local.clusters[2].vpc_id
+  subnet_ids          = local.clusters[2].private_subnet_ids
+  allowed_cidr_blocks = local.database_allowed_cidr_blocks
+  iam_auth_enabled    = var.database_iam_auth_enabled
+
+  providers = {
+    aws = aws.region_2
+  }
+
+  depends_on = [time_sleep.wait_for_database_writer]
+}
+
+module "database_region_3" {
+  # tflint-ignore: terraform_module_pinned_source
+  source = "../../../../modules/aurora-global-member"
+
+  count = local.database_member_enabled[3] ? 1 : 0
+
+  cluster_identifier        = "${var.cluster_name}-${var.regions[3].short_name}-db"
+  global_cluster_identifier = one(aws_rds_global_cluster.camunda[*].id)
+  is_primary                = local.database_writer_slot == 3
+
+  engine_version = var.database_engine_version
+  instance_class = var.database_instance_class
+  num_instances  = var.database_instances_per_region
+
+  database_name      = var.database_name
+  master_username    = local.database_writer_slot == 3 ? var.database_username : null
+  master_password    = local.database_writer_slot == 3 ? one(random_password.database[*].result) : null
+  availability_zones = local.database_writer_slot == 3 ? local.clusters[3].vpc_azs : null
+
+  vpc_id              = local.clusters[3].vpc_id
+  subnet_ids          = local.clusters[3].private_subnet_ids
+  allowed_cidr_blocks = local.database_allowed_cidr_blocks
+  iam_auth_enabled    = var.database_iam_auth_enabled
+
+  providers = {
+    aws = aws.region_3
+  }
+
+  depends_on = [time_sleep.wait_for_database_writer]
+}
+
+locals {
+  database_members = {
+    for i, m in [
+      module.database_region_0,
+      module.database_region_1,
+      module.database_region_2,
+      module.database_region_3,
+    ] : i => one(m) if length(m) > 0
+  }
+
+  # Instance host patterns for the AWS Advanced JDBC Wrapper. Passing every
+  # member lets the driver discover the new writer after a global failover
+  # without any change to the Camunda configuration.
+  database_host_patterns = join(",", [for m in values(local.database_members) : m.instance_host_pattern])
+
+  database_writer_endpoint = try(local.database_members[local.database_writer_slot].endpoint, null)
+}

--- a/aws/kubernetes/eks-multi-region-rdbms/terraform/clusters/outputs.tf
+++ b/aws/kubernetes/eks-multi-region-rdbms/terraform/clusters/outputs.tf
@@ -1,0 +1,121 @@
+################################################################################
+# Outputs                                                                      #
+#                                                                              #
+# Everything downstream (the database root module, the procedure scripts and    #
+# the integration tests) consumes region-indexed maps rather than               #
+# `region_0_*` scalars, so adding a region does not rename an output.           #
+################################################################################
+
+output "region_slot_count" {
+  description = <<-EOT
+    Number of region slots. Feeds `global.multiregion.regions` in the Camunda
+    Helm values and therefore the Zeebe broker node ID stride. Immutable for
+    the lifetime of the Camunda cluster.
+  EOT
+  value       = local.region_slot_count
+}
+
+output "active_region_count" {
+  description = "Number of region slots currently deployed"
+  value       = var.active_region_count
+}
+
+output "regions" {
+  description = "Region slot definitions, indexed by slot number"
+  value       = { for i in local.active_indices : i => var.regions[i] }
+}
+
+output "cluster_names" {
+  description = "EKS cluster name per region slot"
+  value       = { for i in local.active_indices : i => "${var.cluster_name}-${var.regions[i].short_name}" }
+}
+
+output "vpc_ids" {
+  description = "VPC ID per region slot"
+  value       = { for i, c in local.clusters : i => c.vpc_id }
+}
+
+output "private_subnet_ids" {
+  description = "Private subnet IDs per region slot, used by the database root module"
+  value       = { for i, c in local.clusters : i => c.private_subnet_ids }
+}
+
+output "vpc_cidr_blocks" {
+  description = "VPC CIDR block per region slot"
+  value       = { for i in local.active_indices : i => var.regions[i].vpc_cidr_block }
+}
+
+output "service_cidr_blocks" {
+  description = "Kubernetes service CIDR block per region slot"
+  value       = { for i in local.active_indices : i => var.regions[i].service_cidr_block }
+}
+
+output "oidc_provider_arns" {
+  description = "OIDC provider ARN per region slot, used to bind IRSA roles"
+  value       = { for i, c in local.clusters : i => c.oidc_provider_arn }
+}
+
+output "transit_gateway_ids" {
+  description = "Transit Gateway ID per region slot"
+  value       = { for i, h in local.tgw_hubs : i => h.transit_gateway_id }
+}
+
+output "all_cidr_blocks" {
+  description = "Every VPC and Kubernetes service CIDR of the active regions, used to build database firewall rules"
+  value       = concat(local.active_vpc_cidr_blocks, local.active_svc_cidr_blocks)
+}
+
+################################
+# Secondary storage            #
+################################
+
+output "database_global_cluster_id" {
+  description = "Identifier of the Aurora Global Database, consumed by the failover and failback procedures"
+  value       = one(aws_rds_global_cluster.camunda[*].id)
+}
+
+output "database_writer_endpoint" {
+  description = "Writer endpoint of the current Aurora Global Database primary"
+  value       = local.database_writer_endpoint
+}
+
+output "database_cluster_identifiers" {
+  description = "Aurora cluster identifier per region slot hosting a database member"
+  value       = { for i, m in local.database_members : i => m.cluster_identifier }
+}
+
+output "database_name" {
+  description = "Name of the database backing the Camunda secondary storage"
+  value       = var.database_name
+}
+
+output "database_username" {
+  description = "Master username of the Aurora Global Database"
+  value       = var.database_username
+  sensitive   = true
+}
+
+output "database_password" {
+  description = "Master password of the Aurora Global Database"
+  value       = one(random_password.database[*].result)
+  sensitive   = true
+}
+
+output "camunda_rdbms_url" {
+  description = <<-EOT
+    JDBC URL for `orchestration.data.secondaryStorage.rdbms.url`.
+
+    It uses the AWS Advanced JDBC Wrapper with the `failover` plugin and the
+    instance host patterns of every Aurora Global member, so that a global
+    failover is followed transparently and Camunda never has to be
+    reconfigured. Replace this URL with any single-writer endpoint to run the
+    same architecture on a different database.
+  EOT
+  value = local.database_enabled ? format(
+    "jdbc:aws-wrapper:postgresql://%s:5432/%s?wrapperPlugins=%sfailover&globalClusterInstanceHostPatterns=%s",
+    local.database_writer_endpoint,
+    var.database_name,
+    var.database_iam_auth_enabled ? "iam," : "",
+    local.database_host_patterns,
+  ) : null
+}

--- a/aws/kubernetes/eks-multi-region-rdbms/terraform/clusters/security.tf
+++ b/aws/kubernetes/eks-multi-region-rdbms/terraform/clusters/security.tf
@@ -1,0 +1,195 @@
+################################################################################
+# Cross-region firewall rules                                                  #
+#                                                                              #
+# The dual-region reference architecture opens every protocol between the two   #
+# peered VPCs. Here the rules are explicit instead, because the port list is    #
+# the most useful piece of documentation for anyone reproducing a Submariner    #
+# deployment on EKS, and because the surface grows with every added region.     #
+#                                                                              #
+# Rules are attached to the EKS-managed primary security group, which is the    #
+# security group carried by the managed node group instances. Submariner runs   #
+# on the host network of the gateway nodes, so node-level rules are what        #
+# matters for the IPsec tunnels.                                                #
+################################################################################
+
+locals {
+  # Submariner data plane. Matches the rule set validated on ROSA in
+  # aws/openshift/rosa-hcp-dual-region/terraform/peering/peering.tf, which uses
+  # the same libreswan cable driver.
+  submariner_rules = [
+    {
+      key         = "submariner-vxlan"
+      from_port   = 4800
+      to_port     = 4800
+      ip_protocol = "udp"
+      description = "Submariner pod traffic encapsulation (VXLAN)"
+    },
+    {
+      key         = "submariner-natt"
+      from_port   = 4500
+      to_port     = 4500
+      ip_protocol = "udp"
+      description = "Submariner IPsec NAT traversal encapsulation (NAT-T)"
+    },
+    {
+      key         = "submariner-natt-discovery"
+      from_port   = 4490
+      to_port     = 4490
+      ip_protocol = "udp"
+      description = "Submariner NAT traversal discovery"
+    },
+    {
+      key         = "submariner-ike"
+      from_port   = 500
+      to_port     = 500
+      ip_protocol = "udp"
+      description = "IPsec IKE negotiation for the Submariner tunnels"
+    },
+    {
+      key         = "submariner-esp"
+      from_port   = null
+      to_port     = null
+      ip_protocol = "50"
+      description = "ESP, the encrypted payload of the Submariner IPsec tunnels"
+    },
+    {
+      key         = "submariner-metrics"
+      from_port   = 8080
+      to_port     = 8080
+      ip_protocol = "tcp"
+      description = "Submariner gateway metrics and health endpoint"
+    },
+  ]
+
+  # Camunda Orchestration Cluster. Zeebe brokers form a single Raft cluster
+  # stretched across every region, so these must be reachable region to region.
+  camunda_rules = [
+    {
+      key         = "zeebe-gateway-grpc"
+      from_port   = 26500
+      to_port     = 26500
+      ip_protocol = "tcp"
+      description = "Zeebe gateway gRPC API"
+    },
+    {
+      key         = "zeebe-command-api"
+      from_port   = 26501
+      to_port     = 26501
+      ip_protocol = "tcp"
+      description = "Zeebe broker command API"
+    },
+    {
+      key         = "zeebe-internal-api"
+      from_port   = 26502
+      to_port     = 26502
+      ip_protocol = "tcp"
+      description = "Zeebe broker internal API, carries Raft replication across regions"
+    },
+    {
+      key         = "orchestration-rest"
+      from_port   = 8080
+      to_port     = 8080
+      ip_protocol = "tcp"
+      description = "Orchestration Cluster v2 REST API"
+    },
+    {
+      key         = "orchestration-management"
+      from_port   = 9600
+      to_port     = 9600
+      ip_protocol = "tcp"
+      description = "Orchestration Cluster management API, used by the failover and scaling procedures"
+    },
+    {
+      key         = "kubernetes-dns"
+      from_port   = 53
+      to_port     = 53
+      ip_protocol = "udp"
+      description = "CoreDNS and Submariner Lighthouse DNS resolution"
+    },
+    {
+      key         = "kubernetes-dns-tcp"
+      from_port   = 53
+      to_port     = 53
+      ip_protocol = "tcp"
+      description = "CoreDNS and Submariner Lighthouse DNS resolution over TCP"
+    },
+    {
+      key         = "icmp"
+      from_port   = -1
+      to_port     = -1
+      ip_protocol = "icmp"
+      description = "ICMP, required by the Submariner connectivity diagnostics"
+    },
+  ]
+
+  cross_region_rules = concat(local.submariner_rules, local.camunda_rules)
+
+  # (region slot, remote CIDR, rule) triples, flattened into one map per region
+  # so that each aws_vpc_security_group_ingress_rule resource can for_each it.
+  ingress_rules_by_region = {
+    for i in local.active_indices : i => {
+      for entry in flatten([
+        for cidr in local.remote_cidr_blocks[i] : [
+          for rule in local.cross_region_rules : {
+            key         = "${rule.key}|${cidr}"
+            cidr        = cidr
+            from_port   = rule.from_port
+            to_port     = rule.to_port
+            ip_protocol = rule.ip_protocol
+            description = rule.description
+          }
+        ]
+      ]) : entry.key => entry
+    }
+  }
+}
+
+resource "aws_vpc_security_group_ingress_rule" "region_0" {
+  for_each = var.active_region_count > 0 ? local.ingress_rules_by_region[0] : {}
+
+  security_group_id = local.clusters[0].cluster_primary_security_group_id
+  cidr_ipv4         = each.value.cidr
+  from_port         = each.value.from_port
+  to_port           = each.value.to_port
+  ip_protocol       = each.value.ip_protocol
+  description       = each.value.description
+}
+
+resource "aws_vpc_security_group_ingress_rule" "region_1" {
+  provider = aws.region_1
+
+  for_each = var.active_region_count > 1 ? local.ingress_rules_by_region[1] : {}
+
+  security_group_id = local.clusters[1].cluster_primary_security_group_id
+  cidr_ipv4         = each.value.cidr
+  from_port         = each.value.from_port
+  to_port           = each.value.to_port
+  ip_protocol       = each.value.ip_protocol
+  description       = each.value.description
+}
+
+resource "aws_vpc_security_group_ingress_rule" "region_2" {
+  provider = aws.region_2
+
+  for_each = var.active_region_count > 2 ? local.ingress_rules_by_region[2] : {}
+
+  security_group_id = local.clusters[2].cluster_primary_security_group_id
+  cidr_ipv4         = each.value.cidr
+  from_port         = each.value.from_port
+  to_port           = each.value.to_port
+  ip_protocol       = each.value.ip_protocol
+  description       = each.value.description
+}
+
+resource "aws_vpc_security_group_ingress_rule" "region_3" {
+  provider = aws.region_3
+
+  for_each = var.active_region_count > 3 ? local.ingress_rules_by_region[3] : {}
+
+  security_group_id = local.clusters[3].cluster_primary_security_group_id
+  cidr_ipv4         = each.value.cidr
+  from_port         = each.value.from_port
+  to_port           = each.value.to_port
+  ip_protocol       = each.value.ip_protocol
+  description       = each.value.description
+}

--- a/aws/kubernetes/eks-multi-region-rdbms/terraform/clusters/test/golden/golden.tfvars
+++ b/aws/kubernetes/eks-multi-region-rdbms/terraform/clusters/test/golden/golden.tfvars
@@ -1,0 +1,12 @@
+# Golden plan inputs.
+#
+# The plan is rendered with `just regenerate-golden-file` and compared against
+# tfplan-golden.json by the golden workflow. Keep this minimal: every value here
+# is an input the golden plan is pinned to.
+#
+# `active_region_count` is deliberately the full slot count so that the golden
+# plan covers every region, every Transit Gateway peering and both database
+# members.
+aws_profile         = null
+cluster_name        = "camunda"
+active_region_count = 3

--- a/aws/kubernetes/eks-multi-region-rdbms/terraform/clusters/transit-gateway.tf
+++ b/aws/kubernetes/eks-multi-region-rdbms/terraform/clusters/transit-gateway.tf
@@ -1,0 +1,237 @@
+################################################################################
+# Cross-region L3 connectivity: Transit Gateway full mesh                      #
+#                                                                              #
+# Transit Gateway peering is point-to-point and NOT transitive: traffic cannot  #
+# hop through an intermediate Transit Gateway. An N-region topology therefore   #
+# needs N hubs and N*(N-1)/2 peerings.                                          #
+#                                                                              #
+# Transit Gateway is used instead of the VPC peering mesh of the dual-region    #
+# reference architecture because it keeps a single attachment per VPC as        #
+# regions are added, and because the same hub can later carry on-premises or    #
+# Direct Connect attachments.                                                   #
+################################################################################
+
+module "tgw_hub_region_0" {
+  # tflint-ignore: terraform_module_pinned_source
+  source = "../../../../modules/transit-gateway-hub"
+
+  count = var.active_region_count > 0 ? 1 : 0
+
+  name       = "${var.cluster_name}-${var.regions[0].short_name}"
+  vpc_id     = local.clusters[0].vpc_id
+  subnet_ids = local.clusters[0].private_subnet_ids
+  vpc_route_table_ids = concat(
+    [local.clusters[0].vpc_main_route_table_id],
+    local.clusters[0].private_route_table_ids,
+  )
+  remote_cidr_blocks = local.remote_cidr_blocks[0]
+}
+
+module "tgw_hub_region_1" {
+  # tflint-ignore: terraform_module_pinned_source
+  source = "../../../../modules/transit-gateway-hub"
+
+  count = var.active_region_count > 1 ? 1 : 0
+
+  name       = "${var.cluster_name}-${var.regions[1].short_name}"
+  vpc_id     = local.clusters[1].vpc_id
+  subnet_ids = local.clusters[1].private_subnet_ids
+  vpc_route_table_ids = concat(
+    [local.clusters[1].vpc_main_route_table_id],
+    local.clusters[1].private_route_table_ids,
+  )
+  remote_cidr_blocks = local.remote_cidr_blocks[1]
+
+  providers = {
+    aws = aws.region_1
+  }
+}
+
+module "tgw_hub_region_2" {
+  # tflint-ignore: terraform_module_pinned_source
+  source = "../../../../modules/transit-gateway-hub"
+
+  count = var.active_region_count > 2 ? 1 : 0
+
+  name       = "${var.cluster_name}-${var.regions[2].short_name}"
+  vpc_id     = local.clusters[2].vpc_id
+  subnet_ids = local.clusters[2].private_subnet_ids
+  vpc_route_table_ids = concat(
+    [local.clusters[2].vpc_main_route_table_id],
+    local.clusters[2].private_route_table_ids,
+  )
+  remote_cidr_blocks = local.remote_cidr_blocks[2]
+
+  providers = {
+    aws = aws.region_2
+  }
+}
+
+module "tgw_hub_region_3" {
+  # tflint-ignore: terraform_module_pinned_source
+  source = "../../../../modules/transit-gateway-hub"
+
+  count = var.active_region_count > 3 ? 1 : 0
+
+  name       = "${var.cluster_name}-${var.regions[3].short_name}"
+  vpc_id     = local.clusters[3].vpc_id
+  subnet_ids = local.clusters[3].private_subnet_ids
+  vpc_route_table_ids = concat(
+    [local.clusters[3].vpc_main_route_table_id],
+    local.clusters[3].private_route_table_ids,
+  )
+  remote_cidr_blocks = local.remote_cidr_blocks[3]
+
+  providers = {
+    aws = aws.region_3
+  }
+}
+
+locals {
+  tgw_hubs = {
+    for i, m in [
+      module.tgw_hub_region_0,
+      module.tgw_hub_region_1,
+      module.tgw_hub_region_2,
+      module.tgw_hub_region_3,
+    ] : i => one(m) if length(m) > 0
+  }
+}
+
+################################################################################
+# Peering mesh                                                                 #
+#                                                                              #
+# Pairs are ordered (i < j) so that adding a region only appends new peerings.  #
+################################################################################
+
+module "tgw_peering_0_1" {
+  # tflint-ignore: terraform_module_pinned_source
+  source = "../../../../modules/transit-gateway-peering"
+
+  count = var.active_region_count > 1 ? 1 : 0
+
+  name = "${var.cluster_name}-${var.regions[0].short_name}-${var.regions[1].short_name}"
+
+  owner_transit_gateway_id             = local.tgw_hubs[0].transit_gateway_id
+  owner_transit_gateway_route_table_id = local.tgw_hubs[0].transit_gateway_route_table_id
+  owner_cidr_blocks                    = local.region_cidr_blocks[0]
+
+  accepter_transit_gateway_id             = local.tgw_hubs[1].transit_gateway_id
+  accepter_transit_gateway_route_table_id = local.tgw_hubs[1].transit_gateway_route_table_id
+  accepter_cidr_blocks                    = local.region_cidr_blocks[1]
+
+  providers = {
+    aws.owner    = aws
+    aws.accepter = aws.region_1
+  }
+}
+
+module "tgw_peering_0_2" {
+  # tflint-ignore: terraform_module_pinned_source
+  source = "../../../../modules/transit-gateway-peering"
+
+  count = var.active_region_count > 2 ? 1 : 0
+
+  name = "${var.cluster_name}-${var.regions[0].short_name}-${var.regions[2].short_name}"
+
+  owner_transit_gateway_id             = local.tgw_hubs[0].transit_gateway_id
+  owner_transit_gateway_route_table_id = local.tgw_hubs[0].transit_gateway_route_table_id
+  owner_cidr_blocks                    = local.region_cidr_blocks[0]
+
+  accepter_transit_gateway_id             = local.tgw_hubs[2].transit_gateway_id
+  accepter_transit_gateway_route_table_id = local.tgw_hubs[2].transit_gateway_route_table_id
+  accepter_cidr_blocks                    = local.region_cidr_blocks[2]
+
+  providers = {
+    aws.owner    = aws
+    aws.accepter = aws.region_2
+  }
+}
+
+module "tgw_peering_1_2" {
+  # tflint-ignore: terraform_module_pinned_source
+  source = "../../../../modules/transit-gateway-peering"
+
+  count = var.active_region_count > 2 ? 1 : 0
+
+  name = "${var.cluster_name}-${var.regions[1].short_name}-${var.regions[2].short_name}"
+
+  owner_transit_gateway_id             = local.tgw_hubs[1].transit_gateway_id
+  owner_transit_gateway_route_table_id = local.tgw_hubs[1].transit_gateway_route_table_id
+  owner_cidr_blocks                    = local.region_cidr_blocks[1]
+
+  accepter_transit_gateway_id             = local.tgw_hubs[2].transit_gateway_id
+  accepter_transit_gateway_route_table_id = local.tgw_hubs[2].transit_gateway_route_table_id
+  accepter_cidr_blocks                    = local.region_cidr_blocks[2]
+
+  providers = {
+    aws.owner    = aws.region_1
+    aws.accepter = aws.region_2
+  }
+}
+
+module "tgw_peering_0_3" {
+  # tflint-ignore: terraform_module_pinned_source
+  source = "../../../../modules/transit-gateway-peering"
+
+  count = var.active_region_count > 3 ? 1 : 0
+
+  name = "${var.cluster_name}-${var.regions[0].short_name}-${var.regions[3].short_name}"
+
+  owner_transit_gateway_id             = local.tgw_hubs[0].transit_gateway_id
+  owner_transit_gateway_route_table_id = local.tgw_hubs[0].transit_gateway_route_table_id
+  owner_cidr_blocks                    = local.region_cidr_blocks[0]
+
+  accepter_transit_gateway_id             = local.tgw_hubs[3].transit_gateway_id
+  accepter_transit_gateway_route_table_id = local.tgw_hubs[3].transit_gateway_route_table_id
+  accepter_cidr_blocks                    = local.region_cidr_blocks[3]
+
+  providers = {
+    aws.owner    = aws
+    aws.accepter = aws.region_3
+  }
+}
+
+module "tgw_peering_1_3" {
+  # tflint-ignore: terraform_module_pinned_source
+  source = "../../../../modules/transit-gateway-peering"
+
+  count = var.active_region_count > 3 ? 1 : 0
+
+  name = "${var.cluster_name}-${var.regions[1].short_name}-${var.regions[3].short_name}"
+
+  owner_transit_gateway_id             = local.tgw_hubs[1].transit_gateway_id
+  owner_transit_gateway_route_table_id = local.tgw_hubs[1].transit_gateway_route_table_id
+  owner_cidr_blocks                    = local.region_cidr_blocks[1]
+
+  accepter_transit_gateway_id             = local.tgw_hubs[3].transit_gateway_id
+  accepter_transit_gateway_route_table_id = local.tgw_hubs[3].transit_gateway_route_table_id
+  accepter_cidr_blocks                    = local.region_cidr_blocks[3]
+
+  providers = {
+    aws.owner    = aws.region_1
+    aws.accepter = aws.region_3
+  }
+}
+
+module "tgw_peering_2_3" {
+  # tflint-ignore: terraform_module_pinned_source
+  source = "../../../../modules/transit-gateway-peering"
+
+  count = var.active_region_count > 3 ? 1 : 0
+
+  name = "${var.cluster_name}-${var.regions[2].short_name}-${var.regions[3].short_name}"
+
+  owner_transit_gateway_id             = local.tgw_hubs[2].transit_gateway_id
+  owner_transit_gateway_route_table_id = local.tgw_hubs[2].transit_gateway_route_table_id
+  owner_cidr_blocks                    = local.region_cidr_blocks[2]
+
+  accepter_transit_gateway_id             = local.tgw_hubs[3].transit_gateway_id
+  accepter_transit_gateway_route_table_id = local.tgw_hubs[3].transit_gateway_route_table_id
+  accepter_cidr_blocks                    = local.region_cidr_blocks[3]
+
+  providers = {
+    aws.owner    = aws.region_2
+    aws.accepter = aws.region_3
+  }
+}

--- a/aws/kubernetes/eks-multi-region-rdbms/terraform/clusters/variables.tf
+++ b/aws/kubernetes/eks-multi-region-rdbms/terraform/clusters/variables.tf
@@ -1,0 +1,204 @@
+################################################################################
+# Region topology                                                              #
+#                                                                              #
+# `var.regions` describes the REGION SLOTS of the cluster. The number of slots  #
+# is baked into the Zeebe broker identity by the Camunda Helm chart:            #
+#                                                                              #
+#     nodeId = statefulSetOrdinal * global.multiregion.regions + regionId       #
+#                                                                              #
+# Changing the number of slots therefore renumbers every broker and is a        #
+# destructive operation. Pick the slot count up front, then bring regions       #
+# online one at a time with `var.active_region_count`.                          #
+#                                                                              #
+# See ../../README.md, section "Region slots vs active regions".                #
+################################################################################
+
+variable "regions" {
+  description = <<-EOT
+    Ordered list of region slots. Index 0 is region slot 0, index 1 is region
+    slot 1, and so on. The list length is immutable for the lifetime of the
+    Camunda cluster because it drives the Zeebe broker node ID stride.
+
+    `vpc_cidr_block` and `service_cidr_block` must not overlap across regions:
+    Submariner is deployed without Globalnet, and Transit Gateway cannot route
+    duplicate prefixes.
+
+    `short_name` is used to suffix cluster and resource names and must be a
+    valid DNS label.
+  EOT
+
+  type = list(object({
+    region             = string
+    short_name         = string
+    vpc_cidr_block     = string
+    service_cidr_block = string
+  }))
+
+  default = [
+    {
+      region             = "eu-west-2" # London
+      short_name         = "london"
+      vpc_cidr_block     = "10.192.0.0/16" # VPC, node and pod range
+      service_cidr_block = "10.190.0.0/16" # Kubernetes service range
+    },
+    {
+      region             = "eu-west-3" # Paris
+      short_name         = "paris"
+      vpc_cidr_block     = "10.202.0.0/16"
+      service_cidr_block = "10.200.0.0/16"
+    },
+    {
+      region             = "eu-central-2" # Zurich
+      short_name         = "zurich"
+      vpc_cidr_block     = "10.212.0.0/16"
+      service_cidr_block = "10.210.0.0/16"
+    },
+    # Slot 3 is wired but disabled by default. Uncomment to bootstrap a
+    # four-region cluster, and raise `replication_factor` in the Helm values
+    # accordingly. See ../../README.md.
+    # {
+    #   region             = "eu-south-1" # Milan
+    #   short_name         = "milan"
+    #   vpc_cidr_block     = "10.222.0.0/16"
+    #   service_cidr_block = "10.220.0.0/16"
+    # },
+  ]
+
+  validation {
+    condition     = length(var.regions) >= 2 && length(var.regions) <= 4
+    error_message = "Between 2 and 4 region slots are supported. Raising the upper bound requires adding provider aliases in config.tf; see README.md."
+  }
+
+  validation {
+    condition     = length(distinct([for r in var.regions : r.region])) == length(var.regions)
+    error_message = "Each region slot must use a distinct AWS region."
+  }
+
+  validation {
+    condition     = length(distinct([for r in var.regions : r.short_name])) == length(var.regions)
+    error_message = "Each region slot must use a distinct short_name; it is used to suffix cluster names."
+  }
+
+  validation {
+    condition     = length(distinct([for r in var.regions : r.vpc_cidr_block])) == length(var.regions)
+    error_message = "Each region slot must use a distinct VPC CIDR block: Submariner runs without Globalnet and Transit Gateway cannot route duplicate prefixes."
+  }
+
+  validation {
+    condition     = length(distinct([for r in var.regions : r.service_cidr_block])) == length(var.regions)
+    error_message = "Each region slot must use a distinct Kubernetes service CIDR block."
+  }
+}
+
+variable "active_region_count" {
+  description = <<-EOT
+    Number of region slots actually deployed. Must be at least
+    `length(var.regions) - 1` so that every Zeebe partition keeps a majority of
+    its replicas, and at most `length(var.regions)`.
+
+    Deploying fewer regions than slots is the "growth" mode: the cluster runs
+    with one replica missing per partition and tolerates no further region
+    loss until the remaining regions are activated.
+  EOT
+
+  type    = number
+  default = 3
+
+  validation {
+    condition     = var.active_region_count >= 2
+    error_message = "At least two regions must be active."
+  }
+}
+
+# Cross-validation between the two variables above lives in checks.tf, because
+# a variable validation block cannot reference another variable.
+
+################################
+# Variables                    #
+################################
+
+variable "cluster_name" {
+  type        = string
+  description = "Name of the cluster to prefix resources. Each region appends its short_name."
+}
+
+variable "aws_profile" {
+  type        = string
+  description = "AWS Profile to use (null = use default credential chain)"
+  default     = null
+}
+
+variable "kubernetes_version" {
+  type        = string
+  description = "Kubernetes version to use"
+  # renovate: datasource=endoflife-date depName=amazon-eks versioning=loose
+  default = "1.36"
+}
+
+variable "np_instance_types" {
+  type        = list(string)
+  description = "Instance types for the node pool"
+  default     = ["m6i.xlarge"]
+}
+
+variable "np_capacity_type" {
+  type        = string
+  default     = "ON_DEMAND"
+  description = "Allows setting the capacity type to ON_DEMAND or SPOT to determine stable nodes"
+}
+
+variable "np_max_node_count" {
+  type        = number
+  default     = 10
+  description = "Maximum number of nodes in the node pool"
+}
+
+variable "np_desired_node_count" {
+  type        = number
+  default     = 4
+  description = "Desired number of nodes in the node pool"
+}
+
+variable "single_nat_gateway" {
+  type        = bool
+  default     = false
+  description = "If true, only one NAT gateway will be created to save on e.g. IPs, not good for HA"
+}
+
+variable "default_tags" {
+  type        = map(string)
+  default     = {}
+  description = "Default tags to apply to all resources"
+}
+
+################################
+# Derived values               #
+################################
+
+locals {
+  region_slot_count = length(var.regions)
+
+  # Indices of the regions that are actually deployed.
+  active_indices = range(var.active_region_count)
+
+  # CIDRs that must be routable from every region. Kubernetes service CIDRs are
+  # included because Submariner Lighthouse resolves ClusterSetIPs out of the
+  # service range of the exporting cluster.
+  active_vpc_cidr_blocks = [for i in local.active_indices : var.regions[i].vpc_cidr_block]
+  active_svc_cidr_blocks = [for i in local.active_indices : var.regions[i].service_cidr_block]
+
+  # Every CIDR owned by region `i`, used to build routes and firewall rules.
+  region_cidr_blocks = {
+    for i in local.active_indices : i => [
+      var.regions[i].vpc_cidr_block,
+      var.regions[i].service_cidr_block,
+    ]
+  }
+
+  # CIDRs owned by every region except `i`.
+  remote_cidr_blocks = {
+    for i in local.active_indices : i => flatten([
+      for j in local.active_indices : local.region_cidr_blocks[j] if j != i
+    ])
+  }
+}

--- a/aws/kubernetes/eks-multi-region-rdbms/test/go.mod
+++ b/aws/kubernetes/eks-multi-region-rdbms/test/go.mod
@@ -1,0 +1,3 @@
+module multiregionrdbmstests
+
+go 1.26.0

--- a/aws/kubernetes/eks-multi-region-rdbms/test/helpers/procedure.go
+++ b/aws/kubernetes/eks-multi-region-rdbms/test/helpers/procedure.go
@@ -1,0 +1,151 @@
+// Package helpers provides thin wrappers used by the multi-region RDBMS
+// integration tests.
+//
+// The tests deliberately drive the shell procedures under ../../procedure
+// instead of reimplementing them in Go. That keeps a single source of truth:
+// what CI validates is exactly what a user copy-pastes from the documentation,
+// and a bug in a procedure fails the test instead of hiding behind a Go
+// reimplementation of the same logic.
+package helpers
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// ProcedureDir returns the absolute path of the procedure directory.
+func ProcedureDir(t *testing.T) string {
+	t.Helper()
+
+	dir, err := filepath.Abs(filepath.Join("..", "procedure"))
+	if err != nil {
+		t.Fatalf("cannot resolve the procedure directory: %v", err)
+	}
+	return dir
+}
+
+// Env is the environment contract shared by every procedure.
+type Env struct {
+	RegionSlots        int
+	ActiveRegions      int
+	BrokersPerRegion   int
+	ClusterContexts    []string
+	AWSRegions         []string
+	SubmarinerClusters []string
+	Namespace          string
+	ReleaseName        string
+	RdbmsURL           string
+	RdbmsUsername      string
+	RdbmsPassword      string
+	AuroraGlobalID     string
+	Extra              map[string]string
+}
+
+// Vars renders the environment as a KEY=VALUE slice suitable for exec.Cmd.
+func (e Env) Vars() []string {
+	clusterSize := e.BrokersPerRegion * e.RegionSlots
+
+	vars := map[string]string{
+		"CAMUNDA_REGION_SLOTS":        fmt.Sprint(e.RegionSlots),
+		"CAMUNDA_ACTIVE_REGIONS":      fmt.Sprint(e.ActiveRegions),
+		"CAMUNDA_BROKERS_PER_REGION":  fmt.Sprint(e.BrokersPerRegion),
+		"CAMUNDA_CLUSTER_SIZE":        fmt.Sprint(clusterSize),
+		"CAMUNDA_PARTITION_COUNT":     fmt.Sprint(clusterSize),
+		"CAMUNDA_REPLICATION_FACTOR":  fmt.Sprint(e.RegionSlots),
+		"CLUSTER_CONTEXTS":            strings.Join(e.ClusterContexts, " "),
+		"AWS_REGIONS":                 strings.Join(e.AWSRegions, " "),
+		"SUBMARINER_CLUSTER_IDS":      strings.Join(e.SubmarinerClusters, " "),
+		"CAMUNDA_NAMESPACE":           e.Namespace,
+		"CAMUNDA_RELEASE_NAME":        e.ReleaseName,
+		"CAMUNDA_RDBMS_URL":           e.RdbmsURL,
+		"CAMUNDA_RDBMS_USERNAME":      e.RdbmsUsername,
+		"CAMUNDA_RDBMS_PASSWORD":      e.RdbmsPassword,
+		"AURORA_GLOBAL_CLUSTER_ID":    e.AuroraGlobalID,
+		"CAMUNDA_BASIC_AUTH_USER":     GetEnv("CAMUNDA_BASIC_AUTH_USER", "demo"),
+		"CAMUNDA_BASIC_AUTH_PASSWORD": GetEnv("CAMUNDA_BASIC_AUTH_PASSWORD", "demo"),
+	}
+	for k, v := range e.Extra {
+		vars[k] = v
+	}
+
+	out := os.Environ()
+	for k, v := range vars {
+		out = append(out, k+"="+v)
+	}
+	return out
+}
+
+// RunProcedure executes a procedure script and fails the test on a non-zero
+// exit status. Output is streamed to the test log so that a CI failure carries
+// the script output rather than only its exit code.
+func RunProcedure(t *testing.T, env Env, timeout time.Duration, script string, args ...string) string {
+	t.Helper()
+
+	dir := ProcedureDir(t)
+	path := filepath.Join(dir, script)
+
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("procedure %s does not exist: %v", script, err)
+	}
+
+	cmd := exec.Command("bash", append([]string{path}, args...)...)
+	cmd.Dir = dir
+	cmd.Env = env.Vars()
+
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+
+	done := make(chan error, 1)
+	start := time.Now()
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("cannot start %s: %v", script, err)
+	}
+	go func() { done <- cmd.Wait() }()
+
+	select {
+	case err := <-done:
+		t.Logf("=== %s (%s) ===\n%s", script, time.Since(start).Round(time.Second), buf.String())
+		if err != nil {
+			t.Fatalf("%s failed: %v", script, err)
+		}
+	case <-time.After(timeout):
+		_ = cmd.Process.Kill()
+		t.Logf("=== %s (timed out) ===\n%s", script, buf.String())
+		t.Fatalf("%s did not finish within %s", script, timeout)
+	}
+
+	return buf.String()
+}
+
+// RunProcedureAllowFailure behaves like RunProcedure but reports the error
+// instead of failing, for diagnostics wired into a cleanup path.
+func RunProcedureAllowFailure(t *testing.T, env Env, timeout time.Duration, script string, args ...string) {
+	t.Helper()
+
+	dir := ProcedureDir(t)
+	cmd := exec.Command("bash", append([]string{filepath.Join(dir, script)}, args...)...)
+	cmd.Dir = dir
+	cmd.Env = env.Vars()
+
+	out, err := cmd.CombinedOutput()
+	t.Logf("=== %s (best effort) ===\n%s", script, string(out))
+	if err != nil {
+		t.Logf("%s returned %v (ignored)", script, err)
+	}
+	_ = timeout
+}
+
+// GetEnv reads an environment variable with a fallback.
+func GetEnv(key, fallback string) string {
+	if v, ok := os.LookupEnv(key); ok && v != "" {
+		return v
+	}
+	return fallback
+}

--- a/aws/kubernetes/eks-multi-region-rdbms/test/helpers/terraform.go
+++ b/aws/kubernetes/eks-multi-region-rdbms/test/helpers/terraform.go
@@ -1,0 +1,133 @@
+package helpers
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// TerraformOutputs is the subset of the terraform/clusters outputs the tests
+// consume. Region-indexed outputs are maps keyed by the region slot as a
+// string, which keeps adding a region from renaming anything.
+type TerraformOutputs struct {
+	RegionSlotCount   int
+	ActiveRegionCount int
+	AWSRegions        []string
+	ShortNames        []string
+	ClusterNames      []string
+	RdbmsURL          string
+	RdbmsUsername     string
+	RdbmsPassword     string
+	AuroraGlobalID    string
+}
+
+type tfValue struct {
+	Value json.RawMessage `json:"value"`
+}
+
+type tfRegion struct {
+	Region    string `json:"region"`
+	ShortName string `json:"short_name"`
+}
+
+// ReadTerraformOutputs runs `terraform output -json` once and decodes it.
+// A single invocation is used on purpose: each `terraform output` call takes
+// the state lock.
+func ReadTerraformOutputs(t *testing.T, terraformDir string) TerraformOutputs {
+	t.Helper()
+
+	binary := GetEnv("TESTS_TF_BINARY_NAME", "terraform")
+	cmd := exec.Command(binary, "-chdir="+terraformDir, "output", "-json")
+	cmd.Env = os.Environ()
+
+	raw, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("terraform output failed in %s: %v", terraformDir, err)
+	}
+
+	var outputs map[string]tfValue
+	if err := json.Unmarshal(raw, &outputs); err != nil {
+		t.Fatalf("cannot decode terraform outputs: %v", err)
+	}
+
+	decode := func(key string, target any) {
+		v, ok := outputs[key]
+		if !ok {
+			t.Fatalf("terraform output %q is missing; did the apply succeed?", key)
+		}
+		if err := json.Unmarshal(v.Value, target); err != nil {
+			t.Fatalf("cannot decode terraform output %q: %v", key, err)
+		}
+	}
+
+	decodeOptionalString := func(key string) string {
+		v, ok := outputs[key]
+		if !ok {
+			return ""
+		}
+		var s string
+		if err := json.Unmarshal(v.Value, &s); err != nil {
+			return ""
+		}
+		return s
+	}
+
+	result := TerraformOutputs{}
+	decode("region_slot_count", &result.RegionSlotCount)
+	decode("active_region_count", &result.ActiveRegionCount)
+
+	regions := map[string]tfRegion{}
+	decode("regions", &regions)
+
+	clusterNames := map[string]string{}
+	decode("cluster_names", &clusterNames)
+
+	for i := 0; i < result.ActiveRegionCount; i++ {
+		key := fmt.Sprint(i)
+		region, ok := regions[key]
+		if !ok {
+			t.Fatalf("terraform output regions has no entry for slot %d", i)
+		}
+		result.AWSRegions = append(result.AWSRegions, region.Region)
+		result.ShortNames = append(result.ShortNames, region.ShortName)
+		result.ClusterNames = append(result.ClusterNames, clusterNames[key])
+	}
+
+	result.RdbmsURL = decodeOptionalString("camunda_rdbms_url")
+	result.RdbmsUsername = decodeOptionalString("database_username")
+	result.RdbmsPassword = decodeOptionalString("database_password")
+	result.AuroraGlobalID = decodeOptionalString("database_global_cluster_id")
+
+	return result
+}
+
+// UpdateKubeConfig registers one kubectl context per active region, aliased to
+// the names the procedures expect.
+func UpdateKubeConfig(t *testing.T, outputs TerraformOutputs, contexts []string) {
+	t.Helper()
+
+	if len(contexts) < len(outputs.ClusterNames) {
+		t.Fatalf("got %d context aliases for %d clusters", len(contexts), len(outputs.ClusterNames))
+	}
+
+	for i, name := range outputs.ClusterNames {
+		args := []string{
+			"eks", "--region", outputs.AWSRegions[i],
+			"update-kubeconfig", "--name", name,
+			"--alias", contexts[i],
+		}
+		if profile := os.Getenv("AWS_PROFILE"); profile != "" {
+			args = append(args, "--profile", profile)
+		}
+
+		cmd := exec.Command("aws", args...)
+		out, err := cmd.CombinedOutput()
+		t.Logf("aws %s\n%s", strings.Join(args, " "), string(out))
+		if err != nil {
+			t.Fatalf("cannot register the kubectl context for %s: %v", name, err)
+		}
+	}
+}

--- a/aws/kubernetes/eks-multi-region-rdbms/test/multi_region_test.go
+++ b/aws/kubernetes/eks-multi-region-rdbms/test/multi_region_test.go
@@ -1,0 +1,193 @@
+// Integration tests for the AWS EKS multi-region RDBMS reference architecture.
+//
+// The suite is written as a sequence of independently runnable tests so that a
+// failure can be resumed without recreating the whole infrastructure, which
+// takes about 40 minutes. CI runs them in the order below; locally, run the one
+// you care about after the environment exists.
+//
+//	TestMultiRegionKubeConfig       register kubectl contexts
+//	TestMultiRegionSubmariner       build the ClusterSet mesh
+//	TestMultiRegionDeployCamunda    install Camunda in every active region
+//	TestMultiRegionTopology         assert the expected broker distribution
+//	TestMultiRegionActivateRegion   grow the cluster by one region, online
+//	TestMultiRegionRegionLoss       lose a region and keep processing
+//	TestMultiRegionFailback         bring the region back
+//	TestMultiRegionCleanup          uninstall Camunda
+//
+// Infrastructure lifecycle (terraform apply and destroy) is intentionally NOT
+// part of the suite: it is driven by the reusable CI actions so that a failed
+// test run still hits the same teardown path as every other reference
+// architecture.
+package multiregionrdbmstests
+
+import (
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"multiregionrdbmstests/helpers"
+)
+
+const terraformDir = "../terraform/clusters"
+
+func testEnv(t *testing.T) helpers.Env {
+	t.Helper()
+
+	outputs := helpers.ReadTerraformOutputs(t, terraformDir)
+
+	contexts := splitList(helpers.GetEnv("CLUSTER_CONTEXTS", ""))
+	if len(contexts) == 0 {
+		// Default aliases mirror the region short names, which is what
+		// export-terraform-outputs.sh produces.
+		for _, short := range outputs.ShortNames {
+			contexts = append(contexts, "cluster-"+short)
+		}
+	}
+
+	activeRegions := outputs.ActiveRegionCount
+	if v := os.Getenv("CAMUNDA_ACTIVE_REGIONS"); v != "" {
+		parsed, err := strconv.Atoi(v)
+		if err != nil {
+			t.Fatalf("CAMUNDA_ACTIVE_REGIONS is not a number: %v", err)
+		}
+		activeRegions = parsed
+	}
+
+	brokersPerRegion, err := strconv.Atoi(helpers.GetEnv("CAMUNDA_BROKERS_PER_REGION", "2"))
+	if err != nil {
+		t.Fatalf("CAMUNDA_BROKERS_PER_REGION is not a number: %v", err)
+	}
+
+	return helpers.Env{
+		RegionSlots:        outputs.RegionSlotCount,
+		ActiveRegions:      activeRegions,
+		BrokersPerRegion:   brokersPerRegion,
+		ClusterContexts:    contexts,
+		AWSRegions:         outputs.AWSRegions,
+		SubmarinerClusters: outputs.ShortNames,
+		Namespace:          helpers.GetEnv("CAMUNDA_NAMESPACE", "camunda"),
+		ReleaseName:        helpers.GetEnv("CAMUNDA_RELEASE_NAME", "camunda"),
+		RdbmsURL:           outputs.RdbmsURL,
+		RdbmsUsername:      outputs.RdbmsUsername,
+		RdbmsPassword:      outputs.RdbmsPassword,
+		AuroraGlobalID:     outputs.AuroraGlobalID,
+	}
+}
+
+func splitList(value string) []string {
+	if strings.TrimSpace(value) == "" {
+		return nil
+	}
+	return strings.Fields(value)
+}
+
+// TestMultiRegionKubeConfig registers one kubectl context per active region.
+func TestMultiRegionKubeConfig(t *testing.T) {
+	env := testEnv(t)
+	outputs := helpers.ReadTerraformOutputs(t, terraformDir)
+	helpers.UpdateKubeConfig(t, outputs, env.ClusterContexts)
+}
+
+// TestMultiRegionSubmariner builds the Submariner ClusterSet and asserts that
+// every cluster holds N-1 established tunnels.
+func TestMultiRegionSubmariner(t *testing.T) {
+	env := testEnv(t)
+
+	helpers.RunProcedure(t, env, 10*time.Minute, "storageclass-configure.sh")
+	helpers.RunProcedure(t, env, 2*time.Minute, "storageclass-verify.sh")
+
+	helpers.RunProcedure(t, env, 5*time.Minute, "submariner/label-gateway-nodes.sh")
+	helpers.RunProcedure(t, env, 10*time.Minute, "submariner/deploy-broker.sh")
+	helpers.RunProcedure(t, env, 20*time.Minute, "submariner/join-clusters.sh")
+	helpers.RunProcedure(t, env, 20*time.Minute, "submariner/verify-submariner.sh")
+}
+
+// TestMultiRegionDeployCamunda installs Camunda in every active region.
+func TestMultiRegionDeployCamunda(t *testing.T) {
+	env := testEnv(t)
+
+	if env.RdbmsURL == "" {
+		t.Fatal("terraform output camunda_rdbms_url is empty; the database is required for this architecture")
+	}
+
+	helpers.RunProcedure(t, env, 5*time.Minute, "setup-namespaces.sh")
+	helpers.RunProcedure(t, env, 5*time.Minute, "create-rdbms-secret.sh")
+	helpers.RunProcedure(t, env, 30*time.Minute, "deploy.sh")
+	helpers.RunProcedure(t, env, 15*time.Minute, "submariner/export-services.sh")
+}
+
+// TestMultiRegionTopology asserts the multi-region broker distribution:
+// clusterSize brokers, one replica of every partition per region, no unhealthy
+// partition.
+func TestMultiRegionTopology(t *testing.T) {
+	env := testEnv(t)
+
+	defer helpers.RunProcedureAllowFailure(t, env, 5*time.Minute, "submariner/diagnose-submariner.sh")
+	helpers.RunProcedure(t, env, 30*time.Minute, "check-cluster-topology.sh")
+}
+
+// TestMultiRegionActivateRegion grows the cluster by one region while it is
+// serving traffic. It only runs when the infrastructure was bootstrapped with a
+// spare region slot, which is the growth scenario described in the README.
+func TestMultiRegionActivateRegion(t *testing.T) {
+	env := testEnv(t)
+
+	if env.ActiveRegions >= env.RegionSlots {
+		t.Skipf("every region slot is already active (%d/%d), nothing to activate",
+			env.ActiveRegions, env.RegionSlots)
+	}
+
+	slot := env.ActiveRegions
+	env.ActiveRegions = slot + 1
+
+	defer helpers.RunProcedureAllowFailure(t, env, 5*time.Minute, "submariner/diagnose-submariner.sh")
+	helpers.RunProcedure(t, env, 45*time.Minute, "activate-region.sh", strconv.Itoa(slot))
+}
+
+// TestMultiRegionRegionLoss simulates the loss of one region and asserts that
+// the workflow engine keeps its quorum. This is the property the whole
+// architecture exists for, and the one that distinguishes it from the
+// dual-region setup, where the same event halts processing.
+func TestMultiRegionRegionLoss(t *testing.T) {
+	env := testEnv(t)
+
+	if env.ActiveRegions < 3 {
+		t.Skipf("need at least 3 active regions to survive a region loss, have %d", env.ActiveRegions)
+	}
+
+	// The last slot is torn down: the first one drives the management API and
+	// hosts the Submariner broker.
+	lostSlot := env.ActiveRegions - 1
+
+	defer helpers.RunProcedureAllowFailure(t, env, 5*time.Minute, "submariner/diagnose-submariner.sh")
+
+	helpers.RunProcedure(t, env, 15*time.Minute, "simulate-region-loss.sh", strconv.Itoa(lostSlot))
+	helpers.RunProcedure(t, env, 20*time.Minute, "failover.sh", strconv.Itoa(lostSlot))
+
+	// The topology check must still pass for the surviving regions, which is
+	// exactly what "the cluster keeps processing" means here.
+	helpers.RunProcedure(t, env, 20*time.Minute, "verify-degraded-cluster.sh", strconv.Itoa(lostSlot))
+}
+
+// TestMultiRegionFailback brings the lost region back.
+func TestMultiRegionFailback(t *testing.T) {
+	env := testEnv(t)
+
+	if env.ActiveRegions < 3 {
+		t.Skipf("need at least 3 active regions, have %d", env.ActiveRegions)
+	}
+
+	lostSlot := env.ActiveRegions - 1
+
+	defer helpers.RunProcedureAllowFailure(t, env, 5*time.Minute, "submariner/diagnose-submariner.sh")
+	helpers.RunProcedure(t, env, 45*time.Minute, "failback.sh", strconv.Itoa(lostSlot))
+}
+
+// TestMultiRegionCleanup uninstalls Camunda from every region so that the
+// Terraform destroy is not blocked by Kubernetes-managed cloud resources.
+func TestMultiRegionCleanup(t *testing.T) {
+	env := testEnv(t)
+	helpers.RunProcedureAllowFailure(t, env, 20*time.Minute, "cleanup.sh")
+}

--- a/aws/modules/aurora-global-member/README.md
+++ b/aws/modules/aurora-global-member/README.md
@@ -1,0 +1,53 @@
+# aurora-global-member
+
+<!-- BEGIN_TF_DOCS -->
+## Modules
+
+No modules.
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [aws_db_subnet_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_subnet_group) | resource |
+| [aws_kms_key.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
+| [aws_rds_cluster.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster) | resource |
+| [aws_rds_cluster_instance.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster_instance) | resource |
+| [aws_security_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_allowed_cidr_blocks"></a> [allowed\_cidr\_blocks](#input\_allowed\_cidr\_blocks) | CIDR blocks allowed to reach the database. Must contain every participating region VPC CIDR, because brokers in any region connect to the current global writer. | `list(string)` | n/a | yes |
+| <a name="input_apply_immediately"></a> [apply\_immediately](#input\_apply\_immediately) | Whether modifications are applied immediately instead of during the maintenance window | `bool` | `true` | no |
+| <a name="input_auto_minor_version_upgrade"></a> [auto\_minor\_version\_upgrade](#input\_auto\_minor\_version\_upgrade) | Whether minor engine upgrades are applied automatically during the maintenance window | `bool` | `true` | no |
+| <a name="input_availability_zones"></a> [availability\_zones](#input\_availability\_zones) | Availability zones of the regional cluster. Only honoured on the primary member. | `list(string)` | `null` | no |
+| <a name="input_backup_retention_period"></a> [backup\_retention\_period](#input\_backup\_retention\_period) | Number of days automated backups are retained | `number` | `7` | no |
+| <a name="input_ca_cert_identifier"></a> [ca\_cert\_identifier](#input\_ca\_cert\_identifier) | Certificate authority used by the cluster instances | `string` | `"rds-ca-rsa2048-g1"` | no |
+| <a name="input_cluster_identifier"></a> [cluster\_identifier](#input\_cluster\_identifier) | Identifier of the regional Aurora cluster. Format: /[[:lower:][:digit:]-]/ | `string` | n/a | yes |
+| <a name="input_database_name"></a> [database\_name](#input\_database\_name) | Name of the initial database. Only honoured on the primary member. | `string` | `"camunda"` | no |
+| <a name="input_engine"></a> [engine](#input\_engine) | Aurora engine type. Only aurora-postgresql is exercised by the reference architecture. | `string` | `"aurora-postgresql"` | no |
+| <a name="input_engine_version"></a> [engine\_version](#input\_engine\_version) | Aurora engine version. Must match the version of the global cluster. | `string` | `"17.9"` | no |
+| <a name="input_global_cluster_identifier"></a> [global\_cluster\_identifier](#input\_global\_cluster\_identifier) | ID of the aws\_rds\_global\_cluster this regional cluster joins | `string` | n/a | yes |
+| <a name="input_iam_auth_enabled"></a> [iam\_auth\_enabled](#input\_iam\_auth\_enabled) | Whether IAM database authentication is enabled. Recommended: the AWS JDBC wrapper iam plugin removes the need to distribute a password. | `bool` | `true` | no |
+| <a name="input_instance_class"></a> [instance\_class](#input\_instance\_class) | Instance class of the Aurora cluster instances | `string` | `"db.r6g.large"` | no |
+| <a name="input_is_primary"></a> [is\_primary](#input\_is\_primary) | Whether this member is the writer (primary) of the global cluster. Exactly one member must set this to true. | `bool` | `false` | no |
+| <a name="input_master_password"></a> [master\_password](#input\_master\_password) | Master password. Only honoured on the primary member. | `string` | `null` | no |
+| <a name="input_master_username"></a> [master\_username](#input\_master\_username) | Master username. Only honoured on the primary member. | `string` | `null` | no |
+| <a name="input_num_instances"></a> [num\_instances](#input\_num\_instances) | Number of Aurora instances in this region. Use at least 2 in production for intra-region failover. | `number` | `1` | no |
+| <a name="input_port"></a> [port](#input\_port) | Database port | `number` | `5432` | no |
+| <a name="input_skip_final_snapshot"></a> [skip\_final\_snapshot](#input\_skip\_final\_snapshot) | Whether the final snapshot is skipped on destroy. Kept true for the reference architecture, which is disposable. | `bool` | `true` | no |
+| <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | Subnet IDs used for the Aurora DB subnet group | `list(string)` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | Tags applied to every resource created by this module | `map(string)` | `{}` | no |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | ID of the VPC the Aurora security group is created in | `string` | n/a | yes |
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_cluster_arn"></a> [cluster\_arn](#output\_cluster\_arn) | ARN of the regional Aurora cluster |
+| <a name="output_cluster_identifier"></a> [cluster\_identifier](#output\_cluster\_identifier) | Identifier of the regional Aurora cluster |
+| <a name="output_cluster_resource_id"></a> [cluster\_resource\_id](#output\_cluster\_resource\_id) | Immutable resource ID of the cluster, used to build rds-db:connect IAM policies |
+| <a name="output_endpoint"></a> [endpoint](#output\_endpoint) | Writer endpoint of the regional cluster |
+| <a name="output_instance_host_pattern"></a> [instance\_host\_pattern](#output\_instance\_host\_pattern) | Instance host pattern for the AWS Advanced JDBC Wrapper<br/>globalClusterInstanceHostPatterns parameter. The `?` placeholder is<br/>substituted with the instance identifier by the driver, which is how it<br/>enumerates the instances of every region after a global failover. |
+| <a name="output_reader_endpoint"></a> [reader\_endpoint](#output\_reader\_endpoint) | Reader endpoint of the regional cluster |
+| <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | ID of the security group attached to the regional cluster |
+<!-- END_TF_DOCS -->

--- a/aws/modules/aurora-global-member/main.tf
+++ b/aws/modules/aurora-global-member/main.tf
@@ -1,0 +1,125 @@
+###############################################################################
+# One regional member of an Aurora Global Database                            #
+#                                                                             #
+# This module deliberately owns a SINGLE region so that an N-region topology   #
+# can be built by instantiating it once per region with the matching provider  #
+# alias. The `aws_rds_global_cluster` resource itself stays in the caller,     #
+# because it is a global (region-less) object that must exist exactly once.    #
+#                                                                             #
+# Compared to `aws/modules/aurora-global` (hardcoded primary + one secondary), #
+# this module is the building block used by the multi-region reference         #
+# architecture, where Aurora Global can hold up to five secondary regions.     #
+###############################################################################
+
+resource "aws_kms_key" "this" {
+  description             = "${var.cluster_identifier}-key"
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+
+  tags = var.tags
+}
+
+resource "aws_db_subnet_group" "this" {
+  name        = var.cluster_identifier
+  description = "Subnet group for Aurora cluster ${var.cluster_identifier}"
+  subnet_ids  = var.subnet_ids
+
+  tags = var.tags
+}
+
+resource "aws_security_group" "this" {
+  name        = "${var.cluster_identifier}-aurora"
+  description = "Security group for Aurora cluster ${var.cluster_identifier}"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    from_port   = var.port
+    to_port     = var.port
+    protocol    = "TCP"
+    cidr_blocks = var.allowed_cidr_blocks
+    description = "Allow PostgreSQL from every participating region"
+  }
+
+  egress {
+    from_port   = var.port
+    to_port     = var.port
+    protocol    = "TCP"
+    cidr_blocks = var.allowed_cidr_blocks
+    description = "Allow PostgreSQL to every participating region"
+  }
+
+  tags = merge(var.tags, {
+    Name = "${var.cluster_identifier}-aurora"
+  })
+}
+
+###############################################################################
+# Regional cluster                                                            #
+#                                                                             #
+# Secondary members intentionally omit master_username / master_password /     #
+# database_name / availability_zones: those are inherited from the global      #
+# cluster through replication and AWS rejects them on a secondary.            #
+###############################################################################
+
+resource "aws_rds_cluster" "this" {
+  cluster_identifier        = var.cluster_identifier
+  global_cluster_identifier = var.global_cluster_identifier
+  engine                    = var.engine
+  engine_version            = var.engine_version
+
+  availability_zones = var.is_primary ? var.availability_zones : null
+  master_username    = var.is_primary ? var.master_username : null
+  master_password    = var.is_primary ? var.master_password : null
+  database_name      = var.is_primary ? var.database_name : null
+
+  storage_encrypted       = true
+  kms_key_id              = aws_kms_key.this.arn
+  vpc_security_group_ids  = [aws_security_group.this.id]
+  db_subnet_group_name    = aws_db_subnet_group.this.name
+  backup_retention_period = var.backup_retention_period
+  skip_final_snapshot     = var.skip_final_snapshot
+  apply_immediately       = var.apply_immediately
+  copy_tags_to_snapshot   = true
+
+  iam_database_authentication_enabled = var.iam_auth_enabled
+
+  tags = var.tags
+
+  lifecycle {
+    prevent_destroy = false
+
+    # See aws/modules/aurora-global/main.tf for the full rationale. In short,
+    # the provider plans to clear these attributes on a secondary member, which
+    # AWS translates into PromoteReadReplicaDBCluster and silently detaches the
+    # member from the global cluster. Ignoring them is harmless on the primary
+    # (they are either unset or driven by the global cluster) which lets a
+    # single module serve both roles.
+    ignore_changes = [
+      replication_source_identifier,
+      global_cluster_identifier,
+      engine_version,
+      availability_zones,
+    ]
+  }
+}
+
+resource "aws_rds_cluster_instance" "this" {
+  count = var.num_instances
+
+  cluster_identifier         = aws_rds_cluster.this.id
+  identifier                 = "${var.cluster_identifier}-${count.index}"
+  engine                     = var.engine
+  engine_version             = var.engine_version
+  auto_minor_version_upgrade = var.auto_minor_version_upgrade
+  instance_class             = var.instance_class
+  ca_cert_identifier         = var.ca_cert_identifier
+  db_subnet_group_name       = aws_db_subnet_group.this.name
+  apply_immediately          = var.apply_immediately
+  copy_tags_to_snapshot      = true
+
+  tags = var.tags
+
+  lifecycle {
+    prevent_destroy = false
+  }
+}

--- a/aws/modules/aurora-global-member/outputs.tf
+++ b/aws/modules/aurora-global-member/outputs.tf
@@ -1,0 +1,39 @@
+output "cluster_identifier" {
+  description = "Identifier of the regional Aurora cluster"
+  value       = aws_rds_cluster.this.cluster_identifier
+}
+
+output "cluster_arn" {
+  description = "ARN of the regional Aurora cluster"
+  value       = aws_rds_cluster.this.arn
+}
+
+output "cluster_resource_id" {
+  description = "Immutable resource ID of the cluster, used to build rds-db:connect IAM policies"
+  value       = aws_rds_cluster.this.cluster_resource_id
+}
+
+output "endpoint" {
+  description = "Writer endpoint of the regional cluster"
+  value       = aws_rds_cluster.this.endpoint
+}
+
+output "reader_endpoint" {
+  description = "Reader endpoint of the regional cluster"
+  value       = aws_rds_cluster.this.reader_endpoint
+}
+
+output "instance_host_pattern" {
+  description = <<-EOT
+    Instance host pattern for the AWS Advanced JDBC Wrapper
+    globalClusterInstanceHostPatterns parameter. The `?` placeholder is
+    substituted with the instance identifier by the driver, which is how it
+    enumerates the instances of every region after a global failover.
+  EOT
+  value       = "?.${replace(aws_rds_cluster.this.endpoint, "${aws_rds_cluster.this.cluster_identifier}.cluster-", "")}"
+}
+
+output "security_group_id" {
+  description = "ID of the security group attached to the regional cluster"
+  value       = aws_security_group.this.id
+}

--- a/aws/modules/aurora-global-member/variables.tf
+++ b/aws/modules/aurora-global-member/variables.tf
@@ -1,0 +1,129 @@
+variable "cluster_identifier" {
+  description = "Identifier of the regional Aurora cluster. Format: /[[:lower:][:digit:]-]/"
+  type        = string
+}
+
+variable "global_cluster_identifier" {
+  description = "ID of the aws_rds_global_cluster this regional cluster joins"
+  type        = string
+}
+
+variable "is_primary" {
+  description = "Whether this member is the writer (primary) of the global cluster. Exactly one member must set this to true."
+  type        = bool
+  default     = false
+}
+
+variable "engine" {
+  description = "Aurora engine type. Only aurora-postgresql is exercised by the reference architecture."
+  type        = string
+  default     = "aurora-postgresql"
+}
+
+variable "engine_version" {
+  description = "Aurora engine version. Must match the version of the global cluster."
+  type        = string
+  # renovate: datasource=custom.aurora-pg-camunda depName=aurora-postgresql versioning=loose
+  default = "17.9"
+}
+
+variable "auto_minor_version_upgrade" {
+  description = "Whether minor engine upgrades are applied automatically during the maintenance window"
+  type        = bool
+  default     = true
+}
+
+variable "instance_class" {
+  description = "Instance class of the Aurora cluster instances"
+  type        = string
+  default     = "db.r6g.large"
+}
+
+variable "num_instances" {
+  description = "Number of Aurora instances in this region. Use at least 2 in production for intra-region failover."
+  type        = number
+  default     = 1
+}
+
+variable "database_name" {
+  description = "Name of the initial database. Only honoured on the primary member."
+  type        = string
+  default     = "camunda"
+}
+
+variable "master_username" {
+  description = "Master username. Only honoured on the primary member."
+  type        = string
+  sensitive   = true
+  default     = null
+}
+
+variable "master_password" {
+  description = "Master password. Only honoured on the primary member."
+  type        = string
+  sensitive   = true
+  default     = null
+}
+
+variable "availability_zones" {
+  description = "Availability zones of the regional cluster. Only honoured on the primary member."
+  type        = list(string)
+  default     = null
+}
+
+variable "vpc_id" {
+  description = "ID of the VPC the Aurora security group is created in"
+  type        = string
+}
+
+variable "subnet_ids" {
+  description = "Subnet IDs used for the Aurora DB subnet group"
+  type        = list(string)
+}
+
+variable "allowed_cidr_blocks" {
+  description = "CIDR blocks allowed to reach the database. Must contain every participating region VPC CIDR, because brokers in any region connect to the current global writer."
+  type        = list(string)
+}
+
+variable "port" {
+  description = "Database port"
+  type        = number
+  default     = 5432
+}
+
+variable "iam_auth_enabled" {
+  description = "Whether IAM database authentication is enabled. Recommended: the AWS JDBC wrapper iam plugin removes the need to distribute a password."
+  type        = bool
+  default     = true
+}
+
+variable "ca_cert_identifier" {
+  description = "Certificate authority used by the cluster instances"
+  type        = string
+  default     = "rds-ca-rsa2048-g1"
+}
+
+variable "backup_retention_period" {
+  description = "Number of days automated backups are retained"
+  type        = number
+  default     = 7
+}
+
+variable "skip_final_snapshot" {
+  description = "Whether the final snapshot is skipped on destroy. Kept true for the reference architecture, which is disposable."
+  type        = bool
+  default     = true
+}
+
+variable "apply_immediately" {
+  description = "Whether modifications are applied immediately instead of during the maintenance window"
+  type        = bool
+  default     = true
+}
+
+variable "tags" {
+  description = "Tags applied to every resource created by this module"
+  type        = map(string)
+  default     = {}
+}

--- a/aws/modules/aurora-global-member/versions.tf
+++ b/aws/modules/aurora-global-member/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}

--- a/aws/modules/transit-gateway-hub/README.md
+++ b/aws/modules/transit-gateway-hub/README.md
@@ -1,0 +1,30 @@
+# transit-gateway-hub
+
+<!-- BEGIN_TF_DOCS -->
+## Modules
+
+No modules.
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [aws_ec2_transit_gateway.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway) | resource |
+| [aws_ec2_transit_gateway_vpc_attachment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway_vpc_attachment) | resource |
+| [aws_route.remote](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_name"></a> [name](#input\_name) | Name prefix for the Transit Gateway and its attachment, typically <cluster\_name>-<region\_short\_name> | `string` | n/a | yes |
+| <a name="input_remote_cidr_blocks"></a> [remote\_cidr\_blocks](#input\_remote\_cidr\_blocks) | CIDR blocks of every remote region VPC that must be reachable through the Transit Gateway | `list(string)` | `[]` | no |
+| <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | Subnet IDs used for the Transit Gateway VPC attachment. Use one private subnet per availability zone. | `list(string)` | n/a | yes |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | ID of the VPC hosting the regional Kubernetes cluster | `string` | n/a | yes |
+| <a name="input_vpc_route_table_ids"></a> [vpc\_route\_table\_ids](#input\_vpc\_route\_table\_ids) | Route table IDs of the local VPC that must be able to reach the remote regions (main + private route tables) | `list(string)` | n/a | yes |
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_transit_gateway_id"></a> [transit\_gateway\_id](#output\_transit\_gateway\_id) | ID of the regional Transit Gateway |
+| <a name="output_transit_gateway_route_table_id"></a> [transit\_gateway\_route\_table\_id](#output\_transit\_gateway\_route\_table\_id) | Default association route table ID of the regional Transit Gateway |
+| <a name="output_vpc_attachment_id"></a> [vpc\_attachment\_id](#output\_vpc\_attachment\_id) | ID of the VPC attachment of the local cluster VPC |
+<!-- END_TF_DOCS -->

--- a/aws/modules/transit-gateway-hub/main.tf
+++ b/aws/modules/transit-gateway-hub/main.tf
@@ -1,0 +1,72 @@
+###############################################################################
+# Transit Gateway hub for a single region                                     #
+#                                                                             #
+# One instance of this module is created per participating region. It owns:   #
+#   * the regional Transit Gateway                                            #
+#   * the VPC attachment of the local EKS VPC                                 #
+#   * the VPC route table entries pointing remote CIDRs at the local TGW      #
+#                                                                             #
+# Cross-region wiring (TGW <-> TGW peering) is handled by the companion       #
+# module `transit-gateway-peering`, which needs two provider aliases and is    #
+# therefore kept separate. Splitting the two lets a caller scale the mesh by   #
+# instantiating N hubs and N*(N-1)/2 peerings instead of duplicating a         #
+# hardcoded two-region module.                                                #
+###############################################################################
+
+resource "aws_ec2_transit_gateway" "this" {
+  description = "Transit Gateway for ${var.name}"
+
+  # Peering attachments are associated with the default route table but never
+  # propagate routes, so static routes are added by the peering module.
+  auto_accept_shared_attachments  = "enable"
+  default_route_table_association = "enable"
+  default_route_table_propagation = "enable"
+  dns_support                     = "enable"
+
+  tags = {
+    Name = "${var.name}-tgw"
+  }
+}
+
+resource "aws_ec2_transit_gateway_vpc_attachment" "this" {
+  transit_gateway_id = aws_ec2_transit_gateway.this.id
+  vpc_id             = var.vpc_id
+  subnet_ids         = var.subnet_ids
+
+  # Appliance mode is not needed: traffic is symmetric and stateless from the
+  # TGW point of view. DNS support lets Route 53 resolution traverse the TGW.
+  dns_support = "enable"
+
+  transit_gateway_default_route_table_association = true
+  transit_gateway_default_route_table_propagation = true
+
+  tags = {
+    Name = "${var.name}-tgw-attachment"
+  }
+}
+
+###############################################################################
+# VPC route table entries: every remote CIDR is reachable through the TGW      #
+###############################################################################
+
+locals {
+  # Cartesian product of route tables x remote CIDRs, keyed so that adding a
+  # region only appends new entries instead of renumbering existing ones.
+  vpc_routes = {
+    for pair in setproduct(var.vpc_route_table_ids, var.remote_cidr_blocks) :
+    "${pair[0]}|${pair[1]}" => {
+      route_table_id = pair[0]
+      cidr_block     = pair[1]
+    }
+  }
+}
+
+resource "aws_route" "remote" {
+  for_each = local.vpc_routes
+
+  route_table_id         = each.value.route_table_id
+  destination_cidr_block = each.value.cidr_block
+  transit_gateway_id     = aws_ec2_transit_gateway.this.id
+
+  depends_on = [aws_ec2_transit_gateway_vpc_attachment.this]
+}

--- a/aws/modules/transit-gateway-hub/outputs.tf
+++ b/aws/modules/transit-gateway-hub/outputs.tf
@@ -1,0 +1,14 @@
+output "transit_gateway_id" {
+  description = "ID of the regional Transit Gateway"
+  value       = aws_ec2_transit_gateway.this.id
+}
+
+output "transit_gateway_route_table_id" {
+  description = "Default association route table ID of the regional Transit Gateway"
+  value       = aws_ec2_transit_gateway.this.association_default_route_table_id
+}
+
+output "vpc_attachment_id" {
+  description = "ID of the VPC attachment of the local cluster VPC"
+  value       = aws_ec2_transit_gateway_vpc_attachment.this.id
+}

--- a/aws/modules/transit-gateway-hub/variables.tf
+++ b/aws/modules/transit-gateway-hub/variables.tf
@@ -1,0 +1,25 @@
+variable "name" {
+  description = "Name prefix for the Transit Gateway and its attachment, typically <cluster_name>-<region_short_name>"
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "ID of the VPC hosting the regional Kubernetes cluster"
+  type        = string
+}
+
+variable "subnet_ids" {
+  description = "Subnet IDs used for the Transit Gateway VPC attachment. Use one private subnet per availability zone."
+  type        = list(string)
+}
+
+variable "vpc_route_table_ids" {
+  description = "Route table IDs of the local VPC that must be able to reach the remote regions (main + private route tables)"
+  type        = list(string)
+}
+
+variable "remote_cidr_blocks" {
+  description = "CIDR blocks of every remote region VPC that must be reachable through the Transit Gateway"
+  type        = list(string)
+  default     = []
+}

--- a/aws/modules/transit-gateway-hub/versions.tf
+++ b/aws/modules/transit-gateway-hub/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}

--- a/aws/modules/transit-gateway-peering/README.md
+++ b/aws/modules/transit-gateway-peering/README.md
@@ -1,0 +1,33 @@
+# transit-gateway-peering
+
+<!-- BEGIN_TF_DOCS -->
+## Modules
+
+No modules.
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [aws_ec2_transit_gateway_peering_attachment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway_peering_attachment) | resource |
+| [aws_ec2_transit_gateway_peering_attachment_accepter.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway_peering_attachment_accepter) | resource |
+| [aws_ec2_transit_gateway_route.accepter_to_owner](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway_route) | resource |
+| [aws_ec2_transit_gateway_route.owner_to_accepter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway_route) | resource |
+| [aws_region.accepter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_accepter_cidr_blocks"></a> [accepter\_cidr\_blocks](#input\_accepter\_cidr\_blocks) | CIDR blocks reachable through the accepter Transit Gateway | `list(string)` | n/a | yes |
+| <a name="input_accepter_transit_gateway_id"></a> [accepter\_transit\_gateway\_id](#input\_accepter\_transit\_gateway\_id) | ID of the Transit Gateway accepting the peering request | `string` | n/a | yes |
+| <a name="input_accepter_transit_gateway_route_table_id"></a> [accepter\_transit\_gateway\_route\_table\_id](#input\_accepter\_transit\_gateway\_route\_table\_id) | Route table ID of the accepter Transit Gateway, where routes to the owner CIDRs are installed | `string` | n/a | yes |
+| <a name="input_name"></a> [name](#input\_name) | Name prefix for the peering attachment, typically <cluster\_name>-<owner\_short\_name>-<accepter\_short\_name> | `string` | n/a | yes |
+| <a name="input_owner_cidr_blocks"></a> [owner\_cidr\_blocks](#input\_owner\_cidr\_blocks) | CIDR blocks reachable through the owner Transit Gateway | `list(string)` | n/a | yes |
+| <a name="input_owner_transit_gateway_id"></a> [owner\_transit\_gateway\_id](#input\_owner\_transit\_gateway\_id) | ID of the Transit Gateway initiating the peering request | `string` | n/a | yes |
+| <a name="input_owner_transit_gateway_route_table_id"></a> [owner\_transit\_gateway\_route\_table\_id](#input\_owner\_transit\_gateway\_route\_table\_id) | Route table ID of the owner Transit Gateway, where routes to the accepter CIDRs are installed | `string` | n/a | yes |
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_peering_accepter_attachment_id"></a> [peering\_accepter\_attachment\_id](#output\_peering\_accepter\_attachment\_id) | ID of the accepted Transit Gateway peering attachment (accepter side) |
+| <a name="output_peering_attachment_id"></a> [peering\_attachment\_id](#output\_peering\_attachment\_id) | ID of the Transit Gateway peering attachment (owner side) |
+<!-- END_TF_DOCS -->

--- a/aws/modules/transit-gateway-peering/main.tf
+++ b/aws/modules/transit-gateway-peering/main.tf
@@ -1,0 +1,65 @@
+###############################################################################
+# Transit Gateway inter-region peering (one pair of regions)                  #
+#                                                                             #
+# Transit Gateway peering is point-to-point and NOT transitive: a packet       #
+# cannot hop through an intermediate TGW. An N-region topology therefore       #
+# requires a full mesh of N*(N-1)/2 peerings. This module represents exactly   #
+# one edge of that mesh.                                                      #
+#                                                                             #
+# Peering attachments never propagate routes, so static routes are added on    #
+# both TGW route tables.                                                      #
+###############################################################################
+
+data "aws_region" "accepter" {
+  provider = aws.accepter
+}
+
+resource "aws_ec2_transit_gateway_peering_attachment" "this" {
+  provider = aws.owner
+
+  transit_gateway_id      = var.owner_transit_gateway_id
+  peer_transit_gateway_id = var.accepter_transit_gateway_id
+  peer_region             = data.aws_region.accepter.region
+
+  tags = {
+    Name = "${var.name}-tgw-peering"
+  }
+}
+
+resource "aws_ec2_transit_gateway_peering_attachment_accepter" "this" {
+  provider = aws.accepter
+
+  transit_gateway_attachment_id = aws_ec2_transit_gateway_peering_attachment.this.id
+
+  tags = {
+    Name = "${var.name}-tgw-peering-accepter"
+  }
+}
+
+###############################################################################
+# Static routes on both Transit Gateway route tables                          #
+###############################################################################
+
+resource "aws_ec2_transit_gateway_route" "owner_to_accepter" {
+  provider = aws.owner
+
+  for_each = toset(var.accepter_cidr_blocks)
+
+  destination_cidr_block         = each.value
+  transit_gateway_attachment_id  = aws_ec2_transit_gateway_peering_attachment.this.id
+  transit_gateway_route_table_id = var.owner_transit_gateway_route_table_id
+
+  depends_on = [aws_ec2_transit_gateway_peering_attachment_accepter.this]
+}
+
+resource "aws_ec2_transit_gateway_route" "accepter_to_owner" {
+  provider = aws.accepter
+
+  for_each = toset(var.owner_cidr_blocks)
+
+  destination_cidr_block         = each.value
+  transit_gateway_attachment_id  = aws_ec2_transit_gateway_peering_attachment_accepter.this.transit_gateway_attachment_id
+  transit_gateway_route_table_id = var.accepter_transit_gateway_route_table_id
+
+  depends_on = [aws_ec2_transit_gateway_peering_attachment_accepter.this]
+}

--- a/aws/modules/transit-gateway-peering/outputs.tf
+++ b/aws/modules/transit-gateway-peering/outputs.tf
@@ -1,0 +1,9 @@
+output "peering_attachment_id" {
+  description = "ID of the Transit Gateway peering attachment (owner side)"
+  value       = aws_ec2_transit_gateway_peering_attachment.this.id
+}
+
+output "peering_accepter_attachment_id" {
+  description = "ID of the accepted Transit Gateway peering attachment (accepter side)"
+  value       = aws_ec2_transit_gateway_peering_attachment_accepter.this.id
+}

--- a/aws/modules/transit-gateway-peering/variables.tf
+++ b/aws/modules/transit-gateway-peering/variables.tf
@@ -1,0 +1,34 @@
+variable "name" {
+  description = "Name prefix for the peering attachment, typically <cluster_name>-<owner_short_name>-<accepter_short_name>"
+  type        = string
+}
+
+variable "owner_transit_gateway_id" {
+  description = "ID of the Transit Gateway initiating the peering request"
+  type        = string
+}
+
+variable "owner_transit_gateway_route_table_id" {
+  description = "Route table ID of the owner Transit Gateway, where routes to the accepter CIDRs are installed"
+  type        = string
+}
+
+variable "owner_cidr_blocks" {
+  description = "CIDR blocks reachable through the owner Transit Gateway"
+  type        = list(string)
+}
+
+variable "accepter_transit_gateway_id" {
+  description = "ID of the Transit Gateway accepting the peering request"
+  type        = string
+}
+
+variable "accepter_transit_gateway_route_table_id" {
+  description = "Route table ID of the accepter Transit Gateway, where routes to the owner CIDRs are installed"
+  type        = string
+}
+
+variable "accepter_cidr_blocks" {
+  description = "CIDR blocks reachable through the accepter Transit Gateway"
+  type        = list(string)
+}

--- a/aws/modules/transit-gateway-peering/versions.tf
+++ b/aws/modules/transit-gateway-peering/versions.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source                = "hashicorp/aws"
+      version               = "~> 6.0"
+      configuration_aliases = [aws.owner, aws.accepter]
+    }
+  }
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -28,7 +28,7 @@ The official Camunda docs for these references live at:
 
 | Folder    | Contents |
 |-----------|----------|
-| `aws/`    | EKS (single/dual region, IRSA variant), ROSA HCP (single/dual region), ECS Fargate, EC2. Modules: `eks-cluster`, `aurora`, `opensearch`, `rosa-hcp`, `ecs`, `vpn` |
+| `aws/`    | EKS (single/dual/multi region, IRSA variant), ROSA HCP (single/dual region), ECS Fargate, EC2. Modules: `eks-cluster`, `aurora`, `aurora-global`, `aurora-global-member`, `opensearch`, `rosa-hcp`, `ecs`, `vpn`, `transit-gateway`, `transit-gateway-hub`, `transit-gateway-peering` |
 | `azure/`  | AKS (single region, with RDBMS variant). Modules: `aks`, `network`, `kms`, `postgres-db` |
 | `generic/`| Cloud-agnostic Kubernetes (single/dual region), OpenShift, operator-based (CNPG, ECK, Keycloak), Debian bare metal |
 | `local/`  | Kind (Kubernetes in Docker) for local development |
@@ -57,6 +57,15 @@ Camunda 8 deployments consist of two logical clusters:
 
 RDBMS secondary storage is available since 8.9 for the Orchestration Cluster (Operate, Tasklist, v2 REST API). For backend trade-offs and benchmarks, see [secondary storage architecture](https://docs.camunda.io/docs/self-managed/reference-architecture/reference-architecture/#secondary-storage-architecture) and [RDBMS benchmark results](https://docs.camunda.io/docs/self-managed/concepts/secondary-storage/rdbms-benchmark-results/) in the product documentation. Reference implementations with a dedicated RDBMS variant: `azure/kubernetes/aks-single-region-rdbms` (the `*-rdbms` declination of a ref-arch uses a relational database instead of a document store).
 
+**Multi-region topologies:**
+
+| Feature | Regions | Secondary storage | Region loss |
+|---------|---------|-------------------|-------------|
+| `dual-region` | 2 | One Elasticsearch per region, two Camunda exporters | Quorum lost, manual failover then failback with an ES snapshot restore |
+| `multi-region` | N (3 by default) | One RDBMS, replication delegated to the database | Quorum preserved, the engine keeps processing |
+
+The RDBMS exporter has [no multi-region mode](https://docs.camunda.io/docs/next/self-managed/concepts/databases/relational-db/configuration/#multi-region-support): a single JDBC connection exists per Orchestration Cluster. `multi-region` turns that into the design by making replication the database's responsibility (Aurora Global Database in the AWS reference, any single-writer endpoint elsewhere). Reference implementation: `aws/kubernetes/eks-multi-region-rdbms` — **experimental**; the product documents and supports two regions.
+
 **Production baseline:** Minimum 3 Zeebe brokers across 3 availability zones.
 
 ## Naming Convention
@@ -68,6 +77,7 @@ RDBMS secondary storage is available since 8.9 for the Orchestration Cluster (Op
 Examples:
 - `aws/kubernetes/eks-single-region`
 - `aws/kubernetes/eks-dual-region`
+- `aws/kubernetes/eks-multi-region-rdbms`
 - `aws/openshift/rosa-hcp-single-region`
 - `aws/containers/ecs-single-region-fargate`
 - `azure/kubernetes/aks-single-region-rdbms`

--- a/docs/development.md
+++ b/docs/development.md
@@ -31,7 +31,9 @@ aws sso login --profile infraex
 aws sts get-caller-identity --profile infraex   # verify
 ```
 
-> **Warning:** Regions **eu-west-2** and **eu-west-3** are reserved for CI and are nuked nightly. Never use them for local development.
+> **Warning:** Regions **eu-west-2**, **eu-west-3** and **eu-central-2** are reserved for CI and are nuked nightly. **eu-south-1** is a weekly work region, cleaned every Saturday. Never use them for local development.
+>
+> `eu-central-2` (Zurich) and `eu-south-1` (Milan) are AWS **opt-in** regions: they must be enabled on the account before use. The authoritative list and cleanup schedule live in [infraex-common-config](https://github.com/camunda/infraex-common-config#region-usage-for-cloud-providers).
 
 ### Azure
 


### PR DESCRIPTION
## Motivation

The dual-region reference architecture has two structural weaknesses that no amount of tuning removes:

1. **Losing a region halts the engine.** With two regions there is no even replica count that survives losing half of it, so a region loss costs the Raft quorum and processing stops until brokers are force-removed.
2. **Failback is an eight-step procedure** including an Elasticsearch snapshot and cross-region restore, because each region owns its own copy of the secondary storage and a returning region has to be re-seeded.

This PR explores a topology where both disappear, and where a region can be added to a running cluster.

> [!WARNING]
> **Draft, experimental.** Camunda documents and supports **two** regions. Everything here goes beyond that. Opened as a draft to iterate on the design before investing in a full CI run.

## What this is

`aws/kubernetes/eks-multi-region-rdbms` — a Camunda 8.10 Orchestration Cluster stretched across **N AWS regions** (3 by default), backed by a relational secondary storage whose replication is entirely the database's responsibility.

| | `eks-dual-region` | `eks-multi-region-rdbms` |
|---|---|---|
| Region loss | Quorum lost, engine **stops** | Quorum preserved, engine **keeps processing** |
| Failback | 8 steps + ES snapshot/restore | Redeploy the region |
| Secondary storage | 1 Elasticsearch per region, 2 Camunda exporters | 1 database, 1 exporter, replication in the DB |
| Cross-region DNS | CoreDNS stub forwarding, `O(N²)` stanzas, pod IPs only | Submariner Lighthouse, `*.svc.clusterset.local` |
| Cross-region L3 | VPC peering mesh | Transit Gateway, 1 attachment per VPC |
| Add a region | Not possible | `activate-region.sh <slot>`, online |

## Three design decisions worth reviewing

### 1. `replicationFactor == number of regions`

Zeebe distributes partitions round robin over **consecutive node IDs**, and the Helm chart computes `nodeId = ordinal * global.multiregion.regions + regionId`. Combining the two places exactly one replica of every partition in every region:

```
clusterSize 6, partitionCount 6, replicationFactor 3, 3 regions
slot 0 → node IDs {0,3}   slot 1 → {1,4}   slot 2 → {2,5}
partition 1 → nodes 0,1,2 → one replica per region
```

A partition keeps its majority while `N-1 > N/2`, true for every `N >= 3`:

| Regions | RF | Region losses tolerated |
|---|---|---|
| 2 | 4 (dual-region) | **0** |
| 3 | 3 | 1 |
| 4 | 4 | 1 |
| 5 | 5 | 2 |

Three regions is simply the smallest topology where the failover procedure stops being load-bearing.

### 2. Replication-agnostic secondary storage

Camunda exposes [one JDBC connection per Orchestration Cluster and the RDBMS exporter has no multi-region mode](https://docs.camunda.io/docs/next/self-managed/concepts/databases/relational-db/configuration/#multi-region-support):

> *Multi-region support for the RDBMS Exporter is not planned at this time. For multi-region setups, multi-region replication must be handled within the RDBMS itself.*

Rather than working around it, the architecture adopts it. Every broker of every region writes to the same URL. There are no per-region exporters to enable, disable or re-initialise, so region loss desynchronises nothing at the Camunda layer and failback has no restore step.

The reference implementation is Aurora Global Database behind the AWS Advanced JDBC Wrapper:

```
jdbc:aws-wrapper:postgresql://<writer>:5432/camunda
  ?wrapperPlugins=failover
  &globalClusterInstanceHostPatterns=?.<r0-suffix>,?.<r1-suffix>
```

The `failover` plugin discovers the new writer after a global failover, so Camunda is never reconfigured or restarted. Set `deploy_database = false` and supply your own `CAMUNDA_RDBMS_URL` to run the same architecture on Patroni, RDS Proxy, AlloyDB, CockroachDB or a DNS CNAME you repoint by hand.

Database regions are **decoupled** from compute regions: `database_region_slots` defaults to `[0, 1]`, so a three-region Zeebe cluster runs on a two-region Aurora Global Database. Cheaper, and it demonstrates the decoupling.

### 3. Region slots, fixed at bootstrap

The chart bakes the region count into broker identity, so changing it renumbers every broker — fatal for a running Raft cluster. The count is therefore treated as an immutable **slot count**, and regions are activated independently:

- `var.regions` — slot definitions, immutable.
- `var.active_region_count` — how many are deployed, raisable at any time.

Bootstrapping with one slot empty is the intended growth path: every partition still holds `N-1` of `N` replicas, a majority, so the cluster forms and runs. Leaving two or more slots empty is rejected by a `check` block. Activating the last slot does not restart the running regions.

**This does not grow `N` slots to `N+1`.** Provision the largest topology you may need up front. Open to a chart-level `nodeIdOffset` upstream if we want real elasticity later.

## Cross-region networking

**L3 — Transit Gateway.** One hub per region plus a full peering mesh (peering is not transitive, so `N*(N-1)/2` edges). Unlike a VPC peering mesh, the number of attachments and route entries per VPC stays constant as regions are added, and the same hub can later carry Direct Connect.

**L4/L7 — upstream Submariner.** `subctl deploy-broker` / `subctl join`, not the RHACM add-on used by `rosa-hcp-dual-region` (ACM is OpenShift-only). libreswan IPsec, `--air-gapped`, `--natt=false`, Globalnet off. Lighthouse gives `<clusterID>.<service>.<namespace>.svc.clusterset.local`, which is what lets the architecture use **one namespace name in every cluster** instead of the `N×N` namespace matrix CoreDNS forwarding would need.

Firewall rules are written out explicitly rather than "allow all between VPCs" — the port list is the part a reader actually needs.

## Contents

```
aws/modules/transit-gateway-hub/          one TGW + VPC attachment + routes, single provider
aws/modules/transit-gateway-peering/      one mesh edge, owner/accepter providers
aws/modules/aurora-global-member/         one regional member of a global cluster

aws/kubernetes/eks-multi-region-rdbms/
  README.md                               architecture, invariants, trade-offs
  DEVELOPER.md                            local runbook, cost warnings, debugging
  terraform/clusters/                     N EKS + TGW mesh + SGs + Aurora Global, one state
  helm-values/camunda-values.yml          envsubst template, N-region generic
  procedure/                              env, Submariner, RDBMS, topology, activate-region,
                                          failover/failback, diagnostics
  test/                                   Go suite driving the procedures

.github/actions/aws-kubernetes-eks-multi-region-rdbms-create/
.github/workflows/aws_eks_multi_region_rdbms_{tests,golden,daily_cleanup}.yml
```

The Go tests deliberately **drive the shell procedures** instead of reimplementing them, so CI validates exactly what a user copy-pastes.

## Regions

| Slot | Region | Status |
|---|---|---|
| 0 | `eu-west-2` London | existing CI region |
| 1 | `eu-west-3` Paris | existing CI region |
| 2 | `eu-central-2` Zurich | **new**, needs enabling |
| 3 | `eu-south-1` Milan | **new**, weekly, optional 4th slot |

RTT: London↔Paris ~7 ms, London↔Zurich ~20 ms, Paris↔Zurich ~15 ms — comfortably inside the 100 ms budget.

> [!IMPORTANT]
> **Blocking prerequisites, outside this repo:**
> 1. IT must enable the AWS **opt-in** regions `eu-central-2` and `eu-south-1` on the CI account.
> 2. [`camunda/infraex-common-config`](https://github.com/camunda/infraex-common-config#region-usage-for-cloud-providers) must declare `eu-central-2` as a daily CI region and `eu-south-1` as a weekly work region, and the nuke must cover them.
>
> `docs/development.md` has been updated to match, but the authoritative list lives in the other repo.

## Validation done

- `terraform validate` on the root module and all three new modules
- `tflint`, `terraform fmt`, `terraform-docs`
- `trivy` clean on every new module with the repo ignore list
- `helm template` against chart `camunda-platform-8.10` with the generated values: renders, and produces `nodeId = ordinal * 3 + regionId`, `replicas = clusterSize / regions`, the RDBMS secondary storage block and the DNS-gate init container
- `shellcheck`, `yamllint`, `actionlint`, `go vet`, `gofmt`
- Full `pre-commit run` green (except `trivy-scan` and `terraform-test-touched`, which fail on unrelated local artefacts / macOS bash 3.2)

## Not done yet

- [ ] **No real deployment.** Nothing has touched AWS. The first CI run is the real test.
- [ ] `tfplan-golden.json` must be generated once (`just regenerate-golden-file`) before the golden workflow can pass.
- [ ] Backup and restore: RDBMS needs continuous primary-storage backups plus a DB-native backup. Not wired up.
- [ ] IAM database authentication is off by default; enabling it needs IRSA roles per cluster.
- [ ] Connector idempotency across regions is documented, not enforced.
- [ ] `workflow-scheduler.yml` entries at the next release cut (`main` has no scheduler entries today).
- [ ] Companion [camunda-docs](https://github.com/camunda/camunda-docs) page, once the design settles.

## Open questions

1. **Is `activate-region.sh` even needed?** Brokers of an inactive slot are already members of the ClusterTopology computed at bootstrap, so they may simply join when deployed. The script waits for that and falls back to `PATCH /actuator/cluster` if it does not happen. The first CI run will tell us which branch fires — and if auto-join works, the script gets much shorter.
2. **4 slots or 3 by default?** 3 is cheaper and already delivers region-loss tolerance; 4 buys a spare slot for growth at the cost of a fourth EKS cluster.
3. **Should `verify-degraded-cluster.sh` also assert throughput**, not just liveness? Deploying a process and completing an instance while a region is down would be a stronger claim.
4. **libreswan vs vxlan** for the Submariner cable driver. IPsec costs CPU on the gateway node; TGW traffic is already private but unencrypted.
